### PR TITLE
Enforce tabular read-only queries at the SQLite engine level

### DIFF
--- a/src/Primitives/CrestApps.Core.AI.Documents/Tabular/TabularSqlGuard.cs
+++ b/src/Primitives/CrestApps.Core.AI.Documents/Tabular/TabularSqlGuard.cs
@@ -23,7 +23,28 @@ internal static partial class TabularSqlGuard
     /// <returns>The normalized single-statement SQL.</returns>
     public static string EnsureReadOnlyQuery(string sql)
     {
-        var statement = Normalize(sql);
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            throw new TabularSqlException("No SQL statement was provided.");
+        }
+
+        // Split using the quote- and comment-aware scanner so a semicolon inside a string literal or a
+        // comment is not mistaken for statement batching, and require exactly one statement.
+        var statements = SplitStatements(sql);
+
+        if (statements.Count == 0)
+        {
+            throw new TabularSqlException("No SQL statement was provided.");
+        }
+
+        if (statements.Count > 1)
+        {
+            throw new TabularSqlException("Only a single SQL statement is allowed per call.");
+        }
+
+        var statement = statements[0];
+
+        EnsureNoForbiddenKeyword(statement);
 
         if (!StartsWithAny(statement, _readOnlyPrefixes))
         {

--- a/src/Primitives/CrestApps.Core.AI.Documents/Tabular/TabularWorkspace.cs
+++ b/src/Primitives/CrestApps.Core.AI.Documents/Tabular/TabularWorkspace.cs
@@ -114,7 +114,18 @@ internal sealed class TabularWorkspace : IDisposable
                 LoadMetadataFromDatabase();
             }
 
-            await SynchronizeTablesAsync(documents, artifactLoader, workspaceImporter, cancellationToken);
+            // Building tables writes to the database, so open a write window for the duration of the
+            // synchronization and close it again afterward.
+            SetWritable(_connection, true);
+
+            try
+            {
+                await SynchronizeTablesAsync(documents, artifactLoader, workspaceImporter, cancellationToken);
+            }
+            finally
+            {
+                SetWritable(_connection, false);
+            }
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {
@@ -248,33 +259,44 @@ internal sealed class TabularWorkspace : IDisposable
         {
             EnsureLoaded();
 
-            var affected = 0;
-
-            using var transaction = _connection.BeginTransaction();
+            // Manipulation statements write, so open a write window for the batch and close it again
+            // once the transaction has committed or rolled back.
+            SetWritable(_connection, true);
 
             try
             {
-                foreach (var statement in statements)
-                {
-                    using var command = _connection.CreateCommand();
-                    command.Transaction = transaction;
-                    command.CommandText = statement;
-                    command.CommandTimeout = _options.CommandTimeoutSeconds;
+                var affected = 0;
 
-                    affected += await command.ExecuteNonQueryAsync(cancellationToken);
+                using var transaction = _connection.BeginTransaction();
+
+                try
+                {
+                    foreach (var statement in statements)
+                    {
+                        using var command = _connection.CreateCommand();
+                        command.Transaction = transaction;
+                        command.CommandText = statement;
+                        command.CommandTimeout = _options.CommandTimeoutSeconds;
+
+                        affected += await command.ExecuteNonQueryAsync(cancellationToken);
+                    }
+
+                    await transaction.CommitAsync(cancellationToken);
+                    Interlocked.Increment(ref _mutationVersion);
+                }
+                catch
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+
+                    throw;
                 }
 
-                await transaction.CommitAsync(cancellationToken);
-                Interlocked.Increment(ref _mutationVersion);
+                return new TabularCommandResult(affected, statements.Count);
             }
-            catch
+            finally
             {
-                await transaction.RollbackAsync(cancellationToken);
-
-                throw;
+                SetWritable(_connection, false);
             }
-
-            return new TabularCommandResult(affected, statements.Count);
         }
         finally
         {
@@ -526,6 +548,28 @@ internal sealed class TabularWorkspace : IDisposable
         }
     }
 
+    /// <summary>
+    /// Toggles SQLite's connection-level <c>query_only</c> flag. The workspace keeps the connection
+    /// read-only by default so the database engine itself rejects any write, and only the table-build
+    /// and manipulation paths open a narrow write window. This is defense in depth beyond the SQL text
+    /// validation in <see cref="TabularSqlGuard"/>: a write that slipped past the parser on a read path
+    /// still cannot modify data, because the engine refuses it. Every workspace operation runs under
+    /// <see cref="_gate"/>, so this flag is never observed by a concurrent operation.
+    /// </summary>
+    /// <param name="connection">The connection to toggle.</param>
+    /// <param name="writable">When <see langword="true"/>, writes are allowed; otherwise they are blocked.</param>
+    private static void SetWritable(SqliteConnection connection, bool writable)
+    {
+        if (connection is null)
+        {
+            return;
+        }
+
+        using var command = connection.CreateCommand();
+        command.CommandText = writable ? "PRAGMA query_only = OFF" : "PRAGMA query_only = ON";
+        command.ExecuteNonQuery();
+    }
+
     private async Task SynchronizeTablesAsync(
         IReadOnlyList<TabularDocumentRef> documents,
         Func<TabularDocumentRef, CancellationToken, Task<TabularDocumentArtifact>> artifactLoader,
@@ -691,6 +735,10 @@ internal sealed class TabularWorkspace : IDisposable
         walCommand.ExecuteNonQuery();
 
         EnsureMetadataTable(connection);
+
+        // Keep the connection read-only by default. Writes are only enabled inside the narrow windows
+        // opened by the table-build and manipulation paths, so a write can never run on a read path.
+        SetWritable(connection, false);
 
         return connection;
     }

--- a/tests/CrestApps.Core.Tests/Core/Documents/Tabular/TabularSqlGuardTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Documents/Tabular/TabularSqlGuardTests.cs
@@ -33,6 +33,25 @@ public class TabularSqlGuardTests
         Assert.Throws<TabularSqlException>(() => TabularSqlGuard.EnsureReadOnlyQuery(sql));
     }
 
+    [Fact]
+    public void EnsureReadOnlyQuery_AllowsSemicolonInsideStringLiteral()
+    {
+        // A semicolon inside a quoted value is part of one statement, not statement batching.
+        var normalized = TabularSqlGuard.EnsureReadOnlyQuery("SELECT * FROM sales WHERE note = 'a;b;c'");
+
+        Assert.Contains("'a;b;c'", normalized);
+    }
+
+    [Theory]
+    [InlineData("-- pick everything\nSELECT * FROM sales")]
+    [InlineData("/* leading comment */ SELECT * FROM sales")]
+    public void EnsureReadOnlyQuery_AllowsLeadingComment(string sql)
+    {
+        var normalized = TabularSqlGuard.EnsureReadOnlyQuery(sql);
+
+        Assert.StartsWith("SELECT", normalized, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("SELECT * FROM sales; ATTACH DATABASE 'x' AS y")]
     [InlineData("ATTACH DATABASE 'x' AS y")]

--- a/tests/CrestApps.Core.Tests/Core/Documents/Tabular/TabularWorkspaceTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Documents/Tabular/TabularWorkspaceTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using CrestApps.Core.AI.Documents.Tabular;
 using Microsoft.Data.Sqlite;
 
@@ -576,6 +577,55 @@ public class TabularWorkspaceTests
         // After disposal the database is gone; querying throws.
         await Assert.ThrowsAnyAsync<Exception>(
             () => workspace.QueryAsync("SELECT * FROM sales", 100, cancellationToken));
+    }
+
+    /// <summary>
+    /// Defense in depth: the workspace connection is kept read-only at the SQLite engine level outside
+    /// its narrow write windows, so a write that ever reached a read path is refused by the engine even
+    /// if it slipped past the SQL text guard. The sanctioned manipulation path still succeeds.
+    /// </summary>
+    [Fact]
+    public async Task Connection_IsReadOnlyByDefault_AndOnlyWritableInsideCommandWindow()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var workspace = CreateWorkspace();
+        await workspace.EnsureReadyAsync(Documents(), Loader(Csv), cancellationToken);
+
+        var connection = GetConnection(workspace);
+
+        // A direct write on the shared connection is refused because it is in query_only mode.
+        using (var write = connection.CreateCommand())
+        {
+            write.CommandText = "DELETE FROM sales";
+            var exception = Assert.Throws<SqliteException>(() => write.ExecuteNonQuery());
+            Assert.Contains("readonly", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Reads still work on the same connection.
+        using (var read = connection.CreateCommand())
+        {
+            read.CommandText = "SELECT COUNT(*) FROM sales";
+            Assert.Equal(3L, Convert.ToInt64(read.ExecuteScalar()));
+        }
+
+        // The sanctioned manipulation tool opens a write window and succeeds.
+        await workspace.ExecuteAsync("UPDATE sales SET amount = '999' WHERE region = 'North'", cancellationToken);
+        var updated = await workspace.QueryAsync("SELECT amount FROM sales WHERE region = 'North' LIMIT 1", 10, cancellationToken);
+        Assert.Equal(999L, Convert.ToInt64(updated.Rows[0][0]));
+
+        // Once the window closed, the connection is read-only again.
+        using (var write = connection.CreateCommand())
+        {
+            write.CommandText = "DELETE FROM sales";
+            Assert.Throws<SqliteException>(() => write.ExecuteNonQuery());
+        }
+    }
+
+    private static SqliteConnection GetConnection(TabularWorkspace workspace)
+    {
+        var field = typeof(TabularWorkspace).GetField("_connection", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return (SqliteConnection)field!.GetValue(workspace)!;
     }
 
     private static TabularWorkspace CreateWorkspace(TabularWorkspaceOptions options = null)


### PR DESCRIPTION
## Summary

Hardens the tabular workspace's read-only enforcement with defense in depth, so a write can never run on a read path even if the SQL text guard is bypassed.

The tabular tools run model-generated SQL against a per-conversation, file-backed SQLite copy of uploaded data. Read-only was previously enforced **only** by parsing the SQL string (a prefix check), which is fragile for a security boundary. This adds engine-level enforcement.

## Changes

- **Engine-level read-only (defense in depth):** the workspace SQLite connection is kept in `PRAGMA query_only` mode by default. Writes are enabled only inside the narrow windows opened by the table-build (`EnsureReadyAsync`) and manipulation (`ExecuteAsync`) paths, so the engine itself refuses any write on a read path — a fail-safe default.
- **Hardened `TabularSqlGuard.EnsureReadOnlyQuery`:** it now uses the same quote- and comment-aware statement splitter as the command batch path, so a semicolon inside a string literal is no longer mistaken for statement batching, a single statement is required, and leading comments are tolerated.

## Behavior

Reads, aggregation, ordering, exports, and the sanctioned manipulation tool are unaffected — only writes on read paths are blocked. The original uploaded file is still never modified, and per-conversation database isolation is unchanged.

## Tests

- New guard tests: semicolon inside a string literal is allowed; leading comments are allowed.
- New white-box test proving the connection is read-only by default (a direct write is refused with a `readonly` error) and writable only inside a command window.
- All 176 tabular tests pass.
