### PR TITLE
Release 1.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <!-- VersionSuffixBase is the label passed in from the command line (e.g. "preview").
          VersionSuffix is assembled here so the build number is always appended when provided.
          Passing /p:VersionSuffix=... on the command line would create a global MSBuild property

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,9 +28,9 @@
     <PackageVersion Include="PdfPig" Version="0.1.15" />
     <PackageVersion Include="PDFsharp-MigraDoc" Version="6.2.4" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
-    <PackageVersion Include="YesSql.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="YesSql.Core" Version="6.0.0" />
-    <PackageVersion Include="YesSql.Provider.Sqlite" Version="6.0.0" />
+    <PackageVersion Include="YesSql.Abstractions" Version="5.4.7" />
+    <PackageVersion Include="YesSql.Core" Version="5.4.7" />
+    <PackageVersion Include="YesSql.Provider.Sqlite" Version="5.4.7" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/CrestApps.Core.Docs/docs/changelog/1.2.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/1.2.0.md
@@ -2,25 +2,18 @@
 sidebar_label: 1.2.0 Release Notes
 sidebar_position: 4
 title: "Version 1.2.0 Release Notes"
-description: Release notes for the upcoming CrestApps.Core 1.2.0 release.
+description: Release notes for the CrestApps.Core 1.2.0 release.
 ---
 
 # Version 1.2.0 Release Notes
 
 **Package version**: `1.2.0`
 
-:::info
-`CrestApps.Core` 1.2.0 is not yet released and is currently in development. Nightly
-and preview builds are published from `main` under the `1.2.0` version prefix. This
-page will be updated as changes land after 1.1.0.
-:::
-
-## Breaking Changes
-
-- None yet.
+**Release date**: 2026-08-13
 
 ## Change Logs
 
+- Downgraded YesSql to 5.4.7 to unblock the release of CrestApps.OrchardCore 2.1.
 - upgrades SSH.NET to 2026.0.0 to address the high-severity
   [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284)
   advisory reported by NuGet audit

--- a/src/CrestApps.Core.Docs/docs/changelog/1.3.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/1.3.0.md
@@ -1,0 +1,23 @@
+---
+sidebar_label: 1.3.0 Release Notes
+sidebar_position: 5
+title: "Version 1.3.0 Release Notes"
+description: Release notes for the upcoming CrestApps.Core 1.3.0 release.
+---
+
+# Version 1.3.0 Release Notes
+
+**Package version**: `1.3.0`
+
+:::info
+`CrestApps.Core` 1.3.0 is not yet released and is currently in development. Nightly
+and preview builds are published from `main` under the `1.3.0` version prefix.
+:::
+
+## Breaking Changes
+
+- None yet.
+
+## Change Logs
+
+- None yet.

--- a/src/CrestApps.Core.Docs/docs/changelog/index.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/index.md
@@ -11,6 +11,7 @@ This section tracks `CrestApps.Core` releases and notable repository-level chang
 
 | Version | Highlights |
 | --- | --- |
-| [1.2.0](1.2.0) | Next release, currently in development (nightly and preview builds) |
+| [1.3.0](1.3.0) | Next release, currently in development (nightly and preview builds) |
+| [1.2.0](1.2.0) | Intermediate release just to downgrade YesSql to 5.4.7 to align with OrchardCore development. |
 | [1.1.0](1.1.0) | Released 2026-08-13 with opt-in MCP server tool exposure, documentation search tool instances, and MCP/server fixes |
 | [1.0.0](1.0.0) | Initial standalone release plus merged configuration catalogs, automatic AI tool dependency expansion, clearer quick-start guidance, and deployment configuration diagnostics |

--- a/src/CrestApps.Core.Docs/sidebars.js
+++ b/src/CrestApps.Core.Docs/sidebars.js
@@ -96,6 +96,7 @@ const sidebars = {
             label: 'Changelog',
             items: [
                 'changelog/index',
+                'changelog/1.3.0',
                 'changelog/1.2.0',
                 'changelog/1.1.0',
                 'changelog/1.0.0',

--- a/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
+++ b/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
@@ -11,6 +11,4 @@ This section tracks `CrestApps.Core` releases and notable repository-level chang
 
 | Version | Highlights |
 | --- | --- |
-| [1.2.0](/docs/changelog/1.2.0) | Intermediate release just to downgrade YesSql to 5.4.7 to align with OrchardCore development. |
-| [1.1.0](/docs/changelog/1.1.0) | MCP Server Behavior Improvement and bug fixes. |
 | [1.0.0](1.0.0) | Initial standalone release plus merged configuration catalogs, automatic AI tool dependency expansion, clearer quick-start guidance, and deployment configuration diagnostics |

--- a/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
+++ b/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
@@ -11,4 +11,6 @@ This section tracks `CrestApps.Core` releases and notable repository-level chang
 
 | Version | Highlights |
 | --- | --- |
+| [1.2.0](1.2.0) | Intermediate release just to downgrade YesSql to 5.4.7 to align with OrchardCore development. |
+| [1.1.0](1.1.0) | MCP Server Behavior Improvement and bug fixes. |
 | [1.0.0](1.0.0) | Initial standalone release plus merged configuration catalogs, automatic AI tool dependency expansion, clearer quick-start guidance, and deployment configuration diagnostics |

--- a/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
+++ b/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
@@ -11,6 +11,4 @@ This section tracks `CrestApps.Core` releases and notable repository-level chang
 
 | Version | Highlights |
 | --- | --- |
-| [1.2.0](1.2.0) | Intermediate release just to downgrade YesSql to 5.4.7 to align with OrchardCore development. |
-| [1.1.0](1.1.0) | MCP Server Behavior Improvement and bug fixes. |
 | [1.0.0](1.0.0) | Initial standalone release plus merged configuration catalogs, automatic AI tool dependency expansion, clearer quick-start guidance, and deployment configuration diagnostics |

--- a/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
+++ b/src/CrestApps.Core.Docs/versioned_docs/version-1.0/changelog/index.md
@@ -11,4 +11,6 @@ This section tracks `CrestApps.Core` releases and notable repository-level chang
 
 | Version | Highlights |
 | --- | --- |
+| [1.2.0](/docs/changelog/1.2.0) | Intermediate release just to downgrade YesSql to 5.4.7 to align with OrchardCore development. |
+| [1.1.0](/docs/changelog/1.1.0) | MCP Server Behavior Improvement and bug fixes. |
 | [1.0.0](1.0.0) | Initial standalone release plus merged configuration catalogs, automatic AI tool dependency expansion, clearer quick-start guidance, and deployment configuration diagnostics |

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/YesSqlAIChatSessionManagerTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/YesSqlAIChatSessionManagerTests.cs
@@ -214,7 +214,11 @@ public sealed class YesSqlAIChatSessionManagerTests
             .Setup(sessionQuery => sessionQuery.FirstOrDefaultAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync((AIChatSession)null!);
         sessionStore
-            .Setup(session => session.SaveAsync(It.IsAny<AIChatSession>(), It.IsAny<bool>(), It.IsAny<string>()))
+            .Setup(session => session.SaveAsync(
+                It.IsAny<AIChatSession>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         var sessionManager = new YesSqlAIChatSessionManager(
@@ -234,7 +238,11 @@ public sealed class YesSqlAIChatSessionManagerTests
         await sessionManager.SaveAsync(chatSession, TestContext.Current.CancellationToken);
 
         Assert.Equal(now, chatSession.LastActivityUtc);
-        sessionStore.Verify(session => session.SaveAsync(chatSession, false, "AI"), Times.Once);
+        sessionStore.Verify(session => session.SaveAsync(
+            chatSession,
+            false,
+            "AI",
+            CancellationToken.None), Times.Once);
         sessionStore.Verify(session => session.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 


### PR DESCRIPTION
This release only downgrade YesSql to 5.4.7. Version 1.2 should be used when possible as it depends on the future YesSql 6.0.0