### PR TITLE
Fix post-close cycle re-marking and re-logging terminally failed session

### DIFF
--- a/src/Primitives/CrestApps.Core.AI.Chat/Services/AIChatSessionCloseCycleService.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Services/AIChatSessionCloseCycleService.cs
@@ -150,7 +150,14 @@ public sealed class AIChatSessionCloseCycleService
 
                 if (session.PostSessionProcessingAttempts >= postCloseProcessor.MaxPostCloseAttempts)
                 {
-                    workItems.Add(new SessionWorkItem(profile.ItemId, session.SessionId, SessionWorkType.MarkFailed));
+                    // The attempt budget is exhausted. Terminally fail the session, but
+                    // transition it only once: a session that is no longer pending has
+                    // already been finalized (or completed) and must not be re-queued and
+                    // re-logged on every subsequent cycle.
+                    if (session.PostSessionProcessingStatus == PostSessionProcessingStatus.Pending)
+                    {
+                        workItems.Add(new SessionWorkItem(profile.ItemId, session.SessionId, SessionWorkType.MarkFailed));
+                    }
 
                     continue;
                 }
@@ -211,14 +218,21 @@ public sealed class AIChatSessionCloseCycleService
                 break;
 
             case SessionWorkType.MarkFailed:
-                chatSession.PostSessionProcessingStatus = PostSessionProcessingStatus.Failed;
-                await sessionStore.SaveAsync(chatSession, cancellationToken);
-                result.FailedCount = 1;
+                // Only finalize a session that is still pending. Guarding here keeps the
+                // transition idempotent, so an already-failed (or completed) session is
+                // never re-saved or re-logged if it is ever re-queued.
+                if (chatSession.PostSessionProcessingStatus == PostSessionProcessingStatus.Pending)
+                {
+                    chatSession.PostSessionProcessingStatus = PostSessionProcessingStatus.Failed;
+                    await sessionStore.SaveAsync(chatSession, cancellationToken);
+                    result.FailedCount = 1;
 
-                _logger.LogWarning(
-                    "Post-session processing for session '{SessionId}' failed after {MaxAttempts} attempts.",
-                    chatSession.SessionId,
-                    postCloseProcessor.MaxPostCloseAttempts);
+                    _logger.LogWarning(
+                        "Post-session processing for session '{SessionId}' failed after {MaxAttempts} attempts.",
+                        chatSession.SessionId,
+                        postCloseProcessor.MaxPostCloseAttempts);
+                }
+
                 break;
         }
 

--- a/src/Primitives/CrestApps.Core.AI.Chat/Services/AIChatSessionPostCloseProcessor.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Services/AIChatSessionPostCloseProcessor.cs
@@ -59,6 +59,18 @@ public sealed class AIChatSessionPostCloseProcessor
         ArgumentNullException.ThrowIfNull(profile);
         ArgumentNullException.ThrowIfNull(chatSession);
 
+        // A session that has already exhausted its post-close attempt budget and been
+        // marked terminally failed must never be reprocessed. Without this guard the
+        // close cycle keeps rediscovering such sessions on every pass (for example
+        // because analytics or conversion goals were never recorded), re-marking them
+        // failed and re-logging the failure indefinitely - even months after the
+        // session was processed.
+        if (chatSession.PostSessionProcessingStatus == PostSessionProcessingStatus.Failed
+            && chatSession.PostSessionProcessingAttempts >= MaxPostCloseAttempts)
+        {
+            return false;
+        }
+
         var postSessionSettings = profile.GetOrCreateSettings<AIProfilePostSessionSettings>();
         var tasksComplete = ArePostSessionTasksComplete(postSessionSettings, chatSession, MaxPostCloseAttempts);
         chatSession.IsPostSessionTasksProcessed = tasksComplete;

--- a/tests/CrestApps.Core.Tests/Core/Services/PostSession/AIChatSessionPostCloseProcessorTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/PostSession/AIChatSessionPostCloseProcessorTests.cs
@@ -1,3 +1,4 @@
+using CrestApps.Core;
 using CrestApps.Core.AI.Chat.Models;
 using CrestApps.Core.AI.Chat.Services;
 using CrestApps.Core.AI.Clients;
@@ -94,6 +95,68 @@ public sealed class AIChatSessionPostCloseProcessorTests
         Assert.True(queued);
         Assert.False(session.IsPostSessionTasksProcessed);
         Assert.Equal(PostSessionProcessingStatus.Pending, session.PostSessionProcessingStatus);
+    }
+
+    [Fact]
+    public void NeedsProcessing_WhenTerminallyFailedAtAttemptCap_ReturnsFalse()
+    {
+        var processor = CreateProcessor(DateTime.UtcNow);
+
+        var profile = CreateTaskProfile();
+
+        // Analytics is enabled but was never recorded for this session. Without the
+        // terminal guard NeedsProcessing would keep reporting outstanding analytics work
+        // forever, causing the close cycle to re-mark and re-log the session every pass.
+        profile.Put(new AnalyticsMetadata
+        {
+            EnableSessionMetrics = true,
+        });
+
+        var session = new AIChatSession
+        {
+            SessionId = "session-terminal",
+            PostSessionProcessingStatus = PostSessionProcessingStatus.Failed,
+            PostSessionProcessingAttempts = processor.MaxPostCloseAttempts,
+            IsAnalyticsRecorded = false,
+            IsConversionGoalsEvaluated = false,
+            PostSessionResults =
+            {
+                ["summary"] = new PostSessionResult
+                {
+                    Name = "summary",
+                    Status = PostSessionTaskResultStatus.Failed,
+                    Attempts = processor.MaxPostCloseAttempts,
+                    ProcessedAtUtc = new DateTime(2026, 5, 21, 15, 5, 47, DateTimeKind.Utc),
+                },
+            },
+        };
+
+        Assert.False(processor.NeedsProcessing(profile, session));
+    }
+
+    [Fact]
+    public void NeedsProcessing_WhenFailedButAttemptBudgetRemains_ReturnsTrue()
+    {
+        var processor = CreateProcessor(DateTime.UtcNow);
+
+        var profile = CreateTaskProfile();
+        var session = new AIChatSession
+        {
+            SessionId = "session-legacy",
+            PostSessionProcessingStatus = PostSessionProcessingStatus.Failed,
+            PostSessionProcessingAttempts = 0,
+            PostSessionResults =
+            {
+                ["summary"] = new PostSessionResult
+                {
+                    Name = "summary",
+                    Status = PostSessionTaskResultStatus.Failed,
+                    Attempts = 3,
+                },
+            },
+        };
+
+        Assert.True(processor.NeedsProcessing(profile, session));
     }
 
     [Fact]


### PR DESCRIPTION
…ions

The close cycle rediscovers every closed session each pass and, when the post-session attempt budget is exhausted, re-queues a MarkFailed work item. Because NeedsProcessing still reported outstanding work for sessions whose analytics or conversion goals were never recorded, and MarkFailed was neither guarded nor idempotent, terminally failed sessions were re-marked failed and re-logged on every cycle indefinitely - producing fresh warnings for sessions that were actually processed months earlier.

- NeedsProcessing now short-circuits to false for a session that is already marked Failed and has reached the attempt cap, so it is never rediscovered.
- Discovery only enqueues MarkFailed for a session that is still Pending, avoiding both the re-queue loop and mislabeling a Completed session as Failed.
- The MarkFailed handler is now idempotent and only transitions a Pending session, so it never re-saves or re-logs an already-finalized session.

Adds tests covering the terminal-guard behavior and confirming legacy Failed sessions with remaining task attempts are still reprocessed.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
