### PR TITLE
Surface provider 404 (model/endpoint not found) as a helpful chat error

### DIFF
--- a/src/CrestApps.Core.Docs/docs/getting-started.md
+++ b/src/CrestApps.Core.Docs/docs/getting-started.md
@@ -167,7 +167,9 @@ The sample hosts already register the Ollama provider, so running them against y
    curl http://localhost:11434/api/tags
    ```
 
-2. Configure the connection and a deployment whose `ModelName` **exactly matches** the pulled model name (including any tag, e.g. `llama3.2:latest`):
+2. Create an Ollama connection and a chat deployment. In the sample hosts you can add both from the admin UI on the **AI Connections** and **AI Deployments** screens, the same way you would for any provider. Whichever route you use, the deployment's **Model name** must **exactly match** the pulled model name (including any tag, e.g. `llama3.2:latest`).
+
+   You can also provide them through configuration instead of the UI:
 
    ```json
    {

--- a/src/CrestApps.Core.Docs/docs/getting-started.md
+++ b/src/CrestApps.Core.Docs/docs/getting-started.md
@@ -135,6 +135,73 @@ Use `ConnectionName` when a deployment should point at a shared entry from `Cres
 
 Create an AI profile that uses your chat deployment, then use Chat Interactions to test it end to end.
 
+## Run locally with Ollama (no API key)
+
+[Ollama](https://ollama.ai/) is the fastest way to try CrestApps.Core without a cloud provider or API key. The one requirement that trips people up: **Ollama only serves models that have already been pulled onto the machine.** If the deployment's `ModelName` does not match a locally pulled model, the provider returns `404 (Not Found)` and the chat fails.
+
+### Option A — Let the Aspire host do it for you (recommended)
+
+The included Aspire host starts an Ollama container, **pulls a model automatically**, and pre-wires the connection and deployment for both sample hosts, so there is nothing to configure by hand:
+
+```bash
+dotnet run --project .\src\Startup\CrestApps.Core.Aspire.AppHost\CrestApps.Core.Aspire.AppHost.csproj
+```
+
+This requires a running container runtime such as [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+### Option B — Point at your own Ollama instance
+
+1. Pull the model you want to use, then confirm it is available:
+
+   ```bash
+   ollama pull llama3.2
+   ```
+
+   ```bash
+   curl http://localhost:11434/api/tags
+   ```
+
+2. Register the Ollama provider:
+
+   ```csharp
+   builder.Services.AddCrestAppsCore(crestApps => crestApps
+       .AddAISuite(ai => ai
+           .AddOllama()
+           .AddChatInteractions()));
+   ```
+
+3. Configure the connection and a deployment whose `ModelName` **exactly matches** the pulled model name (including any tag, e.g. `llama3.2:latest`):
+
+   ```json
+   {
+     "CrestApps": {
+       "AI": {
+         "Connections": [
+           {
+             "Name": "ollama-local",
+             "ClientName": "Ollama",
+             "Endpoint": "http://localhost:11434"
+           }
+         ],
+         "Deployments": [
+           {
+             "Name": "llama3.2",
+             "ConnectionName": "ollama-local",
+             "ModelName": "llama3.2",
+             "Type": "Chat"
+           }
+         ]
+       }
+     }
+   }
+   ```
+
+Ollama does not require an API key — the connection only needs an `Endpoint`. See the [Ollama provider guide](providers/ollama.md) for model management, Docker setup, and capability details.
+
+:::warning Getting a `404 (Not Found)` from Ollama?
+This almost always means the requested model has not been pulled. Run `ollama pull <model>` and confirm the name appears in `curl http://localhost:11434/api/tags` — it must match the deployment's **Model name** exactly.
+:::
+
 ## Complete Hello World example
 
 Here is a minimal, self-contained `Program.cs` that sends a chat completion request using CrestApps.Core with OpenAI:

--- a/src/CrestApps.Core.Docs/docs/getting-started.md
+++ b/src/CrestApps.Core.Docs/docs/getting-started.md
@@ -149,7 +149,13 @@ dotnet run --project .\src\Startup\CrestApps.Core.Aspire.AppHost\CrestApps.Core.
 
 This requires a running container runtime such as [Docker Desktop](https://www.docker.com/products/docker-desktop/).
 
+:::info First run downloads a model
+On the first run, the Aspire host pulls the default `deepseek-v2:16b` model. Depending on your internet speed this can take a while, and the model takes several gigabytes of disk space. The download only happens once — the model is cached in a persistent volume for later runs. To use a smaller or different model, change the model name in the Aspire host's `Program.cs`.
+:::
+
 ### Option B — Point at your own Ollama instance
+
+The sample hosts already register the Ollama provider, so running them against your own Ollama only requires pulling the model and pointing a connection at it.
 
 1. Pull the model you want to use, then confirm it is available:
 
@@ -161,16 +167,7 @@ This requires a running container runtime such as [Docker Desktop](https://www.d
    curl http://localhost:11434/api/tags
    ```
 
-2. Register the Ollama provider:
-
-   ```csharp
-   builder.Services.AddCrestAppsCore(crestApps => crestApps
-       .AddAISuite(ai => ai
-           .AddOllama()
-           .AddChatInteractions()));
-   ```
-
-3. Configure the connection and a deployment whose `ModelName` **exactly matches** the pulled model name (including any tag, e.g. `llama3.2:latest`):
+2. Configure the connection and a deployment whose `ModelName` **exactly matches** the pulled model name (including any tag, e.g. `llama3.2:latest`):
 
    ```json
    {
@@ -197,6 +194,15 @@ This requires a running container runtime such as [Docker Desktop](https://www.d
    ```
 
 Ollama does not require an API key — the connection only needs an `Endpoint`. See the [Ollama provider guide](providers/ollama.md) for model management, Docker setup, and capability details.
+
+If you are wiring CrestApps.Core into **your own** project rather than running the sample hosts, register the provider the same way as the OpenAI example above, swapping `.AddOpenAI()` for `.AddOllama()`:
+
+```csharp
+builder.Services.AddCrestAppsCore(crestApps => crestApps
+    .AddAISuite(ai => ai
+        .AddOllama()
+        .AddChatInteractions()));
+```
 
 :::warning Getting a `404 (Not Found)` from Ollama?
 This almost always means the requested model has not been pulled. Run `ollama pull <model>` and confirm the name appears in `curl http://localhost:11434/api/tags` — it must match the deployment's **Model name** exactly.

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
@@ -175,6 +175,11 @@ public class AIChatHubCore<TClient> : Hub<TClient>
             return GetInvalidChatModelSettingsMessage();
         }
 
+        if (AIHubErrorMessageHelper.IsModelOrEndpointNotFoundFailure(ex))
+        {
+            return GetModelOrEndpointNotFoundMessage();
+        }
+
         return "An error occurred processing your message.";
     }
 
@@ -184,6 +189,15 @@ public class AIChatHubCore<TClient> : Hub<TClient>
     protected virtual string GetInvalidChatModelSettingsMessage()
     {
         return "The chat model settings are missing or invalid. Update the Chat model in the AI Profile or the global AI settings.";
+    }
+
+    /// <summary>
+    /// Gets the message returned when the provider responds with a 404 (Not Found), which usually
+    /// means the deployment's model name or the connection endpoint is incorrect.
+    /// </summary>
+    protected virtual string GetModelOrEndpointNotFoundMessage()
+    {
+        return "The AI provider could not find the requested model or endpoint (404). Verify that the deployment's model name exists on the provider and that the connection endpoint is correct. If you are using Ollama, make sure the model has been pulled first.";
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
@@ -225,6 +225,11 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
             return GetInvalidChatModelSettingsMessage();
         }
 
+        if (AIHubErrorMessageHelper.IsModelOrEndpointNotFoundFailure(ex))
+        {
+            return GetModelOrEndpointNotFoundMessage();
+        }
+
         return "An error occurred while processing your message.";
     }
 
@@ -234,6 +239,15 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
     protected virtual string GetInvalidChatModelSettingsMessage()
     {
         return "The chat model settings are missing or invalid. Update the Chat model in this chat interaction, the linked AI Profile, or the global AI settings.";
+    }
+
+    /// <summary>
+    /// Gets the message returned when the provider responds with a 404 (Not Found), which usually
+    /// means the deployment's model name or the connection endpoint is incorrect.
+    /// </summary>
+    protected virtual string GetModelOrEndpointNotFoundMessage()
+    {
+        return "The AI provider could not find the requested model or endpoint (404). Verify that the deployment's model name exists on the provider and that the connection endpoint is correct. If you are using Ollama, make sure the model has been pulled first.";
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI.Resilience/AIProviderErrorHelper.cs
+++ b/src/Primitives/CrestApps.Core.AI.Resilience/AIProviderErrorHelper.cs
@@ -45,6 +45,38 @@ public static class AIProviderErrorHelper
     }
 
     /// <summary>
+    /// Determines whether the specified exception represents a provider "not found" (HTTP 404) failure.
+    /// </summary>
+    /// <param name="ex">The exception to inspect.</param>
+    /// <returns>
+    /// <see langword="true"/> when the exception chain contains an HTTP 404 response; otherwise, <see langword="false"/>.
+    /// For most providers a 404 during a completion indicates the configured model/deployment name or the
+    /// connection endpoint could not be found (for example, an Ollama model that has not been pulled).
+    /// </returns>
+    public static bool IsNotFoundException(Exception ex)
+    {
+        if (ex is null)
+        {
+            return false;
+        }
+
+        foreach (var current in EnumerateExceptions(ex))
+        {
+            if (current is HttpRequestException { StatusCode: HttpStatusCode.NotFound })
+            {
+                return true;
+            }
+
+            if (TryGetClientResultStatusCode(current) == (int)HttpStatusCode.NotFound)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Attempts to read a provider status code from a known client exception shape.
     /// </summary>
     /// <param name="ex">The exception to inspect.</param>

--- a/src/Primitives/CrestApps.Core.AI/AIHubErrorMessageHelper.cs
+++ b/src/Primitives/CrestApps.Core.AI/AIHubErrorMessageHelper.cs
@@ -42,7 +42,7 @@ internal static class AIHubErrorMessageHelper
                     HttpStatusCode.BadRequest
                         => S["Invalid request. Please verify your connection settings."],
                     HttpStatusCode.NotFound
-                        => S["The provider endpoint could not be found. Please verify the API URL."],
+                        => S["The provider could not find the requested model or endpoint. Verify the deployment's model name exists on the provider and that the connection endpoint URL is correct."],
                     HttpStatusCode.TooManyRequests
                         => S["Rate limit reached. Please wait and try again later."],
                     >= HttpStatusCode.InternalServerError
@@ -72,6 +72,17 @@ internal static class AIHubErrorMessageHelper
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether the failure is a provider "not found" (HTTP 404) response, which typically
+    /// means the configured model/deployment name or the connection endpoint could not be found
+    /// (for example, an Ollama model that has not been pulled).
+    /// </summary>
+    /// <param name="ex">The ex.</param>
+    public static bool IsModelOrEndpointNotFoundFailure(Exception ex)
+    {
+        return AIProviderErrorHelper.IsNotFoundException(ex);
     }
 
     private static string ExtractRetryAfterMessage(string message)

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/AIChatHubCoreTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/AIChatHubCoreTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Threading.Channels;
 using CrestApps.Core.AI;
 using CrestApps.Core.AI.Chat;
@@ -71,6 +72,53 @@ public sealed class AIChatHubCoreTests
         var message = hub.GetFriendlyErrorMessageForTest(new AIDeploymentNotFoundException("Unable to resolve a chat deployment for the profile."));
 
         Assert.Equal("The chat model settings are missing or invalid. Update the Chat model in the AI Profile or the global AI settings.", message);
+    }
+
+    [Fact]
+    public void GetFriendlyErrorMessage_WithProviderNotFound_ReturnsModelOrEndpointGuidance()
+    {
+        var hub = new TestAIChatHub(new ServiceCollection().BuildServiceProvider());
+
+        var notFound = new HttpRequestException(
+            "Response status code does not indicate success: 404 (Not Found).",
+            inner: null,
+            statusCode: HttpStatusCode.NotFound);
+
+        var message = hub.GetFriendlyErrorMessageForTest(notFound);
+
+        Assert.Equal("The AI provider could not find the requested model or endpoint (404). Verify that the deployment's model name exists on the provider and that the connection endpoint is correct. If you are using Ollama, make sure the model has been pulled first.", message);
+    }
+
+    [Fact]
+    public void GetFriendlyErrorMessage_WithWrappedProviderNotFound_ReturnsModelOrEndpointGuidance()
+    {
+        var hub = new TestAIChatHub(new ServiceCollection().BuildServiceProvider());
+
+        var notFound = new InvalidOperationException(
+            "Streaming failed.",
+            new HttpRequestException(
+                "Response status code does not indicate success: 404 (Not Found).",
+                inner: null,
+                statusCode: HttpStatusCode.NotFound));
+
+        var message = hub.GetFriendlyErrorMessageForTest(notFound);
+
+        Assert.Equal("The AI provider could not find the requested model or endpoint (404). Verify that the deployment's model name exists on the provider and that the connection endpoint is correct. If you are using Ollama, make sure the model has been pulled first.", message);
+    }
+
+    [Fact]
+    public void GetFriendlyErrorMessage_WithNonNotFoundHttpError_ReturnsGenericMessage()
+    {
+        var hub = new TestAIChatHub(new ServiceCollection().BuildServiceProvider());
+
+        var serverError = new HttpRequestException(
+            "Response status code does not indicate success: 500 (Internal Server Error).",
+            inner: null,
+            statusCode: HttpStatusCode.InternalServerError);
+
+        var message = hub.GetFriendlyErrorMessageForTest(serverError);
+
+        Assert.Equal("An error occurred processing your message.", message);
     }
 
     /// <summary>

--- a/tests/CrestApps.Core.Tests/Framework/Mvc/ChatInteractionHubTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/Mvc/ChatInteractionHubTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using System.Threading.Channels;
 using CrestApps.Core.AI.Chat;
@@ -273,6 +274,24 @@ public sealed class ChatInteractionHubTests
         var message = hub.GetFriendlyErrorMessageForTest(new AIDeploymentNotFoundException("Unable to resolve a chat deployment for the profile."));
 
         Assert.Equal("The chat model settings are missing or invalid. Update the Chat model in this chat interaction, the linked AI Profile, or the global AI settings.", message);
+    }
+
+    [Fact]
+    public void GetFriendlyErrorMessage_WithProviderNotFound_ReturnsModelOrEndpointGuidance()
+    {
+        var hub = new TestChatInteractionHub(new ServiceCollection().BuildServiceProvider())
+        {
+            Clients = new Mock<IHubCallerClients<IChatInteractionHubClient>>().Object,
+        };
+
+        var notFound = new HttpRequestException(
+            "Response status code does not indicate success: 404 (Not Found).",
+            inner: null,
+            statusCode: HttpStatusCode.NotFound);
+
+        var message = hub.GetFriendlyErrorMessageForTest(notFound);
+
+        Assert.Equal("The AI provider could not find the requested model or endpoint (404). Verify that the deployment's model name exists on the provider and that the connection endpoint is correct. If you are using Ollama, make sure the model has been pulled first.", message);
     }
 
     [Fact]


### PR DESCRIPTION
When a chat provider returns HTTP 404 during streaming, the hubs previously showed a generic "An error occurred processing your message." This is the common Ollama failure mode when the requested model has not been pulled (Ollama's /api/chat returns 404), so users had no actionable guidance.

- Add AIProviderErrorHelper.IsNotFoundException to detect a 404 anywhere in the exception chain (HttpRequestException or ClientResultException).
- Add AIHubErrorMessageHelper.IsModelOrEndpointNotFoundFailure and a new GetModelOrEndpointNotFoundMessage() hook on both AIChatHubCore and ChatInteractionHubBase that points users at the deployment model name / connection endpoint, with an Ollama "pull the model first" hint.
- Improve the (localized) NotFound message to mention model name, not just URL.
- Add a "Run locally with Ollama" quick-start to getting-started docs that leads with pulling the model and covers the Aspire auto-provisioned path.

Addresses the confusion reported in #142.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
