### PR TITLE
Expose only selectable tools over MCP server

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/1.1.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/1.1.0.md
@@ -34,7 +34,9 @@ page will be updated as changes land after 1.0.0.
 - reworks tool exposure into an opt-in allow-list driven by the `McpServerOptions` site settings. Nothing
   is exposed by default: an MCP server lists and invokes only the tools and configured
   [tool instances](../core/tool-instances.md) named in `McpServerOptions.Tools`, or every tool
-  and instance when `McpServerOptions.ExposeAllTools` is `true`. The allow-list is enforced by both the
+  and instance when `McpServerOptions.ExposeAllTools` is `true`. Only selectable tools participate: system
+  tools (marked `IsSystemTool`) and hidden tools are never exposed, even when `ExposeAllTools` is `true`.
+  The allow-list is enforced by both the
   list and call handlers, so a tool that is not exposed can neither be discovered nor invoked. Because
   `McpServerOptions` is backed by site settings, operators choose which tools to expose from the admin
   settings UI without redeploying. The MVC and Blazor sample hosts add an "Exposed tools" editor to their
@@ -65,6 +67,9 @@ page will be updated as changes land after 1.0.0.
 
 ## Fixes
 
+- stops the MCP server from exposing system tools. `WithCrestAppsHandlers()` now lists and invokes only
+  selectable tools, so tools marked `IsSystemTool` (which agents auto-include based on context) are never
+  discoverable or callable over MCP, even when `McpServerOptions.ExposeAllTools` is `true`
 - makes the MCP tool allow-list respond to site-settings changes at runtime. The list and call handlers
   now read `McpServerOptions` through `IOptionsMonitor` instead of the cached `IOptions`, so exposing or
   removing a tool from the admin settings page takes effect without restarting the host

--- a/src/CrestApps.Core.Docs/docs/mcp/server.md
+++ b/src/CrestApps.Core.Docs/docs/mcp/server.md
@@ -316,7 +316,9 @@ services.Configure<McpServerOptions>(options =>
 | Property | Effect |
 |----------|--------|
 | `Tools` | An allow-list of tool and tool instance names to expose. Matching is case-insensitive. |
-| `ExposeAllTools` | When `true`, every tool and tool instance is exposed and the allow-list is ignored. |
+| `ExposeAllTools` | When `true`, every **selectable** tool and tool instance is exposed and the allow-list is ignored. |
+
+Only selectable tools are ever exposed over MCP. System tools (those marked `IsSystemTool`, which agents auto-include based on context) and hidden tools are never listed or callable — not even when `ExposeAllTools` is `true`.
 
 Because `McpServerOptions` is backed by site settings, an operator can choose which tools to expose from the admin **Settings → MCP server** page without redeploying. The allow-list is enforced by **both** the list and call handlers, so a tool that is not exposed can neither be discovered nor invoked.
 

--- a/src/Primitives/CrestApps.Core.AI.Mcp/McpServerBuilderExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Mcp/McpServerBuilderExtensions.cs
@@ -22,8 +22,10 @@ public static class McpServerBuilderExtensions
     /// This wires the CrestApps tool registry (<see cref="AIToolDefinitionOptions"/>),
     /// <see cref="IMcpServerPromptService"/>, and <see cref="IMcpServerResourceService"/>
     /// into the MCP protocol so both Orchard Core and standalone MVC hosts share the same handler logic.
-    /// Which tools and tool instances are actually listed and callable is controlled by the
-    /// <see cref="McpServerOptions"/> site settings allow-list.
+    /// Only selectable tools (those that are neither system tools nor hidden) are ever exposed, so
+    /// system tools that the orchestrator auto-includes are never listed or callable over MCP.
+    /// Which of those selectable tools and tool instances are actually listed and callable is further
+    /// controlled by the <see cref="McpServerOptions"/> site settings allow-list.
     /// </summary>
     /// <param name="builder">The builder.</param>
     public static IMcpServerBuilder WithCrestAppsHandlers(this IMcpServerBuilder builder)
@@ -43,7 +45,7 @@ public static class McpServerBuilderExtensions
 
                 foreach (var (name, definition) in toolDefinitions.Tools)
                 {
-                    if (definition.Hidden || !IsAllowed(exposeAll, allowList, name, definition.Name))
+                    if (!definition.IsSelectable() || !IsAllowed(exposeAll, allowList, name, definition.Name))
                     {
                         continue;
                     }
@@ -248,7 +250,7 @@ public static class McpServerBuilderExtensions
         ILogger logger)
     {
         if (toolDefinitions.Tools.TryGetValue(protocolName, out var direct) &&
-            !direct.Hidden &&
+            direct.IsSelectable() &&
             IsAllowed(exposeAll, allowList, protocolName, direct.Name) &&
             TryCreateFunction(services, protocolName, logger) is { } directFunction &&
             string.Equals(directFunction.Name, protocolName, StringComparison.Ordinal))
@@ -258,7 +260,7 @@ public static class McpServerBuilderExtensions
 
         foreach (var (name, definition) in toolDefinitions.Tools)
         {
-            if (definition.Hidden || !IsAllowed(exposeAll, allowList, name, definition.Name))
+            if (!definition.IsSelectable() || !IsAllowed(exposeAll, allowList, name, definition.Name))
             {
                 continue;
             }

--- a/tests/CrestApps.Core.Tests/Core/Mcp/McpServerBuilderExtensionsTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Mcp/McpServerBuilderExtensionsTests.cs
@@ -39,7 +39,8 @@ public sealed class McpServerBuilderExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that enabling <c>ExposeAllTools</c> lists every non-hidden tool while hidden tools are omitted.
+    /// Verifies that enabling <c>ExposeAllTools</c> lists every selectable tool while hidden and system
+    /// tools are omitted, because system tools are auto-included by agents and must not be exposed over MCP.
     /// </summary>
     [Fact]
     public async Task ListToolsHandler_ExposeAllTools_ReturnsVisibleToolsAndOmitsHidden()
@@ -48,6 +49,7 @@ public sealed class McpServerBuilderExtensionsTests
 
         AddLocalTool(services, "search-key", new TestAIFunction("search"));
         AddLocalTool(services, "hidden-key", new TestAIFunction("hidden"), hidden: true);
+        AddLocalTool(services, "system-key", new TestAIFunction("system"), isSystemTool: true);
         AddLocalTool(services, "create-key", new TestAIFunction("create"));
 
         using var serviceProvider = services.BuildServiceProvider();
@@ -349,6 +351,26 @@ public sealed class McpServerBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that a system tool cannot be invoked through the call handler even when
+    /// <c>ExposeAllTools</c> is enabled, because system tools are never exposed over MCP.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_ExposeAll_RejectsSystemTool()
+    {
+        var services = CreateServices(configureOptions: options => options.ExposeAllTools = true);
+
+        AddLocalTool(services, "system", new TestAIFunction("system"), isSystemTool: true);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await InvokeCallToolHandlerAsync(
+                serviceProvider,
+                "system",
+                TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
     /// Creates the MCP service collection and registers the CrestApps handlers.
     /// </summary>
     /// <param name="configureOptions">An optional delegate that configures the exposure settings.</param>
@@ -404,13 +426,15 @@ public sealed class McpServerBuilderExtensionsTests
     /// <param name="registrationName">The keyed registration name.</param>
     /// <param name="tool">The local AI function.</param>
     /// <param name="hidden">Whether the tool is hidden.</param>
+    /// <param name="isSystemTool">Whether the tool is a system tool.</param>
     private static void AddLocalTool(
         IServiceCollection services,
         string registrationName,
         AIFunction tool,
-        bool hidden = false)
+        bool hidden = false,
+        bool isSystemTool = false)
     {
-        AddLocalToolDefinition(services, registrationName, hidden);
+        AddLocalToolDefinition(services, registrationName, hidden, isSystemTool);
         services.AddKeyedSingleton<AITool>(registrationName, tool);
     }
 
@@ -420,10 +444,12 @@ public sealed class McpServerBuilderExtensionsTests
     /// <param name="services">The service collection.</param>
     /// <param name="registrationName">The keyed registration name.</param>
     /// <param name="hidden">Whether the tool is hidden.</param>
+    /// <param name="isSystemTool">Whether the tool is a system tool.</param>
     private static void AddLocalToolDefinition(
         IServiceCollection services,
         string registrationName,
-        bool hidden = false)
+        bool hidden = false,
+        bool isSystemTool = false)
     {
         services.Configure<AIToolDefinitionOptions>(options =>
         {
@@ -432,6 +458,7 @@ public sealed class McpServerBuilderExtensionsTests
                 new AIToolDefinitionEntry(typeof(TestAIFunction))
                 {
                     Hidden = hidden,
+                    IsSystemTool = isSystemTool,
                 });
         });
     }


### PR DESCRIPTION
## Summary

The MCP server list and call handlers (`WithCrestAppsHandlers()`) exposed every non-hidden tool, including **system tools** that agents auto-include based on context. Both handlers now gate on `AIToolDefinitionEntry.IsSelectable()` (`!IsSystemTool && !Hidden`), so system and hidden tools are never listed or callable over MCP — even when `ExposeAllTools` is `true`. Tool instances are unchanged (user-created, always selectable).

This restores the intended behavior: `release/1.0` filtered only `!Hidden`, so it also leaked non-hidden system tools; this fix applies the framework's existing selectable-tool concept to MCP.

## Changes
- Filter list handler and call handler (`ResolveAllowedCodeTool`) to selectable tools only
- Tests: system tool omitted from `ExposeAllTools` listing; system tool rejected by call handler
- Docs: `mcp/server.md` exposure section + `changelog/1.1.0.md` Fixes entry

## Validation
- All 2573 unit tests pass
- Docs site builds successfully

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>