### PR TITLE
Protect Algolia documentation API keys

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/1.1.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/1.1.0.md
@@ -75,5 +75,8 @@ page will be updated as changes land after 1.0.0.
   error result, and returns a stable, non-leaking failure message for other errors
 - updates the MVC and Blazor sample hosts to load `@crestapps/bootstrap-select` 1.2.3 for Bootstrap
   select styling
+- protects Algolia DocSearch API keys for documentation search tool instances before persisting them, keeps
+  existing keys when the edit form is saved with the key field blank, and unprotects the key only when the
+  Algolia source is materialized for a search
 - fixes post-session processing endlessly retrying and eventually failing when the AI returned a successful (HTTP 200) response that could not be parsed into structured task results. The no-tools structured output path now records a `Failed` result with a diagnostic message instead of silently returning no result, so these responses no longer exhaust all retry attempts. The unparseable-response case is now logged at `Warning` (including a preview of the raw AI response) instead of only at `Debug`, and the recorded task error message now explains that the AI produced no parseable result or there was no content to evaluate.
 - avoids issuing a post-session AI request when there is no meaningful user content to evaluate. Sessions whose user prompts are empty, whitespace-only, or system-generated are skipped, so a real AI call is only made when there is something to analyze.

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/AlgoliaDocumentationToolSettings.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/AlgoliaDocumentationToolSettings.cs
@@ -3,8 +3,7 @@ namespace CrestApps.Core.AI.Tooling.Instances.Documentation;
 /// <summary>
 /// The user-provided settings for an Algolia DocSearch documentation search tool instance. The settings
 /// are persisted in the owning <see cref="CrestApps.Core.AI.Tooling.AIToolInstance.Properties"/> and bind
-/// the produced function to a single Algolia index. Only the search-only API key should be supplied here,
-/// as it is safe to expose to clients.
+/// the produced function to a single Algolia index.
 /// </summary>
 public sealed class AlgoliaDocumentationToolSettings
 {
@@ -14,7 +13,7 @@ public sealed class AlgoliaDocumentationToolSettings
     public string ApplicationId { get; set; }
 
     /// <summary>
-    /// Gets or sets the Algolia search-only API key.
+    /// Gets or sets the protected Algolia search-only API key.
     /// </summary>
     public string ApiKey { get; set; }
 

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/AlgoliaDocumentationToolSource.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/AlgoliaDocumentationToolSource.cs
@@ -1,4 +1,6 @@
+using CrestApps.Core;
 using CrestApps.Core.AI.Tooling;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -38,7 +40,7 @@ public sealed class AlgoliaDocumentationToolSource : IAIToolInstanceSource
                     ? functionName
                     : instance.Name,
                 ApplicationId = settings.ApplicationId,
-                ApiKey = settings.ApiKey,
+                ApiKey = UnprotectApiKey(settings.ApiKey, instance, services),
                 IndexName = settings.IndexName,
                 MaxResults = settings.MaxResults,
             };
@@ -50,5 +52,31 @@ public sealed class AlgoliaDocumentationToolSource : IAIToolInstanceSource
 
             return new AlgoliaDocumentationSource(site, options, httpClientFactory, logger);
         });
+    }
+
+    private static string UnprotectApiKey(string apiKey, AIToolInstance instance, IServiceProvider services)
+    {
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            return apiKey;
+        }
+
+        var protector = services.GetService<IDataProtectionProvider>()
+            ?.CreateProtector(DocumentationToolConstants.AlgoliaDataProtectionPurpose);
+
+        if (protector is null)
+        {
+            return apiKey;
+        }
+
+        var logger = services.GetService<ILoggerFactory>()?.CreateLogger<AlgoliaDocumentationToolSource>()
+            ?? NullLogger<AlgoliaDocumentationToolSource>.Instance;
+
+        return DataProtectionHelper.Unprotect(
+            protector,
+            apiKey,
+            logger,
+            "Failed to unprotect Algolia documentation API key for tool instance '{ToolInstanceId}'.",
+            instance.ItemId);
     }
 }

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/DocumentationToolConstants.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/DocumentationToolConstants.cs
@@ -25,6 +25,11 @@ public static class DocumentationToolConstants
     public const string AlgoliaSourceName = "algolia-documentation";
 
     /// <summary>
+    /// The data-protection purpose used to protect and unprotect stored Algolia DocSearch credentials.
+    /// </summary>
+    public const string AlgoliaDataProtectionPurpose = "CrestApps.Core.AI.Tooling.AlgoliaDocumentation";
+
+    /// <summary>
     /// The category applied to the documentation search sources so they are grouped as knowledge-base tools.
     /// </summary>
     public const string Category = "Knowledgebase";

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text.Json;
 using CrestApps.Core.AI;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
@@ -86,7 +87,7 @@ public sealed class AIToolInstanceController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Create(AIToolInstanceViewModel model)
     {
-        await ValidateAsync(model, false);
+        await ValidateAsync(model, false, null);
 
         if (!ModelState.IsValid)
         {
@@ -142,7 +143,7 @@ public sealed class AIToolInstanceController : Controller
 
         model.Source = instance.Source;
 
-        await ValidateAsync(model, true);
+        await ValidateAsync(model, true, instance);
 
         if (!ModelState.IsValid)
         {
@@ -190,7 +191,7 @@ public sealed class AIToolInstanceController : Controller
             .ToList();
     }
 
-    private async Task ValidateAsync(AIToolInstanceViewModel model, bool isEditing)
+    private async Task ValidateAsync(AIToolInstanceViewModel model, bool isEditing, AIToolInstance existingInstance)
     {
         if (string.IsNullOrWhiteSpace(model.Source))
         {
@@ -231,7 +232,7 @@ public sealed class AIToolInstanceController : Controller
 
         if (string.Equals(model.Source, DocumentationToolConstants.AlgoliaSourceName, StringComparison.OrdinalIgnoreCase))
         {
-            ValidateAlgolia(model);
+            ValidateAlgolia(model, isEditing, existingInstance);
 
             return;
         }
@@ -362,14 +363,18 @@ public sealed class AIToolInstanceController : Controller
         ValidateAbsoluteUrl(model.SearchIndexUrl, nameof(model.SearchIndexUrl), "Search index URL", required: false);
     }
 
-    private void ValidateAlgolia(AIToolInstanceViewModel model)
+    private void ValidateAlgolia(AIToolInstanceViewModel model, bool isEditing, AIToolInstance existingInstance)
     {
+        model.HasAlgoliaApiKey = isEditing &&
+            existingInstance?.TryGet<AlgoliaDocumentationToolSettings>(out var settings) == true &&
+            !string.IsNullOrEmpty(settings.ApiKey);
+
         if (string.IsNullOrWhiteSpace(model.AlgoliaApplicationId))
         {
             ModelState.AddModelError(nameof(model.AlgoliaApplicationId), "Application ID is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(model.AlgoliaApiKey))
+        if (!model.HasAlgoliaApiKey && string.IsNullOrWhiteSpace(model.AlgoliaApiKey))
         {
             ModelState.AddModelError(nameof(model.AlgoliaApiKey), "Search-only API key is required.");
         }
@@ -435,10 +440,13 @@ public sealed class AIToolInstanceController : Controller
 
         if (string.Equals(model.Source, DocumentationToolConstants.AlgoliaSourceName, StringComparison.OrdinalIgnoreCase))
         {
+            var algoliaProtector = _dataProtectionProvider.CreateProtector(DocumentationToolConstants.AlgoliaDataProtectionPurpose);
+            var existingAlgoliaSettings = instance.GetOrCreate<AlgoliaDocumentationToolSettings>();
+
             instance.Put(new AlgoliaDocumentationToolSettings
             {
                 ApplicationId = model.AlgoliaApplicationId?.Trim(),
-                ApiKey = model.AlgoliaApiKey?.Trim(),
+                ApiKey = ProtectOrReuseProtected(model.AlgoliaApiKey?.Trim(), existingAlgoliaSettings.ApiKey, algoliaProtector),
                 IndexName = model.AlgoliaIndexName?.Trim(),
                 MaxResults = model.AlgoliaMaxResults,
             });
@@ -494,6 +502,30 @@ public sealed class AIToolInstanceController : Controller
         return string.IsNullOrWhiteSpace(newValue) ? existingValue : protector.Protect(newValue);
     }
 
+    private static string ProtectOrReuseProtected(string newValue, string existingValue, IDataProtector protector)
+    {
+        if (!string.IsNullOrWhiteSpace(newValue))
+        {
+            return protector.Protect(newValue);
+        }
+
+        if (string.IsNullOrWhiteSpace(existingValue))
+        {
+            return existingValue;
+        }
+
+        try
+        {
+            protector.Unprotect(existingValue);
+
+            return existingValue;
+        }
+        catch (CryptographicException)
+        {
+            return protector.Protect(existingValue);
+        }
+    }
+
     private static AIToolInstanceViewModel ToViewModel(AIToolInstance instance)
     {
         var model = new AIToolInstanceViewModel
@@ -546,7 +578,7 @@ public sealed class AIToolInstanceController : Controller
         if (instance.TryGet<AlgoliaDocumentationToolSettings>(out var algoliaSettings))
         {
             model.AlgoliaApplicationId = algoliaSettings.ApplicationId;
-            model.AlgoliaApiKey = algoliaSettings.ApiKey;
+            model.HasAlgoliaApiKey = !string.IsNullOrEmpty(algoliaSettings.ApiKey);
             model.AlgoliaIndexName = algoliaSettings.IndexName;
             model.AlgoliaMaxResults = algoliaSettings.MaxResults;
         }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
@@ -186,10 +186,14 @@ public sealed class AIToolInstanceViewModel
     public string AlgoliaApplicationId { get; set; }
 
     /// <summary>
-    /// Gets or sets the Algolia search-only API key for the Algolia DocSearch source. This is a public,
-    /// client-safe key and is stored without additional protection.
+    /// Gets or sets the Algolia search-only API key for the Algolia DocSearch source.
     /// </summary>
     public string AlgoliaApiKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a protected Algolia search-only API key is already stored.
+    /// </summary>
+    public bool HasAlgoliaApiKey { get; set; }
 
     /// <summary>
     /// Gets or sets the Algolia index name to query for the Algolia DocSearch source.

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
@@ -245,9 +245,13 @@
                 </div>
                 <div class="mb-3">
                     <label asp-for="AlgoliaApiKey" class="form-label">Search-only API key <span class="text-danger">*</span></label>
-                    <input asp-for="AlgoliaApiKey" class="form-control" />
+                    <input asp-for="AlgoliaApiKey" class="form-control" type="password" autocomplete="new-password" />
+                    @if (Model.HasAlgoliaApiKey)
+                    {
+                        <div class="form-text">Leave blank to keep the existing API key.</div>
+                    }
                     <span asp-validation-for="AlgoliaApiKey" class="text-danger"></span>
-                    <div class="form-text">Use the public, search-only key. It is safe to expose to clients and is stored without additional protection.</div>
+                    <div class="form-text">Use the search-only key. The value is protected before it is stored.</div>
                 </div>
                 <div class="mb-3">
                     <label asp-for="AlgoliaIndexName" class="form-label">Index name <span class="text-danger">*</span></label>

--- a/tests/CrestApps.Core.Tests/Core/Tools/DocumentationSearchTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Tools/DocumentationSearchTests.cs
@@ -1,5 +1,9 @@
-using CrestApps.Core.AI.Tooling.Instances.Documentation;
+using System.Net;
+using System.Text;
 using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Tooling.Instances.Documentation;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -85,6 +89,52 @@ public sealed class DocumentationSearchTests
         var tool = source.CreateTool(instance);
 
         Assert.IsType<DocumentationSearchToolFunction>(tool);
+    }
+
+    /// <summary>
+    /// Verifies that the Algolia source unprotects the stored API key before issuing a search request.
+    /// </summary>
+    [Fact]
+    public async Task AlgoliaSource_InvokeAsync_UnprotectsStoredApiKey()
+    {
+        var dataProtectionProvider = new EphemeralDataProtectionProvider();
+        var protector = dataProtectionProvider.CreateProtector(DocumentationToolConstants.AlgoliaDataProtectionPurpose);
+        var httpClientFactory = new CapturingHttpClientFactory();
+        var instance = new AIToolInstance
+        {
+            ItemId = "instance-4",
+            Source = DocumentationToolConstants.AlgoliaSourceName,
+            Name = "algolia",
+            CreatedUtc = DateTime.UnixEpoch,
+        };
+
+        instance.Put(new AlgoliaDocumentationToolSettings
+        {
+            ApplicationId = "APP123",
+            ApiKey = protector.Protect("search-key"),
+            IndexName = "docs-index",
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IDataProtectionProvider>(dataProtectionProvider);
+        services.AddSingleton<IDocumentationSourceMaterializer, DefaultDocumentationSourceMaterializer>();
+        services.AddSingleton<IHttpClientFactory>(httpClientFactory);
+
+        using var provider = services.BuildServiceProvider();
+
+        var source = new AlgoliaDocumentationToolSource();
+        var function = Assert.IsType<DocumentationSearchToolFunction>(source.CreateTool(instance));
+        var arguments = new AIFunctionArguments
+        {
+            Services = provider,
+        };
+        arguments["query"] = "start";
+
+        var result = await function.InvokeAsync(arguments, TestContext.Current.CancellationToken);
+
+        Assert.Contains("Getting started", result?.ToString());
+        Assert.Equal("search-key", httpClientFactory.ApiKey);
     }
 
     /// <summary>
@@ -216,6 +266,56 @@ public sealed class DocumentationSearchTests
         public Task<IReadOnlyList<DocumentationSearchResult>> SearchAsync(DocumentationSearchRequest request, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<DocumentationSearchResult>>(_results);
+        }
+    }
+
+    private sealed class CapturingHttpClientFactory : IHttpClientFactory
+    {
+        private const string _responsePayload =
+            """
+            {
+              "hits": [
+                {
+                  "url": "https://docs.example.com/start",
+                  "content": "Start here.",
+                  "hierarchy": {
+                    "lvl0": "Getting started"
+                  }
+                }
+              ]
+            }
+            """;
+
+        public string ApiKey { get; private set; }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(new CapturingHandler(this), disposeHandler: true);
+        }
+
+        private sealed class CapturingHandler : HttpMessageHandler
+        {
+            private readonly CapturingHttpClientFactory _factory;
+
+            public CapturingHandler(CapturingHttpClientFactory factory)
+            {
+                _factory = factory;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Headers.TryGetValues("X-Algolia-API-Key", out var values))
+                {
+                    _factory.ApiKey = values.SingleOrDefault();
+                }
+
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responsePayload, Encoding.UTF8, "application/json"),
+                };
+
+                return Task.FromResult(response);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- protect Algolia documentation tool API keys before storing them
- keep existing Algolia keys when edit forms are saved blank and unprotect keys at use time
- add regression coverage and changelog entry

## Validation
- dotnet test ./tests/CrestApps.Core.Tests/CrestApps.Core.Tests.csproj -c Release /p:NuGetAudit=false /p:CopilotSkipCliDownload=true --filter DocumentationSearchTests
- npm run build --prefix ./src/CrestApps.Core.Docs