### PR TITLE
Bump @crestapps/ai-chat-ui npm version base to 2.0.0-preview

### DIFF
--- a/src/Resources/CrestApps.AI.Resources/package.json
+++ b/src/Resources/CrestApps.AI.Resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crestapps/ai-chat-ui",
-  "version": "1.0.0-preview",
+  "version": "2.0.0-preview",
   "description": "Browser-ready JavaScript widgets and CSS for CrestApps AI chat sessions and chat interactions. Supports streaming responses, image generation, Chart.js interactive charts, document uploads, copy-to-clipboard, and feedback buttons.",
   "license": "MIT",
   "author": "CrestApps",


### PR DESCRIPTION
The npm preview publish derives its version from the package version in src/Resources/CrestApps.AI.Resources/package.json (appending the run number), so previews were shipping as 1.0.0-preview.<run> even though the project is on 2.0.0. Bump the base to 2.0.0-preview so preview builds ship 2.0.0-preview.<run>, newer than 1.0.0. The release publish derives its version from the git tag and is unaffected.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
