### PR TITLE
Improve Catalogs and Managers Inheritance

### DIFF
--- a/src/Abstractions/CrestApps.Core.Abstractions/Services/INamedCatalogManager.cs
+++ b/src/Abstractions/CrestApps.Core.Abstractions/Services/INamedCatalogManager.cs
@@ -1,14 +1,58 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Models;
+
 namespace CrestApps.Core.Services;
 
 /// <summary>
 /// A catalog manager that supports finding entries by their unique name,
-/// extending <see cref="ICatalogManager{T}"/> with name-based lookup for models
+/// extending <see cref="IReadCatalogManager{T}"/> with name-based lookup for models
 /// that implement <see cref="INameAwareModel"/>.
 /// </summary>
 /// <typeparam name="T">The type of catalog entry, which must have a <see cref="INameAwareModel.Name"/> property.</typeparam>
-public interface INamedCatalogManager<T> : ICatalogManager<T>
+public interface INamedCatalogManager<T> : IReadCatalogManager<T>
     where T : INameAwareModel
 {
+    /// <summary>
+    /// Asynchronously deletes the specified model from the catalog.
+    /// </summary>
+    /// <param name="model">The model to delete.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the model was successfully deleted; otherwise, <see langword="false"/>.</returns>
+    ValueTask<bool> DeleteAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously creates a new model instance pre-assigned to the specified name,
+    /// optionally populating it from JSON data.
+    /// </summary>
+    /// <param name="name">The name to assign to the new model.</param>
+    /// <param name="data">Optional JSON data to seed the new model.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A newly created and initialized model instance assigned to the specified name.</returns>
+    ValueTask<T> NewAsync(string name, JsonNode data = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously creates the specified model in the catalog.
+    /// </summary>
+    /// <param name="model">The model to create.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask CreateAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously updates the specified model in the catalog, optionally merging changes from JSON data.
+    /// </summary>
+    /// <param name="model">The model to update.</param>
+    /// <param name="data">Optional JSON data containing fields to merge into the model.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask UpdateAsync(T model, JsonNode data = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously validates the specified model and returns the validation result.
+    /// </summary>
+    /// <param name="model">The model to validate.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The validation result details indicating success or failure with error messages.</returns>
+    ValueTask<ValidationResultDetails> ValidateAsync(T model, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Asynchronously finds a catalog entry by its unique name.
     /// </summary>

--- a/src/Abstractions/CrestApps.Core.Abstractions/Services/INamedSourceCatalogManager.cs
+++ b/src/Abstractions/CrestApps.Core.Abstractions/Services/INamedSourceCatalogManager.cs
@@ -1,14 +1,83 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Models;
+
 namespace CrestApps.Core.Services;
 
 /// <summary>
 /// A catalog manager that supports composite lookup by both name and source,
-/// extending <see cref="INamedCatalogManager{T}"/> and <see cref="ISourceCatalogManager{T}"/>
+/// extending <see cref="IReadCatalogManager{T}"/>
 /// for models that implement both <see cref="INameAwareModel"/> and <see cref="ISourceAwareModel"/>.
 /// </summary>
 /// <typeparam name="T">The type of catalog entry.</typeparam>
-public interface INamedSourceCatalogManager<T> : INamedCatalogManager<T>, ISourceCatalogManager<T>
+public interface INamedSourceCatalogManager<T> : IReadCatalogManager<T>
     where T : INameAwareModel, ISourceAwareModel
 {
+    /// <summary>
+    /// Asynchronously deletes the specified model from the catalog.
+    /// </summary>
+    /// <param name="model">The model to delete.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the model was successfully deleted; otherwise, <see langword="false"/>.</returns>
+    ValueTask<bool> DeleteAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously creates a new model instance pre-assigned to the specified name and source,
+    /// optionally populating it from JSON data.
+    /// </summary>
+    /// <param name="name">The name to assign to the new model.</param>
+    /// <param name="source">The source to assign to the new model.</param>
+    /// <param name="data">Optional JSON data to seed the new model.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A newly created and initialized model instance assigned to the specified name and source.</returns>
+    ValueTask<T> NewAsync(string name, string source, JsonNode data = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously creates the specified model in the catalog.
+    /// </summary>
+    /// <param name="model">The model to create.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask CreateAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously updates the specified model in the catalog, optionally merging changes from JSON data.
+    /// </summary>
+    /// <param name="model">The model to update.</param>
+    /// <param name="data">Optional JSON data containing fields to merge into the model.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask UpdateAsync(T model, JsonNode data = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously validates the specified model and returns the validation result.
+    /// </summary>
+    /// <param name="model">The model to validate.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The validation result details indicating success or failure with error messages.</returns>
+    ValueTask<ValidationResultDetails> ValidateAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously finds a catalog entry by its unique name.
+    /// </summary>
+    /// <param name="name">The unique name of the entry to find.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The matching entry, or <see langword="null"/> if no entry with the specified name exists.</returns>
+    ValueTask<T> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously retrieves all catalog entries belonging to the specified source.
+    /// </summary>
+    /// <param name="source">The source or provider name to filter by.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>An enumerable of entries matching the specified source.</returns>
+    ValueTask<IEnumerable<T>> GetAsync(string source, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously finds all catalog entries that belong to the specified source.
+    /// </summary>
+    /// <param name="source">The source or provider name to search for.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>An enumerable of entries matching the specified source.</returns>
+    ValueTask<IEnumerable<T>> FindBySourceAsync(string source, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Asynchronously retrieves a catalog entry by its unique name and source combination.
     /// </summary>

--- a/src/Abstractions/CrestApps.Core.Abstractions/Services/ISourceCatalogManager.cs
+++ b/src/Abstractions/CrestApps.Core.Abstractions/Services/ISourceCatalogManager.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using CrestApps.Core.Models;
 
 namespace CrestApps.Core.Services;
 
@@ -7,9 +8,40 @@ namespace CrestApps.Core.Services;
 /// extending <see cref="ICatalogManager{T}"/> for models that implement <see cref="ISourceAwareModel"/>.
 /// </summary>
 /// <typeparam name="T">The type of catalog entry, which must have a <see cref="ISourceAwareModel.Source"/> property.</typeparam>
-public interface ISourceCatalogManager<T> : ICatalogManager<T>
+public interface ISourceCatalogManager<T> : IReadCatalogManager<T>
     where T : ISourceAwareModel
 {
+    /// <summary>
+    /// Asynchronously deletes the specified model from the catalog.
+    /// </summary>
+    /// <param name="model">The model to delete.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns><see langword="true"/> if the model was successfully deleted; otherwise, <see langword="false"/>.</returns>
+    ValueTask<bool> DeleteAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously creates the specified model in the catalog.
+    /// </summary>
+    /// <param name="model">The model to create.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask CreateAsync(T model, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously updates the specified model in the catalog, optionally merging changes from JSON data.
+    /// </summary>
+    /// <param name="model">The model to update.</param>
+    /// <param name="data">Optional JSON data containing fields to merge into the model.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    ValueTask UpdateAsync(T model, JsonNode data = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Asynchronously validates the specified model and returns the validation result.
+    /// </summary>
+    /// <param name="model">The model to validate.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>The validation result details indicating success or failure with error messages.</returns>
+    ValueTask<ValidationResultDetails> ValidateAsync(T model, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Asynchronously creates a new model instance pre-assigned to the specified source,
     /// optionally populating it from JSON data.

--- a/src/Abstractions/CrestApps.Core.Infrastructure.Abstractions/Indexing/ISearchIndexProfileManager.cs
+++ b/src/Abstractions/CrestApps.Core.Infrastructure.Abstractions/Indexing/ISearchIndexProfileManager.cs
@@ -5,24 +5,18 @@ namespace CrestApps.Core.Infrastructure.Indexing;
 
 /// <summary>
 /// Manages the full lifecycle of <see cref="SearchIndexProfile"/> entries, including
-/// creation, update, deletion, field retrieval, synchronization, and reset operations.
-/// Extends <see cref="ICatalogManager{T}"/> with indexing-specific methods.
+/// creation, update, deletion, name-scoped initialization, field retrieval,
+/// synchronization, and reset operations. Extends <see cref="INamedCatalogManager{T}"/>
+/// with indexing-specific methods.
 /// </summary>
-public interface ISearchIndexProfileManager : ICatalogManager<SearchIndexProfile>
+public interface ISearchIndexProfileManager : INamedCatalogManager<SearchIndexProfile>
 {
-    /// <summary>
-    /// Asynchronously finds an index profile by its unique name.
-    /// </summary>
-    /// <param name="name">The unique name of the profile to find.</param>
-    /// <returns>The matching profile, or <see langword="null"/> if not found.</returns>
-    ValueTask<SearchIndexProfile> FindByNameAsync(string name);
-
     /// <summary>
     /// Asynchronously retrieves all index profiles of the specified type.
     /// </summary>
     /// <param name="type">The profile type to filter by (e.g., <see cref="IndexProfileTypes.AIDocuments"/>).</param>
     /// <returns>A read-only collection of profiles matching the specified type.</returns>
-    Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type);
+    Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously retrieves the provider-specific field definitions for the specified profile.
@@ -30,9 +24,7 @@ public interface ISearchIndexProfileManager : ICatalogManager<SearchIndexProfile
     /// <param name="profile">The index profile whose fields should be retrieved.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A read-only collection of field definitions for the profile.</returns>
-    ValueTask<IReadOnlyCollection<SearchIndexField>> GetFieldsAsync(
-        SearchIndexProfile profile,
-        CancellationToken cancellationToken = default);
+    ValueTask<IReadOnlyCollection<SearchIndexField>> GetFieldsAsync(SearchIndexProfile profile, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously synchronizes the specified profile to its remote search index provider.

--- a/src/Abstractions/CrestApps.Core.Infrastructure.Abstractions/Indexing/ISearchIndexProfileStore.cs
+++ b/src/Abstractions/CrestApps.Core.Infrastructure.Abstractions/Indexing/ISearchIndexProfileStore.cs
@@ -13,5 +13,5 @@ public interface ISearchIndexProfileStore : ICatalog<SearchIndexProfile>, INamed
     /// </summary>
     /// <param name="type">The index profile type to filter by.</param>
     /// <returns>A read-only collection of matching index profiles.</returns>
-    Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type);
+    Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default);
 }

--- a/src/Primitives/CrestApps.Core.AI.Chat/Handlers/DataSourceChatInteractionSettingsHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Handlers/DataSourceChatInteractionSettingsHandler.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -45,7 +45,7 @@ public sealed class DataSourceChatInteractionSettingsHandler : IChatInteractionS
             return;
         }
 
-        var dataSourceCatalog = _serviceProvider.GetService<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = _serviceProvider.GetService<IAIDataSourceStore>();
         if (dataSourceCatalog == null)
         {
             _logger.LogDebug("Skipping chat interaction data source settings because no AI data source catalog is registered.");

--- a/src/Primitives/CrestApps.Core.AI/DataSources/SearchIndexProfileAIDataSourceSourceHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/DataSources/SearchIndexProfileAIDataSourceSourceHandler.cs
@@ -49,7 +49,7 @@ internal sealed class SearchIndexProfileAIDataSourceSourceHandler : IAIDataSourc
             return;
         }
 
-        var sourceProfile = await _indexProfileManager.FindByNameAsync(dataSource.SourceIndexProfileName);
+        var sourceProfile = await _indexProfileManager.FindByNameAsync(dataSource.SourceIndexProfileName, cancellationToken);
         if (sourceProfile == null)
         {
             result.Fail(new ValidationResult("The selected source index profile could not be found.", [nameof(AIDataSource.SourceIndexProfileName)]));

--- a/src/Primitives/CrestApps.Core.AI/Handlers/DataSourcePreemptiveRagHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Handlers/DataSourcePreemptiveRagHandler.cs
@@ -1,4 +1,5 @@
 using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Orchestration;
@@ -7,7 +8,6 @@ using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.DataSources;
 using CrestApps.Core.Infrastructure.Indexing.Models;
-using CrestApps.Core.Services;
 using CrestApps.Core.Templates.Services;
 using Cysharp.Text;
 using Microsoft.Extensions.AI;
@@ -68,7 +68,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
         }
 
         return ValueTask.FromResult(
-            _serviceProvider.GetService<ICatalog<AIDataSource>>() != null &&
+            _serviceProvider.GetService<IAIDataSourceStore>() != null &&
             _serviceProvider.GetService<ISearchIndexProfileStore>() != null);
     }
 
@@ -93,7 +93,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
 
     private async Task InjectPreemptiveRagContextAsync(PreemptiveRagContext context, AIDataSourceRagMetadata ragMetadata)
     {
-        var dataSourceCatalog = _serviceProvider.GetService<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = _serviceProvider.GetService<IAIDataSourceStore>();
         var indexProfileStore = _serviceProvider.GetService<ISearchIndexProfileStore>();
 
         if (dataSourceCatalog == null || indexProfileStore == null)

--- a/src/Primitives/CrestApps.Core.AI/Indexing/NullSearchIndexProfileStore.cs
+++ b/src/Primitives/CrestApps.Core.AI/Indexing/NullSearchIndexProfileStore.cs
@@ -110,7 +110,7 @@ public sealed class NullSearchIndexProfileStore : ISearchIndexProfileStore
     /// Gets by type.
     /// </summary>
     /// <param name="type">The type.</param>
-    public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+    public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(type);
 

--- a/src/Primitives/CrestApps.Core.AI/Indexing/SearchIndexProfileManager.cs
+++ b/src/Primitives/CrestApps.Core.AI/Indexing/SearchIndexProfileManager.cs
@@ -8,7 +8,7 @@ namespace CrestApps.Core.AI.Indexing;
 /// <summary>
 /// Represents the search Index Profile Manager.
 /// </summary>
-public sealed class SearchIndexProfileManager : CatalogManager<SearchIndexProfile>, ISearchIndexProfileManager
+public sealed class SearchIndexProfileManager : NamedCatalogManager<SearchIndexProfile>, ISearchIndexProfileManager
 {
     private readonly ISearchIndexProfileStore _store;
     private readonly IEnumerable<IIndexProfileHandler> _handlers;
@@ -37,22 +37,19 @@ public sealed class SearchIndexProfileManager : CatalogManager<SearchIndexProfil
     /// Finds by name.
     /// </summary>
     /// <param name="name">The name.</param>
-    public ValueTask<SearchIndexProfile> FindByNameAsync(string name)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(name);
-
-        return _store.FindByNameAsync(name);
-    }
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public new ValueTask<SearchIndexProfile> FindByNameAsync(string name, CancellationToken cancellationToken = default)
+        => base.FindByNameAsync(name, cancellationToken);
 
     /// <summary>
     /// Gets by type.
     /// </summary>
     /// <param name="type">The type.</param>
-    public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+    public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(type);
 
-        return _store.GetByTypeAsync(type);
+        return _store.GetByTypeAsync(type, cancellationToken);
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Indexing/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/Indexing/ServiceCollectionExtensions.cs
@@ -27,7 +27,7 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<ICatalog<SearchIndexProfile>>(sp => sp.GetRequiredService<ISearchIndexProfileStore>());
         services.TryAddScoped<INamedCatalog<SearchIndexProfile>>(sp => sp.GetRequiredService<ISearchIndexProfileStore>());
         services.TryAddScoped<ISearchIndexProfileManager, SearchIndexProfileManager>();
-        services.TryAddScoped<ICatalogManager<SearchIndexProfile>>(sp => sp.GetRequiredService<ISearchIndexProfileManager>());
+        services.TryAddScoped<INamedCatalogManager<SearchIndexProfile>>(sp => sp.GetRequiredService<ISearchIndexProfileManager>());
         services.TryAddScoped<ISearchIndexProfileProvisioningService, SearchIndexProfileProvisioningService>();
 
         return services;

--- a/src/Primitives/CrestApps.Core.AI/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/ServiceCollectionExtensions.cs
@@ -69,9 +69,8 @@ public static class ServiceCollectionExtensions
         });
 
         services.TryAddScoped<IAIProfileTemplateManager, DefaultAIProfileTemplateManager>();
-        services.TryAddScoped<ICatalogManager<AIProfileTemplate>>(sp => sp.GetRequiredService<IAIProfileTemplateManager>());
-        services.TryAddScoped<INamedCatalogManager<AIProfileTemplate>>(sp => sp.GetRequiredService<IAIProfileTemplateManager>());
-        services.TryAddScoped<ISourceCatalogManager<AIProfileTemplate>>(sp => sp.GetRequiredService<IAIProfileTemplateManager>());
+        services.TryAddScoped<INamedCatalogManager<AIProfileTemplate>>(sp => (INamedCatalogManager<AIProfileTemplate>)sp.GetRequiredService<IAIProfileTemplateManager>());
+        services.TryAddScoped<ISourceCatalogManager<AIProfileTemplate>>(sp => (ISourceCatalogManager<AIProfileTemplate>)sp.GetRequiredService<IAIProfileTemplateManager>());
         services.TryAddScoped<INamedSourceCatalogManager<AIProfileTemplate>>(sp => sp.GetRequiredService<IAIProfileTemplateManager>());
         services.TryAddEnumerable(ServiceDescriptor.Scoped<ICatalogEntryHandler<AIProfileTemplate>, AIProfileTemplateCatalogHandler>());
 
@@ -169,7 +168,6 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IOAuth2TokenService, DefaultOAuth2TokenService>();
         services.TryAddScoped<IConnectionAuthHeaderBuilder, DefaultConnectionAuthHeaderBuilder>();
         services.TryAddScoped<IAIProfileManager, DefaultAIProfileManager>();
-        services.TryAddScoped<ICatalogManager<AIProfile>>(sp => sp.GetRequiredService<IAIProfileManager>());
         services.TryAddScoped<INamedCatalogManager<AIProfile>>(sp => sp.GetRequiredService<IAIProfileManager>());
 
         if (!services.Any(descriptor => descriptor.ServiceType == typeof(EmbeddedResourceAIProfileTemplateProvider)))
@@ -448,9 +446,8 @@ public static class ServiceCollectionExtensions
 
         // Register the Framework-level deployment manager.
         services.TryAddScoped<IAIDeploymentManager, DefaultAIDeploymentManager>();
-        services.TryAddScoped<ICatalogManager<AIDeployment>>(sp => sp.GetRequiredService<IAIDeploymentManager>());
-        services.TryAddScoped<INamedCatalogManager<AIDeployment>>(sp => sp.GetRequiredService<IAIDeploymentManager>());
-        services.TryAddScoped<ISourceCatalogManager<AIDeployment>>(sp => sp.GetRequiredService<IAIDeploymentManager>());
+        services.TryAddScoped<INamedCatalogManager<AIDeployment>>(sp => (INamedCatalogManager<AIDeployment>)sp.GetRequiredService<IAIDeploymentManager>());
+        services.TryAddScoped<ISourceCatalogManager<AIDeployment>>(sp => (ISourceCatalogManager<AIDeployment>)sp.GetRequiredService<IAIDeploymentManager>());
         services.TryAddScoped<INamedSourceCatalogManager<AIDeployment>>(sp => sp.GetRequiredService<IAIDeploymentManager>());
 
         services.TryAddSingleton<IExternalChatRelayManager, ExternalChatRelayConnectionManager>();

--- a/src/Primitives/CrestApps.Core.AI/Services/AIDataSourceSearchDocumentHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/AIDataSourceSearchDocumentHandler.cs
@@ -1,6 +1,5 @@
-using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.Infrastructure.Indexing;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -81,7 +80,7 @@ internal sealed class AIDataSourceSearchDocumentHandler : ISearchDocumentHandler
         }
 
         var indexProfileManager = _serviceProvider.GetService<ISearchIndexProfileManager>();
-        var dataSourceCatalog = _serviceProvider.GetService<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = _serviceProvider.GetService<IAIDataSourceStore>();
 
         if (indexProfileManager == null || dataSourceCatalog == null)
         {

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceChangeNotifier.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceChangeNotifier.cs
@@ -1,6 +1,5 @@
 using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.Services;
 
 namespace CrestApps.Core.AI.Services;
 
@@ -9,7 +8,7 @@ namespace CrestApps.Core.AI.Services;
 /// </summary>
 public sealed class DefaultAIDataSourceChangeNotifier : IAIDataSourceChangeNotifier
 {
-    private readonly ICatalog<AIDataSource> _dataSourceCatalog;
+    private readonly IAIDataSourceStore _dataSourceCatalog;
     private readonly IAIDataSourceIndexingQueue _indexingQueue;
 
     /// <summary>
@@ -18,7 +17,7 @@ public sealed class DefaultAIDataSourceChangeNotifier : IAIDataSourceChangeNotif
     /// <param name="dataSourceCatalog">The data source catalog.</param>
     /// <param name="indexingQueue">The indexing queue.</param>
     public DefaultAIDataSourceChangeNotifier(
-        ICatalog<AIDataSource> dataSourceCatalog,
+        IAIDataSourceStore dataSourceCatalog,
         IAIDataSourceIndexingQueue indexingQueue)
     {
         _dataSourceCatalog = dataSourceCatalog;

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceIndexingService.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceIndexingService.cs
@@ -6,7 +6,6 @@ using CrestApps.Core.Infrastructure;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.DataSources;
 using CrestApps.Core.Infrastructure.Indexing.Models;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,7 +20,7 @@ public sealed class DefaultAIDataSourceIndexingService : IAIDataSourceIndexingSe
     private const int BatchSize = 250;
     private const int MaxChunkIdsPerDocument = 1000;
 
-    private readonly ICatalog<AIDataSource> _dataSourceCatalog;
+    private readonly IAIDataSourceStore _dataSourceCatalog;
     private readonly ISearchIndexProfileManager _indexProfileManager;
     private readonly IAIDeploymentManager _deploymentManager;
     private readonly IAIClientFactory _aiClientFactory;
@@ -42,7 +41,7 @@ public sealed class DefaultAIDataSourceIndexingService : IAIDataSourceIndexingSe
     /// <param name="timeProvider">The time provider.</param>
     /// <param name="logger">The logger.</param>
     public DefaultAIDataSourceIndexingService(
-        ICatalog<AIDataSource> dataSourceCatalog,
+        IAIDataSourceStore dataSourceCatalog,
         ISearchIndexProfileManager indexProfileManager,
         IAIDeploymentManager deploymentManager,
         IAIClientFactory aiClientFactory,
@@ -381,7 +380,7 @@ public sealed class DefaultAIDataSourceIndexingService : IAIDataSourceIndexingSe
             return null;
         }
 
-        var knowledgeBaseProfile = await _indexProfileManager.FindByNameAsync(dataSource.AIKnowledgeBaseIndexProfileName);
+        var knowledgeBaseProfile = await _indexProfileManager.FindByNameAsync(dataSource.AIKnowledgeBaseIndexProfileName, cancellationToken);
         if (knowledgeBaseProfile == null)
         {
             _logger.LogWarning("Skipping data source '{DataSourceId}' because knowledge-base index profile '{IndexProfileName}' was not found.", dataSource.ItemId, dataSource.AIKnowledgeBaseIndexProfileName);

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIProfileManager.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIProfileManager.cs
@@ -90,11 +90,12 @@ public sealed class DefaultAIProfileManager : NamedCatalogManager<AIProfile>, IA
     /// <summary>
     /// Creates a new AI profile instance.
     /// </summary>
+    /// <param name="name">The profile name.</param>
     /// <param name="data">The optional initialization data.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    public new async ValueTask<AIProfile> NewAsync(JsonNode data = null, CancellationToken cancellationToken = default)
+    public new async ValueTask<AIProfile> NewAsync(string name, JsonNode data = null, CancellationToken cancellationToken = default)
     {
-        var profile = await base.NewAsync(data, cancellationToken);
+        var profile = await base.NewAsync(name, data, cancellationToken);
 
         EnsureDefaults(profile);
 
@@ -133,15 +134,6 @@ public sealed class DefaultAIProfileManager : NamedCatalogManager<AIProfile>, IA
 
         return result;
     }
-
-    ValueTask<AIProfile> ICatalogManager<AIProfile>.NewAsync(JsonNode data, CancellationToken cancellationToken)
-        => NewAsync(data, cancellationToken);
-
-    ValueTask ICatalogManager<AIProfile>.CreateAsync(AIProfile model, CancellationToken cancellationToken)
-        => CreateAsync(model, cancellationToken);
-
-    ValueTask<ValidationResultDetails> ICatalogManager<AIProfile>.ValidateAsync(AIProfile model, CancellationToken cancellationToken)
-        => ValidateAsync(model, cancellationToken);
 
     private void EnsureDefaults(AIProfile profile)
     {

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Extensions;
 using CrestApps.Core.AI.Models;
@@ -8,7 +9,6 @@ using CrestApps.Core.AI.Services;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.DataSources;
-using CrestApps.Core.Services;
 using Cysharp.Text;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -101,7 +101,7 @@ public sealed class DataSourceSearchTool : AIFunction
                 return "No data source is configured for this profile.";
             }
 
-            var dataSourceStore = arguments.Services.GetRequiredService<ICatalog<AIDataSource>>();
+            var dataSourceStore = arguments.Services.GetRequiredService<IAIDataSourceStore>();
             var dataSource = await dataSourceStore.FindByIdAsync(dataSourceId, cancellationToken);
 
             if (dataSource == null)

--- a/src/Primitives/CrestApps.Core.Elasticsearch/Services/ElasticsearchClientFactory.cs
+++ b/src/Primitives/CrestApps.Core.Elasticsearch/Services/ElasticsearchClientFactory.cs
@@ -1,10 +1,9 @@
 using Elastic.Clients.Elasticsearch;
 using Elastic.Transport;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
-using System.Net.Http;
 
 namespace CrestApps.Core.Elasticsearch.Services;
 

--- a/src/Primitives/CrestApps.Core/Services/CatalogManager.cs
+++ b/src/Primitives/CrestApps.Core/Services/CatalogManager.cs
@@ -1,20 +1,12 @@
 using System.Text.Json.Nodes;
-using CrestApps.Core.Extensions;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
 
 namespace CrestApps.Core.Services;
 
-/// <summary>
-/// Represents the catalog Manager.
-/// </summary>
-public class CatalogManager<T> : ICatalogManager<T>
+public class CatalogManager<T> : CatalogManagerBase<T>, ICatalogManager<T>
     where T : CatalogItem, new()
 {
-    protected readonly ICatalog<T> Catalog;
-    protected readonly ILogger Logger;
-    protected readonly IEnumerable<ICatalogEntryHandler<T>> Handlers;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="CatalogManager"/> class.
     /// </summary>
@@ -25,74 +17,8 @@ public class CatalogManager<T> : ICatalogManager<T>
         ICatalog<T> catalog,
         IEnumerable<ICatalogEntryHandler<T>> handlers,
         ILogger<CatalogManager<T>> logger)
+        : base(catalog, handlers, logger)
     {
-        Catalog = catalog;
-        Handlers = handlers;
-        Logger = logger;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CatalogManager"/> class.
-    /// </summary>
-    /// <param name="store">The store.</param>
-    /// <param name="handlers">The handlers.</param>
-    /// <param name="logger">The logger.</param>
-    protected CatalogManager(
-        ICatalog<T> store,
-        IEnumerable<ICatalogEntryHandler<T>> handlers,
-        ILogger logger)
-    {
-        Catalog = store;
-        Handlers = handlers;
-        Logger = logger;
-    }
-
-    /// <summary>
-    /// Deletes the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask<bool> DeleteAsync(T entry, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        var deletingContext = new DeletingContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.DeletingAsync(ctx, cancellationToken), deletingContext, Logger);
-
-        if (string.IsNullOrEmpty(entry.ItemId))
-        {
-            return false;
-        }
-
-        var removed = await Catalog.DeleteAsync(entry, cancellationToken);
-
-        await DeletedAsync(entry);
-
-        var deletedContext = new DeletedContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.DeletedAsync(ctx, cancellationToken), deletedContext, Logger);
-
-        return removed;
-    }
-
-    /// <summary>
-    /// Finds by id.
-    /// </summary>
-    /// <param name="id">The id.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask<T> FindByIdAsync(string id, CancellationToken cancellationToken = default)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(id);
-
-        var entry = await Catalog.FindByIdAsync(id, cancellationToken);
-
-        if (entry is not null)
-        {
-            await LoadAsync(entry, cancellationToken);
-
-            return entry;
-        }
-
-        return null!;
     }
 
     /// <summary>
@@ -102,134 +28,6 @@ public class CatalogManager<T> : ICatalogManager<T>
     /// <param name="cancellationToken">The cancellation token.</param>
     public virtual async ValueTask<T> NewAsync(JsonNode? data = null, CancellationToken cancellationToken = default)
     {
-        var id = UniqueId.GenerateId();
-
-        var entry = new T()
-        {
-            ItemId = id,
-        };
-
-        var initializingContext = new InitializingContext<T>(entry, data);
-        await Handlers.InvokeAsync((handler, ctx) => handler.InitializingAsync(ctx, cancellationToken), initializingContext, Logger);
-
-        var initializedContext = new InitializedContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.InitializedAsync(ctx, cancellationToken), initializedContext, Logger);
-
-        if (string.IsNullOrEmpty(entry.ItemId))
-        {
-            entry.ItemId = id;
-        }
-
-        return entry;
-    }
-
-    /// <summary>
-    /// Pages the operation.
-    /// </summary>
-    public async ValueTask<PageResult<T>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)
-        where TQuery : QueryContext
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var result = await Catalog.PageAsync(page, pageSize, context, cancellationToken);
-
-        foreach (var entry in result.Entries)
-        {
-            await LoadAsync(entry, cancellationToken);
-        }
-
-        return result;
-    }
-
-    /// <summary>
-    /// Creates the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask CreateAsync(T entry, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        var creatingContext = new CreatingContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.CreatingAsync(ctx, cancellationToken), creatingContext, Logger);
-
-        await Catalog.CreateAsync(entry, cancellationToken);
-
-        var createdContext = new CreatedContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.CreatedAsync(ctx, cancellationToken), createdContext, Logger);
-    }
-
-    /// <summary>
-    /// Updates the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    /// <param name="data">The data.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask UpdateAsync(T entry, JsonNode? data = null, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        var updatingContext = new UpdatingContext<T>(entry, data);
-        await Handlers.InvokeAsync((handler, ctx) => handler.UpdatingAsync(ctx, cancellationToken), updatingContext, Logger);
-
-        await Catalog.UpdateAsync(entry, cancellationToken);
-
-        var updatedContext = new UpdatedContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.UpdatedAsync(ctx, cancellationToken), updatedContext, Logger);
-    }
-
-    /// <summary>
-    /// Validates the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask<ValidationResultDetails> ValidateAsync(T entry, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        var validatingContext = new ValidatingContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.ValidatingAsync(ctx, cancellationToken), validatingContext, Logger);
-
-        var validatedContext = new ValidatedContext<T>(entry, validatingContext.Result);
-        await Handlers.InvokeAsync((handler, ctx) => handler.ValidatedAsync(ctx, cancellationToken), validatedContext, Logger);
-
-        return validatingContext.Result;
-    }
-
-    /// <summary>
-    /// Gets all.
-    /// </summary>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async ValueTask<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        var models = await Catalog.GetAllAsync(cancellationToken);
-
-        foreach (var model in models)
-        {
-            await LoadAsync(model, cancellationToken);
-        }
-
-        return models;
-    }
-
-    /// <summary>
-    /// Deleteds the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    protected virtual ValueTask DeletedAsync(T entry)
-    {
-        return ValueTask.CompletedTask;
-    }
-
-    /// <summary>
-    /// Loads the operation.
-    /// </summary>
-    /// <param name="entry">The entry.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    protected virtual async Task LoadAsync(T entry, CancellationToken cancellationToken = default)
-    {
-        var loadedContext = new LoadedContext<T>(entry);
-
-        await Handlers.InvokeAsync((handler, context) => handler.LoadedAsync(context, cancellationToken), loadedContext, Logger);
+        return await InitializeNewEntryAsync(new T(), data, cancellationToken);
     }
 }

--- a/src/Primitives/CrestApps.Core/Services/CatalogManagerBase.cs
+++ b/src/Primitives/CrestApps.Core/Services/CatalogManagerBase.cs
@@ -1,0 +1,240 @@
+using System.Text.Json.Nodes;
+using CrestApps.Core.Extensions;
+using CrestApps.Core.Models;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.Services;
+
+/// <summary>
+/// Represents the catalog Manager.
+/// </summary>
+public abstract class CatalogManagerBase<T>
+    where T : CatalogItem, new()
+{
+    protected readonly ICatalog<T> Catalog;
+    protected readonly ILogger Logger;
+    protected readonly IEnumerable<ICatalogEntryHandler<T>> Handlers;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CatalogManager"/> class.
+    /// </summary>
+    /// <param name="store">The store.</param>
+    /// <param name="handlers">The handlers.</param>
+    /// <param name="logger">The logger.</param>
+    protected CatalogManagerBase(
+        ICatalog<T> store,
+        IEnumerable<ICatalogEntryHandler<T>> handlers,
+        ILogger logger)
+    {
+        Catalog = store;
+        Handlers = handlers;
+        Logger = logger;
+    }
+
+    /// <summary>
+    /// Deletes the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<bool> DeleteAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var deletingContext = new DeletingContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.DeletingAsync(ctx, cancellationToken), deletingContext, Logger);
+
+        if (string.IsNullOrEmpty(entry.ItemId))
+        {
+            return false;
+        }
+
+        var removed = await Catalog.DeleteAsync(entry, cancellationToken);
+
+        await DeletedAsync(entry);
+
+        var deletedContext = new DeletedContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.DeletedAsync(ctx, cancellationToken), deletedContext, Logger);
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Finds by id.
+    /// </summary>
+    /// <param name="id">The id.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<T> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        var entry = await Catalog.FindByIdAsync(id, cancellationToken);
+
+        if (entry is not null)
+        {
+            await LoadAsync(entry, cancellationToken);
+
+            return entry;
+        }
+
+        return null!;
+    }
+
+    /// <summary>
+    /// Pages the operation.
+    /// </summary>
+    public async ValueTask<PageResult<T>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)
+        where TQuery : QueryContext
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var result = await Catalog.PageAsync(page, pageSize, context, cancellationToken);
+
+        foreach (var entry in result.Entries)
+        {
+            await LoadAsync(entry, cancellationToken);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Creates the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask CreateAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var creatingContext = new CreatingContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.CreatingAsync(ctx, cancellationToken), creatingContext, Logger);
+
+        await Catalog.CreateAsync(entry, cancellationToken);
+
+        var createdContext = new CreatedContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.CreatedAsync(ctx, cancellationToken), createdContext, Logger);
+    }
+
+    /// <summary>
+    /// Updates the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="data">The data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask UpdateAsync(T entry, JsonNode? data = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var updatingContext = new UpdatingContext<T>(entry, data);
+        await Handlers.InvokeAsync((handler, ctx) => handler.UpdatingAsync(ctx, cancellationToken), updatingContext, Logger);
+
+        await Catalog.UpdateAsync(entry, cancellationToken);
+
+        var updatedContext = new UpdatedContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.UpdatedAsync(ctx, cancellationToken), updatedContext, Logger);
+    }
+
+    /// <summary>
+    /// Validates the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<ValidationResultDetails> ValidateAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var validatingContext = new ValidatingContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.ValidatingAsync(ctx, cancellationToken), validatingContext, Logger);
+
+        var validatedContext = new ValidatedContext<T>(entry, validatingContext.Result);
+        await Handlers.InvokeAsync((handler, ctx) => handler.ValidatedAsync(ctx, cancellationToken), validatedContext, Logger);
+
+        return validatingContext.Result;
+    }
+
+    /// <summary>
+    /// Gets all.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var models = await Catalog.GetAllAsync(cancellationToken);
+
+        foreach (var model in models)
+        {
+            await LoadAsync(model, cancellationToken);
+        }
+
+        return models;
+    }
+
+    /// <summary>
+    /// Initializes a new catalog entry and runs the initialization pipeline.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="data">The data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    protected async ValueTask<T> InitializeNewEntryAsync(T entry, JsonNode? data = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var itemId = string.IsNullOrEmpty(entry.ItemId)
+            ? UniqueId.GenerateId()
+            : entry.ItemId;
+
+        entry.ItemId = itemId;
+
+        var initializingContext = new InitializingContext<T>(entry, data);
+        await Handlers.InvokeAsync((handler, ctx) => handler.InitializingAsync(ctx, cancellationToken), initializingContext, Logger);
+
+        var initializedContext = new InitializedContext<T>(entry);
+        await Handlers.InvokeAsync((handler, ctx) => handler.InitializedAsync(ctx, cancellationToken), initializedContext, Logger);
+
+        if (string.IsNullOrEmpty(entry.ItemId))
+        {
+            entry.ItemId = itemId;
+        }
+
+        return entry;
+    }
+
+    /// <summary>
+    /// Sets the name on a name-aware entry.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="name">The name.</param>
+    protected static void SetName(T entry, string name)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var property = typeof(T).GetProperty(nameof(INameAwareModel.Name));
+        if (property?.CanWrite != true)
+        {
+            throw new InvalidOperationException($"The catalog entry type '{typeof(T).FullName}' must expose a writable '{nameof(INameAwareModel.Name)}' property.");
+        }
+
+        property.SetValue(entry, name);
+    }
+
+    /// <summary>
+    /// Deleteds the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    protected virtual ValueTask DeletedAsync(T entry)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Loads the operation.
+    /// </summary>
+    /// <param name="entry">The entry.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    protected virtual async Task LoadAsync(T entry, CancellationToken cancellationToken = default)
+    {
+        var loadedContext = new LoadedContext<T>(entry);
+
+        await Handlers.InvokeAsync((handler, context) => handler.LoadedAsync(context, cancellationToken), loadedContext, Logger);
+    }
+}

--- a/src/Primitives/CrestApps.Core/Services/NamedCatalogManager.cs
+++ b/src/Primitives/CrestApps.Core/Services/NamedCatalogManager.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
 
@@ -6,7 +7,7 @@ namespace CrestApps.Core.Services;
 /// <summary>
 /// Represents the named Catalog Manager.
 /// </summary>
-public class NamedCatalogManager<T> : CatalogManager<T>, INamedCatalogManager<T>
+public class NamedCatalogManager<T> : CatalogManagerBase<T>, INamedCatalogManager<T>
     where T : CatalogItem, INameAwareModel, new()
 {
     protected readonly INamedCatalog<T> NamedCatalog;
@@ -21,7 +22,7 @@ public class NamedCatalogManager<T> : CatalogManager<T>, INamedCatalogManager<T>
         INamedCatalog<T> catalog,
         IEnumerable<ICatalogEntryHandler<T>> handlers,
         ILogger<NamedCatalogManager<T>> logger)
-    : base(catalog, handlers, logger)
+        : base(catalog, handlers, logger)
     {
         NamedCatalog = catalog;
     }
@@ -58,5 +59,25 @@ public class NamedCatalogManager<T> : CatalogManager<T>, INamedCatalogManager<T>
         }
 
         return entry!;
+    }
+
+    /// <summary>
+    /// News the operation.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="data">The data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async ValueTask<T> NewAsync(string name, JsonNode? data = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var entry = new T();
+        SetName(entry, name);
+
+        entry = await InitializeNewEntryAsync(entry, data, cancellationToken);
+
+        SetName(entry, name);
+
+        return entry;
     }
 }

--- a/src/Primitives/CrestApps.Core/Services/NamedSourceCatalogManager.cs
+++ b/src/Primitives/CrestApps.Core/Services/NamedSourceCatalogManager.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
 
@@ -6,7 +7,7 @@ namespace CrestApps.Core.Services;
 /// <summary>
 /// Represents the named Source Catalog Manager.
 /// </summary>
-public class NamedSourceCatalogManager<T> : SourceCatalogManager<T>, INamedCatalogManager<T>, ISourceCatalogManager<T>, INamedSourceCatalogManager<T>
+public class NamedSourceCatalogManager<T> : CatalogManagerBase<T>, INamedCatalogManager<T>, ISourceCatalogManager<T>, INamedSourceCatalogManager<T>
     where T : CatalogItem, INameAwareModel, ISourceAwareModel, new()
 {
     protected readonly INamedSourceCatalog<T> NamedSourceCatalog;
@@ -64,5 +65,107 @@ public class NamedSourceCatalogManager<T> : SourceCatalogManager<T>, INamedCatal
         }
 
         return entry!;
+    }
+
+    /// <summary>
+    /// Gets the operation.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<IEnumerable<T>> GetAsync(string source, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        var entries = await NamedSourceCatalog.GetAsync(source, cancellationToken);
+
+        foreach (var entry in entries)
+        {
+            await LoadAsync(entry, cancellationToken);
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Finds by source.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async ValueTask<IEnumerable<T>> FindBySourceAsync(string source, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        var entries = (await Catalog.GetAllAsync(cancellationToken)).Where(x => x.Source == source);
+
+        foreach (var entry in entries)
+        {
+            await LoadAsync(entry, cancellationToken);
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// News the operation.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="source">The source.</param>
+    /// <param name="data">The data.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public virtual async ValueTask<T> NewAsync(string name, string source, JsonNode? data = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        var entry = new T
+        {
+            Source = source,
+        };
+
+        SetName(entry, name);
+
+        entry = await InitializeNewEntryAsync(entry, data, cancellationToken);
+        entry.Source = source;
+        SetName(entry, name);
+
+        return entry;
+    }
+
+    ValueTask<T> INamedCatalogManager<T>.NewAsync(string name, JsonNode data, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var entry = new T();
+        SetName(entry, name);
+
+        return InitializeNameOnlyEntryAsync(entry, name, data, cancellationToken);
+    }
+
+    ValueTask<T> ISourceCatalogManager<T>.NewAsync(string source, JsonNode data, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        return InitializeSourceOnlyEntryAsync(source, data, cancellationToken);
+    }
+
+    private async ValueTask<T> InitializeNameOnlyEntryAsync(T entry, string name, JsonNode? data, CancellationToken cancellationToken)
+    {
+        entry = await InitializeNewEntryAsync(entry, data, cancellationToken);
+        SetName(entry, name);
+
+        return entry;
+    }
+
+    private async ValueTask<T> InitializeSourceOnlyEntryAsync(string source, JsonNode? data, CancellationToken cancellationToken)
+    {
+        var entry = new T
+        {
+            Source = source,
+        };
+
+        entry = await InitializeNewEntryAsync(entry, data, cancellationToken);
+        entry.Source = source;
+
+        return entry;
     }
 }

--- a/src/Primitives/CrestApps.Core/Services/SourceCatalogManager.cs
+++ b/src/Primitives/CrestApps.Core/Services/SourceCatalogManager.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Nodes;
-using CrestApps.Core.Extensions;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
 

--- a/src/Primitives/CrestApps.Core/Services/SourceCatalogManager.cs
+++ b/src/Primitives/CrestApps.Core/Services/SourceCatalogManager.cs
@@ -8,7 +8,7 @@ namespace CrestApps.Core.Services;
 /// <summary>
 /// Represents the source Catalog Manager.
 /// </summary>
-public class SourceCatalogManager<T> : CatalogManager<T>, ISourceCatalogManager<T>
+public class SourceCatalogManager<T> : CatalogManagerBase<T>, ISourceCatalogManager<T>
     where T : CatalogItem, ISourceAwareModel, new()
 {
     protected readonly ISourceCatalog<T> SourceCatalog;
@@ -76,44 +76,13 @@ public class SourceCatalogManager<T> : CatalogManager<T>, ISourceCatalogManager<
     {
         ArgumentException.ThrowIfNullOrEmpty(source);
 
-        var id = UniqueId.GenerateId();
-
-        var entry = new T()
+        var entry = await InitializeNewEntryAsync(new T()
         {
-            ItemId = id,
             Source = source,
-        };
-
-        var initializingContext = new InitializingContext<T>(entry, data);
-        await Handlers.InvokeAsync((handler, ctx) => handler.InitializingAsync(ctx, cancellationToken), initializingContext, Logger);
-
-        var initializedContext = new InitializedContext<T>(entry);
-        await Handlers.InvokeAsync((handler, ctx) => handler.InitializedAsync(ctx, cancellationToken), initializedContext, Logger);
-
-        if (string.IsNullOrEmpty(entry.ItemId))
-        {
-            entry.ItemId = id;
-        }
+        }, data, cancellationToken);
 
         entry.Source = source;
 
         return entry;
-    }
-
-    /// <summary>
-    /// News the operation.
-    /// </summary>
-    /// <param name="data">The data.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public override ValueTask<T> NewAsync(JsonNode? data = null, CancellationToken cancellationToken = default)
-    {
-        var source = data?["Source"]?.GetValue<string>();
-
-        if (string.IsNullOrEmpty(source))
-        {
-            throw new InvalidOperationException("Data must contain a Source entry");
-        }
-
-        return NewAsync(source, data, cancellationToken);
     }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Services/ArticleIndexingService.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Services/ArticleIndexingService.cs
@@ -124,7 +124,7 @@ public sealed class ArticleIndexingService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var indexProfiles = await _indexProfileStore.GetByTypeAsync(IndexProfileTypes.Articles);
+        var indexProfiles = await _indexProfileStore.GetByTypeAsync(IndexProfileTypes.Articles, cancellationToken);
 
         if (indexProfiles.Count == 0)
         {

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Controllers/ChatInteractionController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Controllers/ChatInteractionController.cs
@@ -6,6 +6,7 @@ using CrestApps.Core.AI.Claude.Services;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Copilot.Models;
 using CrestApps.Core.AI.Copilot.Services;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Documents;
 using CrestApps.Core.AI.Documents.Models;
@@ -37,14 +38,12 @@ namespace CrestApps.Core.Mvc.Web.Areas.ChatInteractions.Controllers;
 public sealed class ChatInteractionController : Controller
 {
     private readonly ICatalogManager<ChatInteraction> _interactionManager;
-    private readonly ICatalog<ChatInteraction> _interactionCatalog;
     private readonly IChatInteractionPromptStore _promptStore;
     private readonly IAIDeploymentStore _deploymentCatalog;
     private readonly ICatalog<A2AConnection> _a2aConnectionCatalog;
     private readonly ICatalog<McpConnection> _mcpConnectionCatalog;
-    private readonly ICatalog<AIDataSource> _dataSourceCatalog;
+    private readonly IAIDataSourceStore _dataSourceCatalog;
     private readonly IAIProfileManager _profileManager;
-    private readonly IAIProfileTemplateManager _templateManager;
     private readonly IAIDocumentStore _documentStore;
     private readonly IAIDocumentChunkStore _chunkStore;
     private readonly IDocumentFileStore _fileStore;
@@ -65,14 +64,12 @@ public sealed class ChatInteractionController : Controller
 
     public ChatInteractionController(
         ICatalogManager<ChatInteraction> interactionManager,
-        ICatalog<ChatInteraction> interactionCatalog,
         IChatInteractionPromptStore promptStore,
         IAIDeploymentStore deploymentCatalog,
         ICatalog<A2AConnection> a2aConnectionCatalog,
         ICatalog<McpConnection> mcpConnectionCatalog,
-        ICatalog<AIDataSource> dataSourceCatalog,
+        IAIDataSourceStore dataSourceCatalog,
         IAIProfileManager profileManager,
-        IAIProfileTemplateManager templateManager,
         IAIDocumentStore documentStore,
         IAIDocumentChunkStore chunkStore,
         IDocumentFileStore fileStore,
@@ -91,14 +88,12 @@ public sealed class ChatInteractionController : Controller
         IOptions<AIToolDefinitionOptions> toolOptions)
     {
         _interactionManager = interactionManager;
-        _interactionCatalog = interactionCatalog;
         _promptStore = promptStore;
         _deploymentCatalog = deploymentCatalog;
         _a2aConnectionCatalog = a2aConnectionCatalog;
         _mcpConnectionCatalog = mcpConnectionCatalog;
         _dataSourceCatalog = dataSourceCatalog;
         _profileManager = profileManager;
-        _templateManager = templateManager;
         _documentStore = documentStore;
         _chunkStore = chunkStore;
         _fileStore = fileStore;
@@ -113,7 +108,6 @@ public sealed class ChatInteractionController : Controller
         _anthropicOptions = anthropicOptions;
         _anthropicClientService = anthropicClientService;
         _copilotOptions = copilotOptions;
-
         _oauthService = oauthService;
         _toolOptions = toolOptions.Value;
     }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Controllers/AIDataSourceController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Controllers/AIDataSourceController.cs
@@ -16,7 +16,7 @@ namespace CrestApps.Core.Mvc.Web.Areas.DataSources.Controllers;
 [Authorize(Policy = "Admin")]
 public sealed class AIDataSourceController : Controller
 {
-    private readonly ICatalogManager<AIDataSource> _manager;
+    private readonly ISourceCatalogManager<AIDataSource> _manager;
     private readonly ISearchIndexProfileStore _indexProfileStore;
     private readonly IAIDataSourceIndexingQueue _indexingQueue;
     private readonly IServiceProvider _serviceProvider;
@@ -25,7 +25,7 @@ public sealed class AIDataSourceController : Controller
     private readonly IReadOnlyList<AIDataSourceSourceDescriptor> _sourceDescriptors;
 
     public AIDataSourceController(
-        ICatalogManager<AIDataSource> manager,
+        ISourceCatalogManager<AIDataSource> manager,
         ISearchIndexProfileStore indexProfileStore,
         IAIDataSourceIndexingQueue indexingQueue,
         IServiceProvider serviceProvider,
@@ -76,7 +76,7 @@ public sealed class AIDataSourceController : Controller
             return View(model);
         }
 
-        var dataSource = await _manager.NewAsync();
+        var dataSource = await _manager.NewAsync(model.Source, cancellationToken: HttpContext.RequestAborted);
         dataSource.CreatedUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
         model.ApplyTo(dataSource, _dataProtectionProvider.CreateProtector(AIDataSourceProtectionConstants.SourceSecretPurpose));

--- a/src/Startup/CrestApps.Core.Startup.Shared/Services/ArticleIndexingService.cs
+++ b/src/Startup/CrestApps.Core.Startup.Shared/Services/ArticleIndexingService.cs
@@ -126,7 +126,7 @@ public sealed class ArticleIndexingService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var indexProfiles = await _indexProfileStore.GetByTypeAsync(IndexProfileTypes.Articles);
+        var indexProfiles = await _indexProfileStore.GetByTypeAsync(IndexProfileTypes.Articles, cancellationToken);
 
         if (indexProfiles.Count == 0)
         {

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreAIDataSourceStore.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreAIDataSourceStore.cs
@@ -13,7 +13,7 @@ public sealed class EntityCoreAIDataSourceStore : SourceDocumentCatalog<AIDataSo
     /// <param name="logger">The logger.</param>
     public EntityCoreAIDataSourceStore(
         CrestAppsEntityDbContext dbContext,
-        ILogger<DocumentCatalog<AIDataSource>> logger = null)
+        ILogger<DocumentCatalog<AIDataSource>> logger)
         : base(dbContext, logger)
     {
     }

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreSearchIndexProfileStore.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreSearchIndexProfileStore.cs
@@ -19,10 +19,10 @@ public sealed class EntityCoreSearchIndexProfileStore : NamedDocumentCatalog<Sea
     /// Gets by type.
     /// </summary>
     /// <param name="type">The type.</param>
-    public async Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+    public async Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(type);
-        var records = await GetReadQuery().Where(x => x.Type == type).ToListAsync();
+        var records = await GetReadQuery().Where(x => x.Type == type).ToListAsync(cancellationToken);
 
         return records.Select(CatalogRecordFactory.Materialize<SearchIndexProfile>).ToArray();
     }

--- a/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlSearchIndexProfileStore.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlSearchIndexProfileStore.cs
@@ -37,12 +37,12 @@ public sealed class YesSqlSearchIndexProfileStore : DocumentCatalog<SearchIndexP
     /// Gets by type.
     /// </summary>
     /// <param name="type">The type.</param>
-    public async Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+    public async Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(type);
 
         var items = await Session.Query<SearchIndexProfile, SearchIndexProfileIndex>(x => x.Type == type, collection: CollectionName)
-            .ListAsync();
+            .ListAsync(cancellationToken);
 
         return items.ToArray();
     }

--- a/tests/CrestApps.Core.Tests/Core/Chat/DataSourceChatInteractionSettingsHandlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Chat/DataSourceChatInteractionSettingsHandlerTests.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using CrestApps.Core.AI.Chat.Handlers;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -13,7 +13,7 @@ public sealed class DataSourceChatInteractionSettingsHandlerTests
     [Fact]
     public async Task UpdatingAsync_WithDataSource_PersistsDataSourceAndDefaultRagMetadata()
     {
-        var dataSourceCatalog = new Mock<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = new Mock<IAIDataSourceStore>();
         dataSourceCatalog
             .Setup(catalog => catalog.FindByIdAsync("datasource-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AIDataSource { ItemId = "datasource-1" });

--- a/tests/CrestApps.Core.Tests/Core/Services/AIDataSourceSearchDocumentHandlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/AIDataSourceSearchDocumentHandlerTests.cs
@@ -1,6 +1,6 @@
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Services;
-using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.Models;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/CrestApps.Core.Tests/Core/Services/AIDataSourceSearchDocumentHandlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/AIDataSourceSearchDocumentHandlerTests.cs
@@ -1,8 +1,8 @@
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.Models;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -27,7 +27,7 @@ public sealed class AIDataSourceSearchDocumentHandlerTests
         indexProfileManager.Setup(manager => manager.FindByIdAsync(sourceProfile.ItemId, cancellationToken))
             .ReturnsAsync(sourceProfile);
 
-        var dataSourceCatalog = new Mock<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = new Mock<IAIDataSourceStore>();
         dataSourceCatalog.Setup(catalog => catalog.GetAllAsync(cancellationToken))
             .ReturnsAsync(
             [
@@ -71,7 +71,7 @@ public sealed class AIDataSourceSearchDocumentHandlerTests
         indexProfileManager.Setup(manager => manager.FindByIdAsync(sourceProfile.ItemId, cancellationToken))
             .ReturnsAsync(sourceProfile);
 
-        var dataSourceCatalog = new Mock<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = new Mock<IAIDataSourceStore>();
         dataSourceCatalog.Setup(catalog => catalog.GetAllAsync(cancellationToken))
             .ReturnsAsync(
             [

--- a/tests/CrestApps.Core.Tests/Core/Services/AIServiceCollectionExtensionsTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/AIServiceCollectionExtensionsTests.cs
@@ -50,8 +50,8 @@ public sealed class AIServiceCollectionExtensionsTests
         var scopedServices = scope.ServiceProvider;
 
         Assert.IsType<DefaultAIProfileManager>(scopedServices.GetRequiredService<IAIProfileManager>());
-        Assert.IsType<DefaultAIProfileManager>(scopedServices.GetRequiredService<ICatalogManager<AIProfile>>());
         Assert.IsType<DefaultAIProfileManager>(scopedServices.GetRequiredService<INamedCatalogManager<AIProfile>>());
+        Assert.Null(scopedServices.GetService<ICatalogManager<AIProfile>>());
     }
 
     [Fact]

--- a/tests/CrestApps.Core.Tests/Core/Services/Catalogs/NamedCatalogManagerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/Catalogs/NamedCatalogManagerTests.cs
@@ -45,6 +45,39 @@ public sealed class NamedCatalogManagerTests
     }
 
     [Fact]
+    public async Task NewAsync_AssignsRequestedName()
+    {
+        var manager = CreateManager();
+
+        var entry = await manager.NewAsync("Test", cancellationToken: CancellationToken);
+
+        Assert.Equal("Test", entry.Name);
+        Assert.False(string.IsNullOrEmpty(entry.ItemId));
+    }
+
+    [Fact]
+    public async Task NewAsync_RestoresRequestedNameAfterInitialization()
+    {
+        var catalog = InMemoryCatalogFactory.CreateNamedCatalog<TestNamedCatalogEntry>([]);
+        var logger = Mock.Of<ILogger<NamedCatalogManager<TestNamedCatalogEntry>>>();
+        var handler = new TestCatalogEntryHandler<TestNamedCatalogEntry>
+        {
+            OnInitializingAsync = ctx =>
+            {
+                ctx.Model.Name = "Changed";
+
+                return Task.CompletedTask;
+            }
+        };
+
+        var manager = new NamedCatalogManager<TestNamedCatalogEntry>(catalog, [handler], logger);
+
+        var entry = await manager.NewAsync("Test", cancellationToken: CancellationToken);
+
+        Assert.Equal("Test", entry.Name);
+    }
+
+    [Fact]
     public async Task FindByNameAsync_InvokesLoadedHandler()
     {
         var entry = new TestNamedCatalogEntry { ItemId = "1", Name = "Test" };

--- a/tests/CrestApps.Core.Tests/Core/Services/Catalogs/NamedSourceCatalogManagerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/Catalogs/NamedSourceCatalogManagerTests.cs
@@ -41,6 +41,42 @@ public sealed class NamedSourceCatalogManagerTests
     }
 
     [Fact]
+    public async Task NewAsync_AssignsRequestedNameAndSource()
+    {
+        var manager = CreateManager();
+
+        var entry = await manager.NewAsync("Test", "A", cancellationToken: CancellationToken);
+
+        Assert.Equal("Test", entry.Name);
+        Assert.Equal("A", entry.Source);
+        Assert.False(string.IsNullOrEmpty(entry.ItemId));
+    }
+
+    [Fact]
+    public async Task NewAsync_RestoresRequestedNameAndSourceAfterInitialization()
+    {
+        var catalog = InMemoryCatalogFactory.CreateNamedSourceCatalog<TestNamedSourceCatalogEntry>([]);
+        var logger = Mock.Of<ILogger<NamedSourceCatalogManager<TestNamedSourceCatalogEntry>>>();
+        var handler = new TestCatalogEntryHandler<TestNamedSourceCatalogEntry>
+        {
+            OnInitializingAsync = ctx =>
+            {
+                ctx.Model.Name = "Changed";
+                ctx.Model.Source = "Changed";
+
+                return Task.CompletedTask;
+            }
+        };
+
+        var manager = new NamedSourceCatalogManager<TestNamedSourceCatalogEntry>(catalog, [handler], logger);
+
+        var entry = await manager.NewAsync("Test", "A", cancellationToken: CancellationToken);
+
+        Assert.Equal("Test", entry.Name);
+        Assert.Equal("A", entry.Source);
+    }
+
+    [Fact]
     public async Task FindByNameAsync_InvokesLoadedHandler()
     {
         var entry = new TestNamedSourceCatalogEntry { ItemId = "1", Name = "Test", Source = "A" };

--- a/tests/CrestApps.Core.Tests/Core/Services/Catalogs/SourceCatalogManagerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/Catalogs/SourceCatalogManagerTests.cs
@@ -1,0 +1,82 @@
+using CrestApps.Core.Services;
+using CrestApps.Core.Tests.Core.Services.Catalogs.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CrestApps.Core.Tests.Core.Services.Catalogs;
+
+public sealed class SourceCatalogManagerTests
+{
+    private static CancellationToken CancellationToken => TestContext.Current.CancellationToken;
+
+    private static SourceCatalogManager<TestNamedSourceCatalogEntry> CreateManager(List<TestNamedSourceCatalogEntry> records = null)
+    {
+        records ??= [];
+        var catalog = InMemoryCatalogFactory.CreateNamedSourceCatalog(records);
+        var logger = Mock.Of<ILogger<SourceCatalogManager<TestNamedSourceCatalogEntry>>>();
+
+        return new SourceCatalogManager<TestNamedSourceCatalogEntry>(catalog, [], logger);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsEntriesForRequestedSource()
+    {
+        var manager = CreateManager(
+        [
+            new TestNamedSourceCatalogEntry { ItemId = "1", Name = "First", Source = "A" },
+            new TestNamedSourceCatalogEntry { ItemId = "2", Name = "Second", Source = "B" },
+        ]);
+
+        var entries = await manager.GetAsync("A", CancellationToken);
+
+        Assert.Collection(entries, entry => Assert.Equal("1", entry.ItemId));
+    }
+
+    [Fact]
+    public async Task FindBySourceAsync_ReturnsEntriesForRequestedSource()
+    {
+        var manager = CreateManager(
+        [
+            new TestNamedSourceCatalogEntry { ItemId = "1", Name = "First", Source = "A" },
+            new TestNamedSourceCatalogEntry { ItemId = "2", Name = "Second", Source = "A" },
+            new TestNamedSourceCatalogEntry { ItemId = "3", Name = "Third", Source = "B" },
+        ]);
+
+        var entries = await manager.FindBySourceAsync("A", CancellationToken);
+
+        Assert.Equal(["1", "2"], entries.Select(entry => entry.ItemId));
+    }
+
+    [Fact]
+    public async Task NewAsync_AssignsRequestedSource()
+    {
+        var manager = CreateManager();
+
+        var entry = await manager.NewAsync("A", cancellationToken: CancellationToken);
+
+        Assert.Equal("A", entry.Source);
+        Assert.False(string.IsNullOrEmpty(entry.ItemId));
+    }
+
+    [Fact]
+    public async Task NewAsync_RestoresRequestedSourceAfterInitialization()
+    {
+        var catalog = InMemoryCatalogFactory.CreateNamedSourceCatalog<TestNamedSourceCatalogEntry>([]);
+        var logger = Mock.Of<ILogger<SourceCatalogManager<TestNamedSourceCatalogEntry>>>();
+        var handler = new TestCatalogEntryHandler<TestNamedSourceCatalogEntry>
+        {
+            OnInitializingAsync = ctx =>
+            {
+                ctx.Model.Source = "Changed";
+
+                return Task.CompletedTask;
+            }
+        };
+
+        var manager = new SourceCatalogManager<TestNamedSourceCatalogEntry>(catalog, [handler], logger);
+
+        var entry = await manager.NewAsync("A", cancellationToken: CancellationToken);
+
+        Assert.Equal("A", entry.Source);
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/Services/DefaultAIDataSourceChangeNotifierTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/DefaultAIDataSourceChangeNotifierTests.cs
@@ -1,6 +1,6 @@
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Services;
-using CrestApps.Core.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -13,7 +13,7 @@ public sealed class DefaultAIDataSourceChangeNotifierTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var queue = new AIDataSourceIndexingQueue(NullLogger<AIDataSourceIndexingQueue>.Instance);
-        var catalog = new Mock<ICatalog<AIDataSource>>();
+        var catalog = new Mock<IAIDataSourceStore>();
         catalog.Setup(store => store.FindByIdAsync("ds-1", cancellationToken))
             .ReturnsAsync(new AIDataSource
             {
@@ -37,7 +37,7 @@ public sealed class DefaultAIDataSourceChangeNotifierTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var queue = new AIDataSourceIndexingQueue(NullLogger<AIDataSourceIndexingQueue>.Instance);
-        var catalog = new Mock<ICatalog<AIDataSource>>();
+        var catalog = new Mock<IAIDataSourceStore>();
         catalog.Setup(store => store.FindByIdAsync("missing", cancellationToken))
             .ReturnsAsync((AIDataSource)null);
 

--- a/tests/CrestApps.Core.Tests/Core/Services/IndexingServiceCollectionExtensionsTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/IndexingServiceCollectionExtensionsTests.cs
@@ -27,6 +27,7 @@ public sealed class IndexingServiceCollectionExtensionsTests
         Assert.Same(store, scopedServices.GetRequiredService<ICatalog<SearchIndexProfile>>());
         Assert.Same(store, scopedServices.GetRequiredService<INamedCatalog<SearchIndexProfile>>());
         Assert.IsType<SearchIndexProfileManager>(scopedServices.GetRequiredService<ISearchIndexProfileManager>());
+        Assert.IsType<SearchIndexProfileManager>(scopedServices.GetRequiredService<INamedCatalogManager<SearchIndexProfile>>());
         Assert.IsType<SearchIndexProfileProvisioningService>(scopedServices.GetRequiredService<ISearchIndexProfileProvisioningService>());
     }
 

--- a/tests/CrestApps.Core.Tests/Core/Services/SearchProviderClientFactoryTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/SearchProviderClientFactoryTests.cs
@@ -1,18 +1,17 @@
+using System.Text;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
+using CrestApps.Core.AI.Models;
 using CrestApps.Core.Azure.AISearch;
 using CrestApps.Core.Azure.AISearch.Services;
 using CrestApps.Core.Elasticsearch;
-using CrestApps.Core.AI.Models;
 using CrestApps.Core.Elasticsearch.Services;
 using Elastic.Transport;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using System.Net.Http;
-using System.Text;
 
 namespace CrestApps.Core.Tests.Core.Services;
 

--- a/tests/CrestApps.Core.Tests/EntityCoreStoreTests.cs
+++ b/tests/CrestApps.Core.Tests/EntityCoreStoreTests.cs
@@ -213,7 +213,7 @@ public sealed class EntityCoreStoreTests
         await indexProfileStore.CreateAsync(indexProfile, cancellationToken);
         await committer.CommitAsync(cancellationToken);
         Assert.Equal(indexProfile.ItemId, (await indexProfileStore.FindByNameAsync("docs-index", cancellationToken))?.ItemId);
-        Assert.Single(await indexProfileStore.GetByTypeAsync("AIDocuments"));
+        Assert.Single(await indexProfileStore.GetByTypeAsync("AIDocuments", cancellationToken));
 
         var profile = new AIProfile
         {

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/ChatInteractionHubTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/ChatInteractionHubTests.cs
@@ -3,6 +3,7 @@ using CrestApps.Core.AI.Chat;
 using CrestApps.Core.AI.Chat.Handlers;
 using CrestApps.Core.AI.Chat.Hubs;
 using CrestApps.Core.AI.Chat.Services;
+using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Exceptions;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Profiles;
@@ -191,7 +192,7 @@ public sealed class ChatInteractionHubTests
             .Returns(new ValueTask<ChatInteraction>(interaction));
         managerMock.Setup(manager => manager.UpdateAsync(interaction, null))
             .Returns(ValueTask.CompletedTask);
-        var dataSourceCatalog = new Mock<ICatalog<AIDataSource>>();
+        var dataSourceCatalog = new Mock<IAIDataSourceStore>();
         dataSourceCatalog.Setup(catalog => catalog
             .FindByIdAsync("datasource-1"))
             .ReturnsAsync(new AIDataSource { ItemId = "datasource-1" });

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/IndexProfileTypeRulesTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/IndexProfileTypeRulesTests.cs
@@ -348,7 +348,7 @@ public sealed class IndexProfileTypeRulesTests
             return ValueTask.FromResult(string.Equals(id, _profile.ItemId, StringComparison.Ordinal) ? _profile : null);
         }
 
-        public ValueTask<SearchIndexProfile> FindByNameAsync(string name)
+        public ValueTask<SearchIndexProfile> FindByNameAsync(string name, CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult<SearchIndexProfile>(null);
         }
@@ -363,14 +363,14 @@ public sealed class IndexProfileTypeRulesTests
             return ValueTask.FromResult<IEnumerable<SearchIndexProfile>>([]);
         }
 
-        public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+        public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IReadOnlyCollection<SearchIndexProfile>>([]);
         }
 
-        public ValueTask<SearchIndexProfile> NewAsync(JsonNode data = null, CancellationToken cancellationToken = default)
+        public ValueTask<SearchIndexProfile> NewAsync(string name, JsonNode data = null, CancellationToken cancellationToken = default)
         {
-            return ValueTask.FromResult(new SearchIndexProfile());
+            return ValueTask.FromResult(new SearchIndexProfile { Name = name });
         }
 
         public ValueTask<PageResult<SearchIndexProfile>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/SearchIndexProfileProvisioningServiceTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/SearchIndexProfileProvisioningServiceTests.cs
@@ -156,7 +156,7 @@ public sealed class SearchIndexProfileProvisioningServiceTests
             return ValueTask.FromResult<SearchIndexProfile>(null);
         }
 
-        public ValueTask<SearchIndexProfile> FindByNameAsync(string name)
+        public ValueTask<SearchIndexProfile> FindByNameAsync(string name, CancellationToken cancellationToken = default)
         {
             return ValueTask.FromResult<SearchIndexProfile>(null);
         }
@@ -184,14 +184,14 @@ public sealed class SearchIndexProfileProvisioningServiceTests
             return ValueTask.FromResult<IEnumerable<SearchIndexProfile>>([]);
         }
 
-        public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type)
+        public Task<IReadOnlyCollection<SearchIndexProfile>> GetByTypeAsync(string type, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<IReadOnlyCollection<SearchIndexProfile>>([]);
         }
 
-        public ValueTask<SearchIndexProfile> NewAsync(JsonNode data = null, CancellationToken cancellationToken = default)
+        public ValueTask<SearchIndexProfile> NewAsync(string name, JsonNode data = null, CancellationToken cancellationToken = default)
         {
-            return ValueTask.FromResult(new SearchIndexProfile());
+            return ValueTask.FromResult(new SearchIndexProfile { Name = name });
         }
 
         public ValueTask<PageResult<SearchIndexProfile>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)


### PR DESCRIPTION
This pull request introduces significant changes to the catalog manager abstractions and their implementations, primarily to clarify responsibilities between read-only and mutable operations and to align interface inheritance with intended usage. The changes also update dependency injection registrations and method signatures to support cancellation tokens and improve consistency.

**Abstraction and Interface Refactoring:**

* The `INamedCatalogManager<T>`, `ISourceCatalogManager<T>`, and `INamedSourceCatalogManager<T>` interfaces now inherit from `IReadCatalogManager<T>` instead of `ICatalogManager<T>`, and have been expanded with explicit CRUD and validation methods, each supporting cancellation tokens. [[1]](diffhunk://#diff-0f7201eeb536e5d72268f6bcae48a8a5ed567bf6cc80f93bfb2c31e19b331588R1-R55) [[2]](diffhunk://#diff-ec04477e731d755f5d9004c94f477b3ee60038e76399db8a719748c6d91cb2edL10-R44) [[3]](diffhunk://#diff-1c8da0887e201c7613e693d1476575d7f00ee144b38739e3c48a2d4e30e7e694R1-R80)
* `ISearchIndexProfileManager` now inherits from `INamedCatalogManager<SearchIndexProfile>` instead of `ICatalogManager<SearchIndexProfile>`, and its methods have been updated to support cancellation tokens.
* `ISearchIndexProfileStore`'s `GetByTypeAsync` method now accepts a cancellation token.

**Implementation and Dependency Injection Updates:**

* `SearchIndexProfileManager` now derives from `NamedCatalogManager<SearchIndexProfile>`, and its methods are updated for cancellation token support and to delegate name-based lookups to the base class. [[1]](diffhunk://#diff-d183c6fcf40f52e339096842725733e1d18c4471fd84310578cb42d7125861f0L11-R11) [[2]](diffhunk://#diff-d183c6fcf40f52e339096842725733e1d18c4471fd84310578cb42d7125861f0L40-R52)
* Service registration for `ICatalogManager<SearchIndexProfile>` is replaced by `INamedCatalogManager<SearchIndexProfile>` to match the new interface hierarchy.

**Codebase Consistency and Usage:**

* All usages of `ICatalog<AIDataSource>` in the AI data source handlers are replaced with `IAIDataSourceStore` for improved clarity and alignment with the new abstractions. [[1]](diffhunk://#diff-21230e163f121722b0113beb63d8c4c798bed95980f577008b1b52b21c2c240cL48-R48) [[2]](diffhunk://#diff-7f821a480fe9970e3cbb1cfe0c125a59a3d1a496628f43e4fa960fb4ac786d4bL71-R71) [[3]](diffhunk://#diff-7f821a480fe9970e3cbb1cfe0c125a59a3d1a496628f43e4fa960fb4ac786d4bL96-R96)
* `FindByNameAsync` and `GetByTypeAsync` methods across interfaces and implementations consistently support cancellation tokens. [[1]](diffhunk://#diff-4790fdc05c3d887424c875c0a097a147ee74f3f92b17cd9d82bc0f22fd3253efL52-R52) [[2]](diffhunk://#diff-7ca99baec93b5b72db20ef11649b0ba4494f0631f602ef779ef58e80d0b88d37L113-R113)

These changes collectively improve the clarity, flexibility, and testability of the catalog management infrastructure by separating read and write responsibilities, standardizing async operations, and ensuring all relevant methods support cancellation.