### PR TITLE
Add strategy-based web crawlers that scrape sites into a Web data source

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,8 +59,8 @@ When a change affects public behavior, configuration, setup, or project guidance
 
 ### Changelog conventions
 
-- Changelog files are named after their version with no `v` prefix (for example `1.1.0.md`, `1.2.0.md`).
-- The next planned release is **1.2.0**. Document all upcoming changes — new features, fixes, dependency upgrades, branching or workflow changes, and other notable repository-level updates — in `src\CrestApps.Core.Docs\docs\changelog\1.2.0.md` until it ships.
+- Changelog files are named after their version with no `v` prefix (for example `1.1.0.md`, `2.0.0.md`).
+- The next planned release is **2.0.0**. Document all upcoming changes — new features, fixes, dependency upgrades, branching or workflow changes, and other notable repository-level updates — in `src\CrestApps.Core.Docs\docs\changelog\2.0.0.md` until it ships.
 - When a new development cycle begins, add a changelog file for that version (again with no `v` prefix), register it in `src\CrestApps.Core.Docs\sidebars.js` and `src\CrestApps.Core.Docs\docs\changelog\index.md`, and document ongoing work there.
 
 Keep the docs focused on `CrestApps.Core`. If you need to mention the Orchard Core implementation, treat it as a related downstream product and link to <https://orchardcore.crestapps.com>.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,10 @@ update the relevant docs under `src\CrestApps.Core.Docs\docs` and build the docs
 
 - Changelog files are named after their version with no `v` prefix (for example
   `1.1.0.md`, `1.2.0.md`).
-- The next planned release is **1.2.0**. Document all upcoming changes going forward —
+- The next planned release is **2.0.0**. Document all upcoming changes going forward —
   new features, fixes, dependency upgrades, branching or workflow changes, and other
   notable repository-level updates — in
-  `src\CrestApps.Core.Docs\docs\changelog\1.2.0.md` until it ships.
+  `src\CrestApps.Core.Docs\docs\changelog\2.0.0.md` until it ships.
 - When a new development cycle starts, add a changelog file for that version (again
   with no `v` prefix), register it in `src\CrestApps.Core.Docs\sidebars.js` and
   `src\CrestApps.Core.Docs\docs\changelog\index.md`, and document ongoing work there.

--- a/CrestApps.Core.slnx
+++ b/CrestApps.Core.slnx
@@ -46,7 +46,9 @@
     <Project Path="src/Primitives/CrestApps.Core.AI.Resilience/CrestApps.Core.AI.Resilience.csproj">
       <Build Solution="Debug|*" Project="false" />
     </Project>
+    <Project Path="src/Primitives/CrestApps.Core.AI.WebCrawlers/CrestApps.Core.AI.WebCrawlers.csproj" />
     <Project Path="src/Primitives/CrestApps.Core.AI/CrestApps.Core.AI.csproj" />
+    <Project Path="src/Primitives/CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj" />
     <Project Path="src/Primitives/CrestApps.Core.Azure.AISearch/CrestApps.Core.Azure.AISearch.csproj" />
     <Project Path="src/Primitives/CrestApps.Core.Azure/CrestApps.Core.Azure.csproj" />
     <Project Path="src/Primitives/CrestApps.Core.Elasticsearch/CrestApps.Core.Elasticsearch.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <!-- Miscellaneous Packages -->
     <PackageVersion Include="A2A" Version="1.0.0-preview2" />
     <PackageVersion Include="A2A.AspNetCore" Version="1.0.0-preview2" />
+    <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="Anthropic" Version="12.44.0" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="[8.19.24,9.0.0)" />

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/DataSources/IWebCrawlStateStore.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/DataSources/IWebCrawlStateStore.cs
@@ -1,0 +1,28 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.Core.AI.DataSources;
+
+/// <summary>
+/// Persists the per-page crawl state (<see cref="WebCrawlState"/>) for web crawlers. The re-index service
+/// uses it to diff a fresh crawl against the pages already indexed. Records are grouped by the owning
+/// crawler, which is stored as their source, so <see cref="ISourceCatalog{T}.GetAsync(string, System.Threading.CancellationToken)"/>
+/// retrieves every page for a crawler.
+/// </summary>
+public interface IWebCrawlStateStore : ISourceCatalog<WebCrawlState>
+{
+    /// <summary>
+    /// Deletes every crawl-state record for the specified crawler.
+    /// </summary>
+    /// <param name="webCrawlerId">The owning crawler identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task DeleteByCrawlerIdAsync(string webCrawlerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the crawl-state records for the specified page URLs within a crawler.
+    /// </summary>
+    /// <param name="webCrawlerId">The owning crawler identifier.</param>
+    /// <param name="urls">The page URLs whose crawl state should be removed.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task DeleteByUrlsAsync(string webCrawlerId, IEnumerable<string> urls, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/DataSources/IWebCrawlerStore.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/DataSources/IWebCrawlerStore.cs
@@ -1,0 +1,18 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.Core.AI.DataSources;
+
+/// <summary>
+/// Store for managing <see cref="WebCrawler"/> records.
+/// </summary>
+public interface IWebCrawlerStore : ISourceCatalog<WebCrawler>
+{
+    /// <summary>
+    /// Retrieves every crawler that targets the specified AI data source.
+    /// </summary>
+    /// <param name="dataSourceId">The target AI data source identifier.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The crawlers pointing at the data source.</returns>
+    Task<IReadOnlyCollection<WebCrawler>> GetByDataSourceIdAsync(string dataSourceId, CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AIDataSourceSourceTypes.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AIDataSourceSourceTypes.cs
@@ -24,4 +24,10 @@ public static class AIDataSourceSourceTypes
     /// Source documents are read from a PostgreSQL table using explicit connection settings.
     /// </summary>
     public const string PostgreSQL = "PostgreSQL";
+
+    /// <summary>
+    /// Source documents are produced by web crawlers that scrape public websites. The data source is a
+    /// target bucket; the sites to scrape are managed as separate web-crawler records that point at it.
+    /// </summary>
+    public const string Web = "Web";
 }

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/WebCrawlState.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/WebCrawlState.cs
@@ -1,0 +1,47 @@
+using CrestApps.Core.Models;
+
+namespace CrestApps.Core.AI.Models;
+
+/// <summary>
+/// Tracks the last-known crawl state of a single scraped page for one <see cref="WebCrawler"/>. The
+/// re-index service compares a fresh crawl against these records to decide which pages are new, changed,
+/// or removed, so only affected pages are re-fetched and re-embedded. The owning crawler's identifier is
+/// stored in <see cref="CrestApps.Core.Models.SourceCatalogEntry.Source"/> so the records can be queried
+/// through the source-catalog abstraction.
+/// </summary>
+public sealed class WebCrawlState : SourceCatalogEntry
+{
+    /// <summary>
+    /// Gets or sets the canonical, absolute URL of the scraped page. This is the reference id used for the
+    /// knowledge-base chunks and the page's citation link.
+    /// </summary>
+    public string Url { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last-modified timestamp advertised for the page the last time it was indexed, or
+    /// <see langword="null"/> when the crawl did not report one.
+    /// </summary>
+    public DateTime? LastModifiedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the change-frequency hint advertised for the page, or <see langword="null"/> when the
+    /// crawl did not report one.
+    /// </summary>
+    public string ChangeFrequency { get; set; }
+
+    /// <summary>
+    /// Gets or sets a hash of the cleaned page content captured at the last index.
+    /// </summary>
+    public string ContentHash { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when the page was last fetched and indexed.
+    /// </summary>
+    public DateTime LastIndexedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when the page was last seen during a crawl. A page missing since the
+    /// previous crawl is treated as removed.
+    /// </summary>
+    public DateTime LastSeenUtc { get; set; }
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/WebCrawler.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/WebCrawler.cs
@@ -1,0 +1,77 @@
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+
+namespace CrestApps.Core.AI.Models;
+
+/// <summary>
+/// Represents one configured web crawler: a scraping strategy identified by its <see cref="Source"/> (for
+/// example <c>Sitemap</c>), the strategy's settings (stored in <see cref="ExtensibleEntity.Properties"/>),
+/// and the target <see cref="AIDataSourceId"/> whose knowledge base the scraped pages are indexed into.
+/// Many crawlers can point at a single <c>Web</c> AI data source.
+/// </summary>
+public sealed class WebCrawler : SourceCatalogEntry, IDisplayTextAwareModel, IModifiedUtcAwareModel, ICloneable<WebCrawler>
+{
+    /// <summary>
+    /// Gets or sets the human-readable display name for this crawler.
+    /// </summary>
+    public string DisplayText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the target <c>Web</c> AI data source whose knowledge base receives
+    /// the scraped pages.
+    /// </summary>
+    public string AIDataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this crawler is active. Disabled crawlers are skipped by the
+    /// re-index background service and are not read during a full data source synchronization.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how often, in minutes, the background service re-crawls this site and re-indexes the
+    /// pages that changed. When not set, the global default is used.
+    /// </summary>
+    public int? ReindexIntervalMinutes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when this crawler was created.
+    /// </summary>
+    public DateTime CreatedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when this crawler was last modified.
+    /// </summary>
+    public DateTime? ModifiedUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the user who created this crawler.
+    /// </summary>
+    public string Author { get; set; }
+
+    /// <summary>
+    /// Gets or sets the owner identifier associated with this crawler.
+    /// </summary>
+    public string OwnerId { get; set; }
+
+    /// <summary>
+    /// Clones the crawler.
+    /// </summary>
+    public WebCrawler Clone()
+    {
+        return new WebCrawler
+        {
+            ItemId = ItemId,
+            DisplayText = DisplayText,
+            AIDataSourceId = AIDataSourceId,
+            Source = Source,
+            Enabled = Enabled,
+            ReindexIntervalMinutes = ReindexIntervalMinutes,
+            CreatedUtc = CreatedUtc,
+            ModifiedUtc = ModifiedUtc,
+            Author = Author,
+            OwnerId = OwnerId,
+            Properties = Properties.Clone(),
+        };
+    }
+}

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -79,6 +79,21 @@ and preview builds are published from `main` under the `2.0.0` version prefix.
 
 ## Change Logs
 
+- **New strategy-based web crawlers (`CrestApps.Core.AI.WebCrawlers`).** Public websites can now populate
+  a knowledge base directly. A new `Web` AI data source acts as a target bucket, and separate **web
+  crawler** records — each choosing a scraping **strategy** and pointing at a `Web` data source — manage
+  the sites to scrape, so many sites can map into a single knowledge base. The first strategy is sitemap
+  discovery (flat `urlset`, nested `sitemapindex`, gzip and plain-text sitemaps, RSS/Atom feeds, and
+  `robots.txt` advertisements); the strategy contract (`IWebCrawlerStrategy`) makes future strategies (for
+  example depth-limited link following) drop-in. A `WebCrawlerReindexBackgroundService` re-crawls each
+  crawler on its own cadence and re-indexes only the pages whose `<lastmod>` changed (adding new pages and
+  removing deleted ones), backed by per-crawler crawl-state stores (YesSql and EntityCore). The scraped
+  page URL is kept for citations. Opt in with `AddCoreWebCrawlers()` plus `AddCoreWebCrawlerStoresYesSql()`
+  or `AddCoreWebCrawlerStoresEntityCore()`, and both sample hosts ship a **Web Crawlers** management UI.
+- **New `CrestApps.Core.DataIngestion` package.** A reusable `HtmlIngestionDocumentReader` for
+  `Microsoft.Extensions.DataIngestion` cleans HTML (removing scripts, styles, and markup and extracting the
+  page title) into an `IngestionDocument` for chunking and embedding. The web crawlers use it to ingest
+  scraped pages.
 - **Tool instances now support user-declared parameters.** A tool instance can declare typed,
   described parameters instead of leaving the AI model to guess at a free-form argument bag. Each
   parameter declares who fills it — the model, a fixed value the user pins, or the ambient request

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -91,9 +91,11 @@ and preview builds are published from `main` under the `2.0.0` version prefix.
   page URL is kept for citations. Opt in with `AddCoreWebCrawlers()` plus `AddCoreWebCrawlerStoresYesSql()`
   or `AddCoreWebCrawlerStoresEntityCore()`, and both sample hosts ship a **Web Crawlers** management UI.
 - **New `CrestApps.Core.DataIngestion` package.** A reusable `HtmlIngestionDocumentReader` for
-  `Microsoft.Extensions.DataIngestion` cleans HTML (removing scripts, styles, and markup and extracting the
-  page title) into an `IngestionDocument` for chunking and embedding. The web crawlers use it to ingest
-  scraped pages.
+  `Microsoft.Extensions.DataIngestion` turns HTML into an `IngestionDocument` for chunking and embedding.
+  Because scraped pages are untrusted, it parses the HTML with a standards-compliant HTML5 parser
+  (AngleSharp) rather than pattern matching, removing `script`, `style`, and other non-content nodes
+  together with their contents so no markup or executable code survives into the embedded and stored text.
+  The web crawlers use it to ingest scraped pages.
 - **Tool instances now support user-declared parameters.** A tool instance can declare typed,
   described parameters instead of leaving the AI model to guess at a free-form argument bag. Each
   parameter declares who fills it — the model, a fixed value the user pins, or the ambient request

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -79,6 +79,7 @@ and preview builds are published from `main` under the `2.0.0` version prefix.
 
 ## Change Logs
 
+- Improved web-crawler-backed data-source retrieval so preemptive RAG and the `search_data_sources` tool expand their candidate pool, filter out obvious non-page assets and error pages, and preserve the raw user query alongside derived search terms. This prevents high-scoring boilerplate from displacing relevant pgvector hits, and the sitemap web crawler now skips non-HTML responses such as `.kml` assets during future indexing runs.
 - **New strategy-based web crawlers (`CrestApps.Core.AI.WebCrawlers`).** Public websites can now populate
   a knowledge base directly. A new `Web` AI data source acts as a target bucket, and separate **web
   crawler** records — each choosing a scraping **strategy** and pointing at a `Web` data source — manage

--- a/src/CrestApps.Core.Docs/docs/data-sources/index.md
+++ b/src/CrestApps.Core.Docs/docs/data-sources/index.md
@@ -40,8 +40,11 @@ The built-in source types are:
 | `Elasticsearch` | An external Elasticsearch index using per-data-source connection settings | explicit notifications through `IAIDataSourceChangeNotifier` |
 | `AzureAISearch` | An external Azure AI Search index using per-data-source connection settings | explicit notifications through `IAIDataSourceChangeNotifier` |
 | `PostgreSQL` | An external PostgreSQL table using per-data-source connection settings | explicit notifications through `IAIDataSourceChangeNotifier` |
+| `Web` | A target bucket populated by [web crawlers](./web-crawlers.md) that scrape public websites | scheduled re-crawl that re-indexes only the pages that changed |
 
 `SearchIndexProfile` remains the default source type and the simplest option when your content is already indexed through CrestApps.Core.
+
+A `Web` data source holds no site configuration itself. Instead, one or more **web crawlers** — each choosing a scraping strategy (today, sitemap discovery) — point at it, so many sites can populate a single knowledge base. See [Web Crawlers](./web-crawlers.md).
 
 ## Field Mapping
 

--- a/src/CrestApps.Core.Docs/docs/data-sources/web-crawlers.md
+++ b/src/CrestApps.Core.Docs/docs/data-sources/web-crawlers.md
@@ -39,9 +39,11 @@ can be added later by implementing one interface — without changing the data s
 | `Sitemap` | Discovers pages through the site's sitemap(s) — flat `urlset`, nested `sitemapindex`, gzip and plain-text sitemaps, RSS/Atom feeds, and `robots.txt` advertisements — then fetches and cleans each page. |
 
 Each page's HTML is cleaned into plain text through a reusable
-`CrestApps.Core.DataIngestion.HtmlIngestionDocumentReader` (a `Microsoft.Extensions.DataIngestion`
-reader that strips scripts, styles, and markup), and the resulting text is normalized and token-chunked by
-the shared data-source indexing pipeline.
+`CrestApps.Core.DataIngestion.HtmlIngestionDocumentReader`. Because scraped pages are untrusted, it parses
+the HTML with a standards-compliant HTML5 parser (AngleSharp) — not pattern matching — and removes
+`script`, `style`, and other non-content nodes together with their contents before reading any text. The
+parser never executes scripts, so no markup or code survives into the text that is embedded and stored.
+The resulting text is then normalized and token-chunked by the shared data-source indexing pipeline.
 
 ### Sitemap settings
 

--- a/src/CrestApps.Core.Docs/docs/data-sources/web-crawlers.md
+++ b/src/CrestApps.Core.Docs/docs/data-sources/web-crawlers.md
@@ -1,0 +1,99 @@
+---
+sidebar_label: Web Crawlers
+sidebar_position: 6
+title: Web Crawlers
+description: Scrape public websites into a Web AI data source with pluggable crawl strategies, starting with sitemap discovery.
+---
+
+# Web Crawlers
+
+> Populate an AI knowledge base directly from public websites. A **web crawler** picks a scraping
+> **strategy**, supplies that strategy's settings, and points at a **Web** data source. Many crawlers can
+> map many sites into a single knowledge base, and each is re-crawled on its own schedule.
+
+Web crawlers live in the opt-in `CrestApps.Core.AI.WebCrawlers` package and are managed through the
+**Web Crawlers** area of the sample hosts.
+
+## How it fits together
+
+```text
+Web Crawler (strategy: Sitemap) ─┐
+Web Crawler (strategy: Sitemap) ─┼──▶  Web AI Data Source  ──▶  Knowledge-base index (chunks + embeddings)
+Web Crawler (future strategy)   ─┘
+```
+
+- A **Web** AI data source (source type `Web`) is a plain target bucket — no site configuration, no field
+  mapping. Create it under **Data Sources** and choose the **Web** source type.
+- A **web crawler** record chooses a **strategy** (its `Source`, for example `Sitemap`), configures that
+  strategy (base/sitemap URL, page limits, URL filters), and selects the target **Web** data source.
+- The crawler's pages are fetched, cleaned to text, chunked, embedded, and stored in the data source's
+  knowledge base with the page URL retained for citations.
+
+Because the data source is strategy-agnostic, new strategies (for example depth-limited link following)
+can be added later by implementing one interface — without changing the data source or the UI.
+
+## Strategies
+
+| Strategy | What it does |
+| --- | --- |
+| `Sitemap` | Discovers pages through the site's sitemap(s) — flat `urlset`, nested `sitemapindex`, gzip and plain-text sitemaps, RSS/Atom feeds, and `robots.txt` advertisements — then fetches and cleans each page. |
+
+Each page's HTML is cleaned into plain text through a reusable
+`CrestApps.Core.DataIngestion.HtmlIngestionDocumentReader` (a `Microsoft.Extensions.DataIngestion`
+reader that strips scripts, styles, and markup), and the resulting text is normalized and token-chunked by
+the shared data-source indexing pipeline.
+
+### Sitemap settings
+
+| Setting | Purpose |
+| --- | --- |
+| Base URL | Resolves the sitemap through `robots.txt` and the conventional locations when no explicit sitemap URL is given. |
+| Sitemap URL | An explicit sitemap or sitemap-index URL to start discovery from. |
+| Max pages | Caps how many pages are scraped from the site. |
+| Max concurrent requests | Bounds parallel page fetches. |
+| Request timeout (seconds) | Per-page fetch timeout. |
+| User agent | The `User-Agent` header presented while crawling. |
+| Include / Exclude URL patterns | Optional regular expressions; a page must match an include (when any are set) and must not match an exclude. |
+
+A base URL or an explicit sitemap URL is required.
+
+## Re-indexing
+
+Each crawler has its own **re-index interval**. A background service (`WebCrawlerReindexBackgroundService`)
+periodically re-crawls each due site and enqueues only the pages that changed:
+
+- **New** pages (not seen before) are queued for indexing.
+- **Changed** pages — those whose sitemap `<lastmod>` is newer than the recorded value — are re-fetched
+  and re-embedded.
+- **Removed** pages (missing from the crawl) are deleted from the knowledge base.
+
+Pages without a `<lastmod>` timestamp are refreshed by the framework's nightly full data-source alignment
+rather than the incremental pass. Re-index diffing and scheduling are exposed as the injectable
+`IWebCrawlerReindexPlanner`, so a host can drive them from its own scheduler.
+
+## Citations
+
+The scraped page URL is stored as each chunk's reference id, and a keyed `IAIReferenceLinkResolver` returns
+that URL as the citation link, so chat answers grounded in scraped content link back to the original page.
+
+## Registration
+
+Both sample hosts opt in. Register the feature and a persistence backend:
+
+```csharp
+// Feature services (source handler, strategies, planner, background service).
+builder.Services.AddCoreWebCrawlers();
+
+// Persistence: choose the backend that matches your data stores.
+builder.Services.AddCoreWebCrawlerStoresYesSql();      // YesSql
+// builder.Services.AddCoreWebCrawlerStoresEntityCore(); // EntityFramework Core
+```
+
+`AddCoreWebCrawlers()` registers the `Web` data source source handler and citation link resolver, the crawl
+strategies, the re-index planner and its background service, and the crawler catalog handler.
+
+## Extending with a new strategy
+
+Implement `IWebCrawlerStrategy` (discover page references, fetch and clean a page, validate the crawler's
+settings), register it keyed by its identifier, and add a descriptor to `WebCrawlerStrategyOptions` so it
+appears in the strategy dropdown. No data-source or UI changes are required.

--- a/src/CrestApps.Core.Docs/sidebars.js
+++ b/src/CrestApps.Core.Docs/sidebars.js
@@ -59,6 +59,7 @@ const sidebars = {
                         'data-sources/azure-ai',
                         'data-sources/elasticsearch',
                         'data-sources/postgresql',
+                        'data-sources/web-crawlers',
                     ],
                 },
                 'core/data-storage',

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/ISitemapCrawler.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/ISitemapCrawler.cs
@@ -1,0 +1,23 @@
+namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+
+/// <summary>
+/// Discovers page URLs for a site by walking its sitemap graph. The crawler understands the full
+/// sitemaps.org protocol as it appears on the market: a flat <c>&lt;urlset&gt;</c>, a
+/// <c>&lt;sitemapindex&gt;</c> that nests child sitemaps (for example those emitted by Yoast, Rank Math,
+/// or Google), gzip-compressed sitemaps (<c>.xml.gz</c>), plain-text sitemaps, RSS 2.0 and Atom 1.0
+/// feeds (which Google also accepts as sitemaps), and sitemaps advertised through <c>robots.txt</c>.
+/// </summary>
+public interface ISitemapCrawler
+{
+    /// <summary>
+    /// Discovers the page entries for the supplied request by walking its sitemap graph.
+    /// </summary>
+    /// <param name="client">The HTTP client used to download sitemap and <c>robots.txt</c> documents.</param>
+    /// <param name="request">The discovery request describing the site and limits.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The discovered page entries, de-duplicated by URL and bounded by the request limit.</returns>
+    Task<IReadOnlyList<SitemapEntry>> DiscoverAsync(
+        HttpClient client,
+        SitemapCrawlRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapCrawlRequest.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapCrawlRequest.cs
@@ -1,0 +1,28 @@
+namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+
+/// <summary>
+/// Describes a single sitemap discovery run for the <see cref="ISitemapCrawler"/>. Either
+/// <see cref="SitemapUrl"/> or <see cref="BaseUrl"/> must be supplied; an explicit sitemap URL wins,
+/// otherwise the crawler resolves the sitemap from <c>robots.txt</c> and the conventional locations
+/// under <see cref="BaseUrl"/>.
+/// </summary>
+public sealed class SitemapCrawlRequest
+{
+    /// <summary>
+    /// Gets or sets the base URL of the site to crawl (for example <c>https://docs.example.com</c>). Used
+    /// to resolve the sitemap when <see cref="SitemapUrl"/> is not supplied.
+    /// </summary>
+    public string BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets an explicit sitemap URL. When set, discovery starts from this URL and does not consult
+    /// <c>robots.txt</c> or the conventional locations.
+    /// </summary>
+    public string SitemapUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of page URLs to discover. Discovery stops once this many pages have
+    /// been found, bounding the work for very large sites.
+    /// </summary>
+    public int MaxPages { get; set; } = int.MaxValue;
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapCrawler.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapCrawler.cs
@@ -1,0 +1,433 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+
+/// <summary>
+/// The default <see cref="ISitemapCrawler"/>. It resolves the sitemap seeds for a site, walks any
+/// sitemap index into its child sitemaps, and returns the discovered page entries together with the
+/// change metadata each sitemap advertises. Discovery is bounded so a misconfigured or hostile site
+/// cannot loop forever or download an unbounded number of documents.
+/// </summary>
+public sealed class SitemapCrawler : ISitemapCrawler
+{
+    /// <summary>
+    /// The maximum number of nested sitemap levels the crawler follows. A sitemap index may point at
+    /// child indexes; this bounds that recursion so a misconfigured or hostile site cannot loop forever.
+    /// </summary>
+    private const int MaxSitemapDepth = 5;
+
+    /// <summary>
+    /// The maximum number of sitemap documents (indexes and leaf sitemaps combined) the crawler downloads
+    /// while discovering page URLs for a single site.
+    /// </summary>
+    private const int MaxSitemapDocuments = 50;
+
+    private readonly ILogger<SitemapCrawler> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SitemapCrawler"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    public SitemapCrawler(ILogger<SitemapCrawler> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SitemapEntry>> DiscoverAsync(
+        HttpClient client,
+        SitemapCrawlRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var maxPages = Math.Max(1, request.MaxPages);
+        var seeds = await ResolveSitemapSeedsAsync(client, request, cancellationToken);
+
+        var entries = new List<SitemapEntry>();
+        var seenPages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visitedSitemaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<(string Url, int Depth)>();
+
+        foreach (var seed in seeds)
+        {
+            if (visitedSitemaps.Add(seed))
+            {
+                queue.Enqueue((seed, 0));
+            }
+        }
+
+        var processedSitemaps = 0;
+
+        while (queue.Count > 0 && entries.Count < maxPages && processedSitemaps < MaxSitemapDocuments)
+        {
+            var (sitemapUrl, depth) = queue.Dequeue();
+            processedSitemaps++;
+
+            var content = await DownloadSitemapContentAsync(client, sitemapUrl, cancellationToken);
+
+            if (content is null)
+            {
+                continue;
+            }
+
+            var (childSitemaps, pages) = ParseSitemap(content);
+
+            foreach (var page in pages)
+            {
+                if (entries.Count >= maxPages)
+                {
+                    break;
+                }
+
+                if (seenPages.Add(page.Url))
+                {
+                    entries.Add(page);
+                }
+            }
+
+            if (depth < MaxSitemapDepth)
+            {
+                foreach (var child in childSitemaps)
+                {
+                    if (visitedSitemaps.Add(child))
+                    {
+                        queue.Enqueue((child, depth + 1));
+                    }
+                }
+            }
+        }
+
+        return entries;
+    }
+
+    /// <summary>
+    /// Determines the sitemap URLs to start crawling from. An explicitly configured sitemap URL wins;
+    /// otherwise the crawler consults <c>robots.txt</c> and the conventional sitemap locations under the
+    /// base URL.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> ResolveSitemapSeedsAsync(HttpClient client, SitemapCrawlRequest request, CancellationToken cancellationToken)
+    {
+        var seeds = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string url)
+        {
+            if (!string.IsNullOrWhiteSpace(url) && seen.Add(url.Trim()))
+            {
+                seeds.Add(url.Trim());
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SitemapUrl))
+        {
+            Add(request.SitemapUrl);
+
+            return seeds;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.BaseUrl))
+        {
+            foreach (var advertised in await GetRobotsSitemapsAsync(client, request.BaseUrl, cancellationToken))
+            {
+                Add(advertised);
+            }
+
+            var baseUrl = request.BaseUrl.TrimEnd('/');
+
+            // The two conventional locations. Yoast/Rank Math sites typically redirect /sitemap.xml to
+            // their index; HttpClient follows those redirects, and unreachable candidates fail gracefully.
+            Add($"{baseUrl}/sitemap.xml");
+            Add($"{baseUrl}/sitemap_index.xml");
+        }
+
+        return seeds;
+    }
+
+    /// <summary>
+    /// Reads any <c>Sitemap:</c> directives advertised in the site's <c>robots.txt</c>.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> GetRobotsSitemapsAsync(HttpClient client, string baseUrl, CancellationToken cancellationToken)
+    {
+        const string directive = "Sitemap:";
+        var robotsUrl = $"{baseUrl.TrimEnd('/')}/robots.txt";
+
+        try
+        {
+            var content = await client.GetStringAsync(robotsUrl, cancellationToken);
+            var results = new List<string>();
+
+            foreach (var line in content.Split('\n'))
+            {
+                var trimmed = line.Trim();
+
+                if (trimmed.StartsWith(directive, StringComparison.OrdinalIgnoreCase))
+                {
+                    var value = trimmed[directive.Length..].Trim();
+
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        results.Add(value);
+                    }
+                }
+            }
+
+            return results;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "Failed to read robots.txt '{RobotsUrl}' during sitemap discovery.", robotsUrl);
+            }
+
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Downloads a sitemap document and returns its decoded text, transparently decompressing gzip
+    /// payloads (both <c>.xml.gz</c> files and gzip-encoded responses).
+    /// </summary>
+    private async Task<string> DownloadSitemapContentAsync(HttpClient client, string url, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var bytes = await client.GetByteArrayAsync(url, cancellationToken);
+
+            if (bytes.Length == 0)
+            {
+                return null;
+            }
+
+            // Gzip files begin with the magic bytes 0x1F 0x8B. This covers .xml.gz sitemaps served with a
+            // binary content type, which HttpClient's automatic decompression does not unwrap.
+            if (bytes.Length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B)
+            {
+                bytes = Decompress(bytes);
+            }
+
+            return DecodeText(bytes);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read sitemap '{SitemapUrl}' during sitemap discovery.", url);
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses a sitemap document, separating child sitemap URLs (from a sitemap index) from page entries.
+    /// Supports the standard <c>&lt;urlset&gt;</c> and <c>&lt;sitemapindex&gt;</c> XML formats (including
+    /// the News/Image/Video extensions, whose page URL is the <c>&lt;url&gt;&lt;loc&gt;</c>), RSS 2.0 and
+    /// Atom 1.0 feeds (which Google also accepts as sitemaps), and plain-text sitemaps. Page entries are
+    /// classified by their parent element so that asset locations such as <c>&lt;image:loc&gt;</c> and
+    /// <c>&lt;video:loc&gt;</c> are ignored.
+    /// </summary>
+    private static (IReadOnlyList<string> ChildSitemaps, IReadOnlyList<SitemapEntry> Pages) ParseSitemap(string content)
+    {
+        var childSitemaps = new List<string>();
+        var pages = new List<SitemapEntry>();
+
+        XDocument document = null;
+
+        try
+        {
+            document = XDocument.Parse(content);
+        }
+        catch
+        {
+            // Not XML. Fall through to the plain-text sitemap handling below.
+        }
+
+        if (document is not null)
+        {
+            foreach (var element in document.Descendants())
+            {
+                var name = element.Name.LocalName;
+
+                if (string.Equals(name, "sitemap", StringComparison.OrdinalIgnoreCase))
+                {
+                    var loc = GetChildValue(element, "loc");
+
+                    if (!string.IsNullOrEmpty(loc))
+                    {
+                        childSitemaps.Add(loc);
+                    }
+                }
+                else if (string.Equals(name, "url", StringComparison.OrdinalIgnoreCase))
+                {
+                    var loc = GetChildValue(element, "loc");
+
+                    if (!string.IsNullOrEmpty(loc))
+                    {
+                        pages.Add(new SitemapEntry(
+                            loc,
+                            ParseLastModified(GetChildValue(element, "lastmod")),
+                            NormalizeChangeFrequency(GetChildValue(element, "changefreq")),
+                            ParsePriority(GetChildValue(element, "priority"))));
+                    }
+                }
+            }
+
+            // No sitemaps.org <url>/<sitemap> elements were found. The document may be an RSS 2.0 or Atom
+            // 1.0 feed, which Google also accepts as a sitemap format.
+            if (childSitemaps.Count == 0 && pages.Count == 0)
+            {
+                ExtractFeedEntries(document, pages);
+            }
+
+            return (childSitemaps, pages);
+        }
+
+        // Plain-text sitemap: one absolute URL per line.
+        foreach (var line in content.Split('\n'))
+        {
+            var trimmed = line.Trim();
+
+            if (trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                pages.Add(new SitemapEntry(trimmed));
+            }
+        }
+
+        return (childSitemaps, pages);
+    }
+
+    /// <summary>
+    /// Extracts item/entry URLs from an RSS 2.0 or Atom 1.0 feed. RSS items carry the URL as the text of a
+    /// <c>&lt;link&gt;</c> element and a timestamp in <c>&lt;pubDate&gt;</c>; Atom entries carry the URL in
+    /// the <c>href</c> attribute of an <c>&lt;link&gt;</c> element (preferring the <c>alternate</c>
+    /// relation) and a timestamp in <c>&lt;updated&gt;</c>. Feed-level links (the channel or feed homepage)
+    /// are ignored because only <c>&lt;item&gt;</c> and <c>&lt;entry&gt;</c> links are read.
+    /// </summary>
+    private static void ExtractFeedEntries(XDocument document, List<SitemapEntry> pages)
+    {
+        foreach (var element in document.Descendants())
+        {
+            var name = element.Name.LocalName;
+
+            if (string.Equals(name, "item", StringComparison.OrdinalIgnoreCase))
+            {
+                var link = element.Elements()
+                    .FirstOrDefault(child => string.Equals(child.Name.LocalName, "link", StringComparison.OrdinalIgnoreCase));
+
+                // RSS uses the element text; some feeds instead carry an Atom-style href.
+                var url = link?.Value?.Trim();
+
+                if (string.IsNullOrEmpty(url))
+                {
+                    url = link?.Attribute("href")?.Value?.Trim();
+                }
+
+                if (!string.IsNullOrEmpty(url))
+                {
+                    pages.Add(new SitemapEntry(url, ParseLastModified(GetChildValue(element, "pubDate"))));
+                }
+            }
+            else if (string.Equals(name, "entry", StringComparison.OrdinalIgnoreCase))
+            {
+                var links = element.Elements()
+                    .Where(child => string.Equals(child.Name.LocalName, "link", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                // Prefer the alternate (or unspecified) relation; never the self/edit/enclosure links.
+                var preferred = links.FirstOrDefault(child =>
+                {
+                    var rel = child.Attribute("rel")?.Value;
+
+                    return string.IsNullOrEmpty(rel) || string.Equals(rel, "alternate", StringComparison.OrdinalIgnoreCase);
+                }) ?? links.FirstOrDefault();
+
+                var url = preferred?.Attribute("href")?.Value?.Trim();
+
+                if (!string.IsNullOrEmpty(url))
+                {
+                    pages.Add(new SitemapEntry(url, ParseLastModified(GetChildValue(element, "updated"))));
+                }
+            }
+        }
+    }
+
+    private static string GetChildValue(XElement parent, string localName)
+    {
+        var child = parent.Elements()
+            .FirstOrDefault(element => string.Equals(element.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase));
+
+        return child?.Value?.Trim();
+    }
+
+    private static DateTimeOffset? ParseLastModified(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    private static string NormalizeChangeFrequency(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return value.Trim().ToLowerInvariant();
+    }
+
+    private static double? ParsePriority(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    private static byte[] Decompress(byte[] input)
+    {
+        using var source = new MemoryStream(input);
+        using var gzip = new GZipStream(source, CompressionMode.Decompress);
+        using var destination = new MemoryStream();
+
+        gzip.CopyTo(destination);
+
+        return destination.ToArray();
+    }
+
+    private static string DecodeText(byte[] bytes)
+    {
+        var text = Encoding.UTF8.GetString(bytes);
+
+        // Strip a leading UTF-8 byte-order mark (U+FEFF) so XDocument.Parse does not choke on it.
+        return text.TrimStart('﻿');
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapEntry.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Crawling/SitemapEntry.cs
@@ -1,0 +1,26 @@
+namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+
+/// <summary>
+/// Represents a single page discovered while walking a site's sitemap graph, together with the change
+/// metadata a sitemap can advertise. The change metadata (<see cref="LastModifiedUtc"/> and
+/// <see cref="ChangeFrequency"/>) lets a re-indexing process decide which pages actually need to be
+/// fetched again instead of re-crawling the whole site.
+/// </summary>
+/// <param name="Url">The canonical, absolute URL of the page.</param>
+/// <param name="LastModifiedUtc">
+/// The UTC timestamp advertised by the sitemap's <c>&lt;lastmod&gt;</c> element (or an equivalent feed
+/// field), or <see langword="null"/> when the sitemap does not report one.
+/// </param>
+/// <param name="ChangeFrequency">
+/// The advertised <c>&lt;changefreq&gt;</c> hint (for example <c>daily</c> or <c>weekly</c>), or
+/// <see langword="null"/> when the sitemap does not report one.
+/// </param>
+/// <param name="Priority">
+/// The advertised <c>&lt;priority&gt;</c> value between 0.0 and 1.0, or <see langword="null"/> when the
+/// sitemap does not report one.
+/// </param>
+public sealed record SitemapEntry(
+    string Url,
+    DateTimeOffset? LastModifiedUtc = null,
+    string ChangeFrequency = null,
+    double? Priority = null);

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/CrestApps.Core.AI.WebCrawlers.csproj
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/CrestApps.Core.AI.WebCrawlers.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CrestApps.Core.AI.WebCrawlers</RootNamespace>
+    <Title>CrestApps AI Web Crawlers</Title>
+    <Description>
+      $(CrestAppsDescription)
+
+      Strategy-based web crawlers that scrape public websites (starting with sitemap discovery) and
+      populate CrestApps AI data sources for retrieval-augmented generation.
+    </Description>
+    <PackageTags>$(PackageTags) web crawler scraper sitemap ai data-sources rag</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DataIngestion" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../CrestApps.Core.AI/CrestApps.Core.AI.csproj" />
+    <ProjectReference Include="../CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj" />
+    <ProjectReference Include="../../Abstractions/CrestApps.Core.Infrastructure.Abstractions/CrestApps.Core.Infrastructure.Abstractions.csproj" />
+    <ProjectReference Include="../CrestApps.Core.Infrastructure/CrestApps.Core.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Handlers/WebCrawlerCatalogHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Handlers/WebCrawlerCatalogHandler.cs
@@ -1,0 +1,215 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
+using System.Text.Json.Nodes;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.Handlers;
+using CrestApps.Core.Models;
+using CrestApps.Core.Support;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.WebCrawlers.Handlers;
+
+/// <summary>
+/// Authoritative catalog handler for <see cref="WebCrawler"/>: applies create-time defaults, validates
+/// required fields plus the selected strategy's settings, and keeps the target data source's knowledge
+/// base aligned by queueing a full synchronization when a crawler changes.
+/// </summary>
+internal sealed class WebCrawlerCatalogHandler : CatalogEntryHandlerBase<WebCrawler>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly TimeProvider _timeProvider;
+    private readonly IAIDataSourceStore _dataSourceStore;
+    private readonly IAIDataSourceIndexingQueue _indexingQueue;
+    private readonly IWebCrawlStateStore _crawlStateStore;
+    private readonly IWebCrawlerStrategyResolver _strategyResolver;
+    private readonly ILogger<WebCrawlerCatalogHandler> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerCatalogHandler"/> class.
+    /// </summary>
+    /// <param name="httpContextAccessor">The HTTP context accessor.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="dataSourceStore">The AI data source store.</param>
+    /// <param name="indexingQueue">The data source indexing queue.</param>
+    /// <param name="crawlStateStore">The crawl-state store.</param>
+    /// <param name="strategyResolver">The strategy resolver.</param>
+    /// <param name="logger">The logger.</param>
+    public WebCrawlerCatalogHandler(
+        IHttpContextAccessor httpContextAccessor,
+        TimeProvider timeProvider,
+        IAIDataSourceStore dataSourceStore,
+        IAIDataSourceIndexingQueue indexingQueue,
+        IWebCrawlStateStore crawlStateStore,
+        IWebCrawlerStrategyResolver strategyResolver,
+        ILogger<WebCrawlerCatalogHandler> logger)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _timeProvider = timeProvider;
+        _dataSourceStore = dataSourceStore;
+        _indexingQueue = indexingQueue;
+        _crawlStateStore = crawlStateStore;
+        _strategyResolver = strategyResolver;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public override Task InitializingAsync(InitializingContext<WebCrawler> context, CancellationToken cancellationToken = default)
+        => PopulateAsync(context.Model, context.Data);
+
+    /// <inheritdoc />
+    public override async Task UpdatingAsync(UpdatingContext<WebCrawler> context, CancellationToken cancellationToken = default)
+    {
+        await PopulateAsync(context.Model, context.Data);
+        context.Model.ModifiedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+    }
+
+    /// <inheritdoc />
+    public override Task InitializedAsync(InitializedContext<WebCrawler> context, CancellationToken cancellationToken = default)
+    {
+        EnsureCreatedDefaults(context.Model);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override Task CreatingAsync(CreatingContext<WebCrawler> context, CancellationToken cancellationToken = default)
+    {
+        EnsureCreatedDefaults(context.Model);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override async Task ValidatingAsync(ValidatingContext<WebCrawler> context, CancellationToken cancellationToken = default)
+    {
+        var crawler = context.Model;
+
+        if (string.IsNullOrWhiteSpace(crawler.DisplayText))
+        {
+            context.Result.Fail(new ValidationResult("Display text is required.", [nameof(WebCrawler.DisplayText)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(crawler.AIDataSourceId))
+        {
+            context.Result.Fail(new ValidationResult("A target Web data source is required.", [nameof(WebCrawler.AIDataSourceId)]));
+        }
+
+        if (string.IsNullOrWhiteSpace(crawler.Source))
+        {
+            context.Result.Fail(new ValidationResult("A crawl strategy is required.", [nameof(WebCrawler.Source)]));
+
+            return;
+        }
+
+        var strategy = _strategyResolver.Get(crawler.Source);
+
+        if (strategy is null)
+        {
+            context.Result.Fail(new ValidationResult("The selected crawl strategy is not supported.", [nameof(WebCrawler.Source)]));
+
+            return;
+        }
+
+        await strategy.ValidateAsync(crawler, context.Result, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override Task CreatedAsync(CreatedContext<WebCrawler> context, CancellationToken cancellationToken = default)
+        => QueueDataSourceSyncAsync(context.Model, nameof(CreatedAsync), cancellationToken);
+
+    /// <inheritdoc />
+    public override Task UpdatedAsync(UpdatedContext<WebCrawler> context, CancellationToken cancellationToken = default)
+        => QueueDataSourceSyncAsync(context.Model, nameof(UpdatedAsync), cancellationToken);
+
+    /// <inheritdoc />
+    public override async Task DeletedAsync(DeletedContext<WebCrawler> context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _crawlStateStore.DeleteByCrawlerIdAsync(context.Model.ItemId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete crawl state for web crawler '{CrawlerId}'.", context.Model.ItemId);
+        }
+
+        await QueueDataSourceSyncAsync(context.Model, nameof(DeletedAsync), cancellationToken);
+    }
+
+    private async Task QueueDataSourceSyncAsync(WebCrawler crawler, string eventName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(crawler.AIDataSourceId))
+        {
+            return;
+        }
+
+        try
+        {
+            var dataSource = await _dataSourceStore.FindByIdAsync(crawler.AIDataSourceId, cancellationToken);
+
+            if (dataSource is null)
+            {
+                return;
+            }
+
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                _logger.LogTrace("Web crawler catalog event '{EventName}' queued a full synchronization for data source '{DataSourceId}'.", eventName, dataSource.ItemId);
+            }
+
+            await _indexingQueue.QueueSyncDataSourceAsync(dataSource, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to queue synchronization for web crawler '{CrawlerId}'.", crawler.ItemId);
+        }
+    }
+
+    private void EnsureCreatedDefaults(WebCrawler crawler)
+    {
+        if (crawler.CreatedUtc == default)
+        {
+            crawler.CreatedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        }
+
+        var user = _httpContextAccessor.HttpContext?.User;
+
+        if (user is null)
+        {
+            return;
+        }
+
+        crawler.OwnerId ??= user.FindFirstValue(ClaimTypes.NameIdentifier);
+        crawler.Author ??= user.Identity?.Name;
+    }
+
+    private static Task PopulateAsync(WebCrawler crawler, JsonNode data)
+    {
+        if (data is not JsonObject json)
+        {
+            return Task.CompletedTask;
+        }
+
+        json.TryUpdateTrimmedStringValue(nameof(WebCrawler.DisplayText), value => crawler.DisplayText = value);
+        json.TryUpdateTrimmedStringValue(nameof(WebCrawler.AIDataSourceId), value => crawler.AIDataSourceId = value);
+        json.TryUpdateTrimmedStringValue(nameof(WebCrawler.Source), value => crawler.Source = value);
+        json.TryUpdateTrimmedStringValue(nameof(WebCrawler.OwnerId), value => crawler.OwnerId = value);
+        json.TryUpdateTrimmedStringValue(nameof(WebCrawler.Author), value => crawler.Author = value);
+
+        if (json.TryGetBooleanValue(nameof(WebCrawler.Enabled), out var enabled))
+        {
+            crawler.Enabled = enabled;
+        }
+
+        if (json.TryGetNullableInt32Value(nameof(WebCrawler.ReindexIntervalMinutes), out var reindexIntervalMinutes))
+        {
+            crawler.ReindexIntervalMinutes = reindexIntervalMinutes;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/IWebCrawlerReindexPlanner.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/IWebCrawlerReindexPlanner.cs
@@ -1,0 +1,20 @@
+using CrestApps.Core.AI.Models;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Computes and enqueues the incremental re-index work for one <see cref="WebCrawler"/> by diffing a fresh
+/// crawl against the recorded per-page crawl state. This is the reusable unit of work the background
+/// service (or any host that wants its own scheduling) drives.
+/// </summary>
+public interface IWebCrawlerReindexPlanner
+{
+    /// <summary>
+    /// Re-crawls the site, diffs it against the stored crawl state, and enqueues the pages that were added,
+    /// changed, or removed into the crawler's target data source. Unchanged pages are skipped.
+    /// </summary>
+    /// <param name="crawler">The crawler to re-index.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A summary of the planned work.</returns>
+    Task<WebCrawlerReindexResult> PlanAndEnqueueAsync(WebCrawler crawler, CancellationToken cancellationToken = default);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/IWebCrawlerReindexService.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/IWebCrawlerReindexService.cs
@@ -1,0 +1,21 @@
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Orchestrates re-indexing across every configured web crawler. This is the reusable unit of work driven
+/// by <see cref="WebCrawlerReindexBackgroundService"/>; hosts that prefer their own scheduling (or a manual
+/// trigger) can invoke it directly instead.
+/// </summary>
+public interface IWebCrawlerReindexService
+{
+    /// <summary>
+    /// Re-indexes every enabled crawler that is due per its re-index interval.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task ReindexDueAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Re-indexes every enabled crawler immediately, regardless of its re-index interval.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    Task ReindexAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtensions
             new LocalizedString("Sitemap Strategy Description", "Discover pages through the site's sitemap(s) and scrape each page as text.")));
 
         services.TryAddScoped<IWebCrawlerReindexPlanner, WebCrawlerReindexPlanner>();
+        services.TryAddScoped<IWebCrawlerReindexService, WebCrawlerReindexService>();
         services.TryAddKeyedScoped<IAIDataSourceSourceHandler, WebAIDataSourceSourceHandler>(AIDataSourceSourceTypes.Web);
         services.TryAddKeyedSingleton<IAIReferenceLinkResolver, WebCrawlerReferenceLinkResolver>(AIDataSourceSourceTypes.Web);
         services.TryAddEnumerable(ServiceDescriptor.Scoped<ICatalogEntryHandler<WebCrawler>, WebCrawlerCatalogHandler>());

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using CrestApps.Core;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Profiles;
+using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.WebCrawlers.Handlers;
+using CrestApps.Core.DataIngestion;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+using CrestApps.Core.Handlers;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Localization;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Registration helpers for the web-crawlers feature.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the web-crawlers feature: the <c>Web</c> AI data source source handler and citation link
+    /// resolver, the crawl strategies (starting with sitemap discovery), the re-index planner and its
+    /// scheduled background service, the crawler catalog handler, and the shared crawling primitives. The
+    /// <see cref="IWebCrawlerStore"/> and <see cref="IWebCrawlStateStore"/> are provided by the persistence
+    /// layer (call the matching YesSql or EntityCore registration).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddCoreWebCrawlers(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddOptions<WebCrawlerOptions>();
+        services.AddOptions<WebCrawlerStrategyOptions>();
+        services.AddCatalogManagers();
+        services.AddCoreWebCrawlerCrawling();
+
+        services
+            .AddHttpClient(WebCrawlerConstants.HttpClientName, client =>
+            {
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("CrestApps-WebCrawler/1.0 (+https://crestapps.com)");
+                client.Timeout = TimeSpan.FromSeconds(60);
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                // Transparently decompress sitemaps and pages and follow the redirects that sites such as
+                // Yoast/Rank Math use for /sitemap.xml.
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
+                AllowAutoRedirect = true,
+            });
+
+        services.TryAddSingleton<IWebCrawlerStrategyResolver, WebCrawlerStrategyResolver>();
+        services.TryAddKeyedSingleton<IWebCrawlerStrategy, SitemapWebCrawlerStrategy>(WebCrawlerConstants.Strategies.Sitemap);
+        services.Configure<WebCrawlerStrategyOptions>(options => options.AddOrUpdate(
+            WebCrawlerConstants.Strategies.Sitemap,
+            new LocalizedString("Sitemap", "Sitemap"),
+            new LocalizedString("Sitemap Strategy Description", "Discover pages through the site's sitemap(s) and scrape each page as text.")));
+
+        services.TryAddScoped<IWebCrawlerReindexPlanner, WebCrawlerReindexPlanner>();
+        services.TryAddKeyedScoped<IAIDataSourceSourceHandler, WebAIDataSourceSourceHandler>(AIDataSourceSourceTypes.Web);
+        services.TryAddKeyedSingleton<IAIReferenceLinkResolver, WebCrawlerReferenceLinkResolver>(AIDataSourceSourceTypes.Web);
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<ICatalogEntryHandler<WebCrawler>, WebCrawlerCatalogHandler>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WebCrawlerReindexBackgroundService>());
+
+        services.Configure<AIDataSourceSourceOptions>(options => options.AddOrUpdate(
+            AIDataSourceSourceTypes.Web,
+            new LocalizedString("Web", "Web"),
+            new LocalizedString("Web Source Description", "A target for web crawlers. Configure the sites to scrape in the Web Crawlers area; each page is indexed with its URL kept for citations.")));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the shared sitemap crawler primitive. Page content is cleaned through the static
+    /// <see cref="HtmlIngestionDocumentReader"/>. Registration is idempotent.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddCoreWebCrawlerCrawling(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<ISitemapCrawler, SitemapCrawler>();
+
+        return services;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/ServiceCollectionExtensions.cs
@@ -3,7 +3,7 @@ using CrestApps.Core;
 using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Profiles;
-using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.AI.WebCrawlers.Handlers;
 using CrestApps.Core.DataIngestion;
 using CrestApps.Core.AI.WebCrawlers.Strategies;

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/CrawledPage.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/CrawledPage.cs
@@ -1,0 +1,8 @@
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// The cleaned title and plain-text body of a fetched page.
+/// </summary>
+/// <param name="Title">The page title, or <see langword="null"/>.</param>
+/// <param name="Content">The plain-text body with markup removed.</param>
+public sealed record CrawledPage(string Title, string Content);

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/CrawledPageRef.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/CrawledPageRef.cs
@@ -1,0 +1,13 @@
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// A page discovered by a crawl strategy, together with the change metadata used to decide whether the
+/// page needs to be re-fetched.
+/// </summary>
+/// <param name="Url">The canonical, absolute URL of the page.</param>
+/// <param name="LastModifiedUtc">The advertised last-modified timestamp, or <see langword="null"/>.</param>
+/// <param name="ChangeFrequency">The advertised change-frequency hint, or <see langword="null"/>.</param>
+public sealed record CrawledPageRef(
+    string Url,
+    DateTimeOffset? LastModifiedUtc = null,
+    string ChangeFrequency = null);

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/IWebCrawlerStrategy.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/IWebCrawlerStrategy.cs
@@ -1,0 +1,43 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Models;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// A pluggable web-crawl strategy. A strategy defines how a site is discovered (which pages exist and
+/// when they changed) and how a single page is fetched and cleaned. Implementations are registered keyed
+/// by <see cref="Name"/>. Today the only built-in strategy is sitemap discovery; future strategies (for
+/// example depth-limited link following) plug in without changing the data source or the UI.
+/// </summary>
+public interface IWebCrawlerStrategy
+{
+    /// <summary>
+    /// Gets the strategy identifier (for example <c>Sitemap</c>).
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Validates the crawler's strategy-specific settings.
+    /// </summary>
+    /// <param name="crawler">The crawler to validate.</param>
+    /// <param name="result">The validation result collector.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    ValueTask ValidateAsync(WebCrawler crawler, ValidationResultDetails result, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Discovers the current set of pages for the crawler, together with their change metadata.
+    /// </summary>
+    /// <param name="crawler">The crawler configuration.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The discovered pages.</returns>
+    Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches and cleans a single page.
+    /// </summary>
+    /// <param name="crawler">The crawler configuration.</param>
+    /// <param name="url">The page URL to fetch.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The cleaned page, or <see langword="null"/> when the page could not be fetched or was empty.</returns>
+    Task<CrawledPage> FetchAsync(WebCrawler crawler, string url, CancellationToken cancellationToken = default);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/IWebCrawlerStrategyResolver.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/IWebCrawlerStrategyResolver.cs
@@ -1,0 +1,15 @@
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// Resolves a registered <see cref="IWebCrawlerStrategy"/> by its identifier.
+/// </summary>
+public interface IWebCrawlerStrategyResolver
+{
+    /// <summary>
+    /// Gets the strategy registered under the specified identifier, or <see langword="null"/> when none is
+    /// registered.
+    /// </summary>
+    /// <param name="strategy">The strategy identifier.</param>
+    /// <returns>The strategy, or <see langword="null"/>.</returns>
+    IWebCrawlerStrategy Get(string strategy);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerHelper.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerHelper.cs
@@ -1,0 +1,128 @@
+using System.Text.RegularExpressions;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers.Crawling;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+
+/// <summary>
+/// Resolves the effective sitemap-strategy configuration for a crawler by merging its
+/// <see cref="SitemapWebCrawlerMetadata"/> with the global <see cref="WebCrawlerOptions"/>, and builds the
+/// derived crawl request and URL filter.
+/// </summary>
+internal static class SitemapWebCrawlerHelper
+{
+    /// <summary>
+    /// Attempts to read the sitemap metadata from the crawler.
+    /// </summary>
+    /// <param name="crawler">The crawler.</param>
+    /// <param name="metadata">The resolved metadata when present.</param>
+    /// <returns><see langword="true"/> when metadata is present and specifies a site; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetMetadata(WebCrawler crawler, out SitemapWebCrawlerMetadata metadata)
+    {
+        if (crawler.TryGet(out metadata) &&
+            (!string.IsNullOrWhiteSpace(metadata.BaseUrl) || !string.IsNullOrWhiteSpace(metadata.SitemapUrl)))
+        {
+            return true;
+        }
+
+        metadata = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the sitemap discovery request for the resolved configuration.
+    /// </summary>
+    /// <param name="metadata">The crawler metadata.</param>
+    /// <param name="options">The global options.</param>
+    /// <returns>The crawl request.</returns>
+    public static SitemapCrawlRequest CreateCrawlRequest(SitemapWebCrawlerMetadata metadata, WebCrawlerOptions options)
+    {
+        return new SitemapCrawlRequest
+        {
+            BaseUrl = metadata.BaseUrl,
+            SitemapUrl = metadata.SitemapUrl,
+            MaxPages = Math.Max(1, metadata.MaxPages ?? options.DefaultMaxPages),
+        };
+    }
+
+    /// <summary>
+    /// Resolves the effective per-request fetch timeout.
+    /// </summary>
+    /// <param name="metadata">The crawler metadata.</param>
+    /// <param name="options">The global options.</param>
+    /// <returns>The effective timeout.</returns>
+    public static TimeSpan ResolveRequestTimeout(SitemapWebCrawlerMetadata metadata, WebCrawlerOptions options)
+    {
+        var seconds = Math.Max(1, metadata.RequestTimeoutSeconds ?? options.DefaultRequestTimeoutSeconds);
+
+        return TimeSpan.FromSeconds(seconds);
+    }
+
+    /// <summary>
+    /// Resolves the effective <c>User-Agent</c> header.
+    /// </summary>
+    /// <param name="metadata">The crawler metadata.</param>
+    /// <param name="options">The global options.</param>
+    /// <returns>The effective user agent.</returns>
+    public static string ResolveUserAgent(SitemapWebCrawlerMetadata metadata, WebCrawlerOptions options)
+    {
+        return string.IsNullOrWhiteSpace(metadata.UserAgent) ? options.DefaultUserAgent : metadata.UserAgent;
+    }
+
+    /// <summary>
+    /// Compiles the include/exclude URL patterns into a predicate. Invalid patterns are skipped. When no
+    /// include patterns are configured, every URL is eligible; exclude patterns are always applied.
+    /// </summary>
+    /// <param name="metadata">The crawler metadata.</param>
+    /// <returns>A predicate returning <see langword="true"/> when a URL should be scraped.</returns>
+    public static Func<string, bool> CreateUrlFilter(SitemapWebCrawlerMetadata metadata)
+    {
+        var includes = CompilePatterns(metadata.IncludeUrlPatterns);
+        var excludes = CompilePatterns(metadata.ExcludeUrlPatterns);
+
+        if (includes.Count == 0 && excludes.Count == 0)
+        {
+            return static _ => true;
+        }
+
+        return url =>
+        {
+            if (includes.Count > 0 && !includes.Any(pattern => pattern.IsMatch(url)))
+            {
+                return false;
+            }
+
+            return !excludes.Any(pattern => pattern.IsMatch(url));
+        };
+    }
+
+    private static List<Regex> CompilePatterns(IEnumerable<string> patterns)
+    {
+        var compiled = new List<Regex>();
+
+        if (patterns is null)
+        {
+            return compiled;
+        }
+
+        foreach (var pattern in patterns)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                continue;
+            }
+
+            try
+            {
+                compiled.Add(new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant));
+            }
+            catch (ArgumentException)
+            {
+                // A malformed pattern is ignored rather than failing the whole crawl.
+            }
+        }
+
+        return compiled;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerHelper.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerHelper.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.Crawling;
 
 namespace CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
 

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerMetadata.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerMetadata.cs
@@ -1,0 +1,52 @@
+namespace CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+
+/// <summary>
+/// Settings for the sitemap crawl strategy, stored in a <see cref="CrestApps.Core.AI.Models.WebCrawler"/>'s
+/// properties: which site to scrape and how much of it.
+/// </summary>
+public sealed class SitemapWebCrawlerMetadata
+{
+    /// <summary>
+    /// Gets or sets the base URL of the site to scrape. Used to resolve the sitemap through
+    /// <c>robots.txt</c> and the conventional locations when <see cref="SitemapUrl"/> is not supplied.
+    /// </summary>
+    public string BaseUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets an explicit sitemap or sitemap-index URL. When set, discovery starts from this URL.
+    /// </summary>
+    public string SitemapUrl { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of pages to scrape. When not set, the global default is used.
+    /// </summary>
+    public int? MaxPages { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent page requests. When not set, the global default is used.
+    /// </summary>
+    public int? MaxConcurrentRequests { get; set; }
+
+    /// <summary>
+    /// Gets or sets the per-request fetch timeout, in seconds. When not set, the global default is used.
+    /// </summary>
+    public int? RequestTimeoutSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the regular-expression patterns a page URL must match to be scraped. When empty, every
+    /// discovered page is eligible.
+    /// </summary>
+    public List<string> IncludeUrlPatterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets the regular-expression patterns that exclude a page URL from scraping. Applied after
+    /// <see cref="IncludeUrlPatterns"/>.
+    /// </summary>
+    public List<string> ExcludeUrlPatterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets the <c>User-Agent</c> header presented while crawling. When not set, the global default
+    /// is used.
+    /// </summary>
+    public string UserAgent { get; set; }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text;
-using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Crawling;
+using CrestApps.Core.AI.Models;
 using CrestApps.Core.DataIngestion;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
@@ -116,6 +116,18 @@ public sealed class SitemapWebCrawlerStrategy : IWebCrawlerStrategy
             using var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead, timeoutSource.Token);
             response.EnsureSuccessStatusCode();
 
+            if (!IsSupportedPageContent(response.Content.Headers.ContentType?.MediaType, url))
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Skipping non-HTML web-crawler response '{Url}' with content type '{ContentType}'.",
+                        url,
+                        response.Content.Headers.ContentType?.MediaType);
+                }
+
+                return null;
+            }
+
             var html = await response.Content.ReadAsStringAsync(timeoutSource.Token);
             var title = HtmlIngestionDocumentReader.ExtractTitle(html);
             var document = HtmlIngestionDocumentReader.Read(html, url);
@@ -176,5 +188,31 @@ public sealed class SitemapWebCrawlerStrategy : IWebCrawlerStrategy
 
         return Uri.TryCreate(value.Trim(), UriKind.Absolute, out uri) &&
             (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+
+    private static bool IsSupportedPageContent(string mediaType, string url)
+    {
+        if (string.Equals(mediaType, "text/html", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(mediaType, "application/xhtml+xml", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(mediaType))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return true;
+        }
+
+        var extension = Path.GetExtension(uri.AbsolutePath);
+
+        return string.IsNullOrEmpty(extension) ||
+            string.Equals(extension, ".htm", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".html", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".xhtml", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
@@ -1,0 +1,180 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.DataIngestion;
+using CrestApps.Core.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+
+/// <summary>
+/// The sitemap crawl strategy. It discovers pages by walking a site's sitemap(s) and fetches each page as
+/// cleaned plain text, using the shared <see cref="ISitemapCrawler"/> and
+/// <see cref="IWebPageContentExtractor"/>.
+/// </summary>
+public sealed class SitemapWebCrawlerStrategy : IWebCrawlerStrategy
+{
+    private readonly ISitemapCrawler _sitemapCrawler;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly WebCrawlerOptions _options;
+    private readonly ILogger<SitemapWebCrawlerStrategy> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SitemapWebCrawlerStrategy"/> class.
+    /// </summary>
+    /// <param name="sitemapCrawler">The sitemap crawler.</param>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
+    /// <param name="options">The web-crawler options.</param>
+    /// <param name="logger">The logger.</param>
+    public SitemapWebCrawlerStrategy(
+        ISitemapCrawler sitemapCrawler,
+        IHttpClientFactory httpClientFactory,
+        IOptions<WebCrawlerOptions> options,
+        ILogger<SitemapWebCrawlerStrategy> logger)
+    {
+        _sitemapCrawler = sitemapCrawler;
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => WebCrawlerConstants.Strategies.Sitemap;
+
+    /// <inheritdoc />
+    public ValueTask ValidateAsync(WebCrawler crawler, ValidationResultDetails result, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+        ArgumentNullException.ThrowIfNull(result);
+
+        crawler.TryGet<SitemapWebCrawlerMetadata>(out var metadata);
+        var hasBaseUrl = TryCreateAbsoluteUrl(metadata?.BaseUrl, out _);
+        var hasSitemapUrl = TryCreateAbsoluteUrl(metadata?.SitemapUrl, out _);
+
+        if (!hasBaseUrl && !hasSitemapUrl)
+        {
+            result.Fail(new ValidationResult(
+                "A valid website base URL or sitemap URL is required.",
+                [nameof(SitemapWebCrawlerMetadata.BaseUrl), nameof(SitemapWebCrawlerMetadata.SitemapUrl)]));
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+
+        if (!SitemapWebCrawlerHelper.TryGetMetadata(crawler, out var metadata))
+        {
+            return [];
+        }
+
+        var client = _httpClientFactory.CreateClient(WebCrawlerConstants.HttpClientName);
+        var filter = SitemapWebCrawlerHelper.CreateUrlFilter(metadata);
+
+        var discovered = await _sitemapCrawler.DiscoverAsync(
+            client,
+            SitemapWebCrawlerHelper.CreateCrawlRequest(metadata, _options),
+            cancellationToken);
+
+        return discovered
+            .Where(entry => filter(entry.Url))
+            .Select(entry => new CrawledPageRef(entry.Url, entry.LastModifiedUtc, entry.ChangeFrequency))
+            .ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<CrawledPage> FetchAsync(WebCrawler crawler, string url, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+
+        if (string.IsNullOrWhiteSpace(url) || !SitemapWebCrawlerHelper.TryGetMetadata(crawler, out var metadata))
+        {
+            return null;
+        }
+
+        var client = _httpClientFactory.CreateClient(WebCrawlerConstants.HttpClientName);
+        var userAgent = SitemapWebCrawlerHelper.ResolveUserAgent(metadata, _options);
+        var requestTimeout = SitemapWebCrawlerHelper.ResolveRequestTimeout(metadata, _options);
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(requestTimeout);
+
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            if (!string.IsNullOrWhiteSpace(userAgent))
+            {
+                request.Headers.TryAddWithoutValidation("User-Agent", userAgent);
+            }
+
+            using var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead, timeoutSource.Token);
+            response.EnsureSuccessStatusCode();
+
+            var html = await response.Content.ReadAsStringAsync(timeoutSource.Token);
+            var title = HtmlIngestionDocumentReader.ExtractTitle(html);
+            var document = HtmlIngestionDocumentReader.Read(html, url);
+            var content = FlattenDocument(document);
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return null;
+            }
+
+            return new CrawledPage(title, content);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(ex, "Failed to fetch page '{Url}' for web crawler '{CrawlerId}'.", url, crawler.ItemId);
+            }
+
+            return null;
+        }
+    }
+
+    private static string FlattenDocument(Microsoft.Extensions.DataIngestion.IngestionDocument document)
+    {
+        var builder = new StringBuilder();
+
+        foreach (var element in document.EnumerateContent())
+        {
+            if (string.IsNullOrWhiteSpace(element.Text))
+            {
+                continue;
+            }
+
+            if (builder.Length > 0)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append(element.Text);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryCreateAbsoluteUrl(string value, out Uri uri)
+    {
+        uri = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return Uri.TryCreate(value.Trim(), UriKind.Absolute, out uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/Sitemap/SitemapWebCrawlerStrategy.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.DataIngestion;
 using CrestApps.Core.Models;
 using Microsoft.Extensions.Logging;
@@ -10,9 +10,9 @@ using Microsoft.Extensions.Options;
 namespace CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
 
 /// <summary>
-/// The sitemap crawl strategy. It discovers pages by walking a site's sitemap(s) and fetches each page as
-/// cleaned plain text, using the shared <see cref="ISitemapCrawler"/> and
-/// <see cref="IWebPageContentExtractor"/>.
+/// The sitemap crawl strategy. It discovers pages by walking a site's sitemap(s) with the shared
+/// <see cref="ISitemapCrawler"/> and fetches each page as cleaned plain text through the reusable
+/// <see cref="HtmlIngestionDocumentReader"/>.
 /// </summary>
 public sealed class SitemapWebCrawlerStrategy : IWebCrawlerStrategy
 {

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyDescriptor.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyDescriptor.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Localization;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// Describes a selectable web-crawl strategy shown to operators when they create a crawler.
+/// </summary>
+public sealed class WebCrawlerStrategyDescriptor
+{
+    /// <summary>
+    /// Gets or sets the technical strategy identifier.
+    /// </summary>
+    public string Strategy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display name shown to operators.
+    /// </summary>
+    public LocalizedString DisplayName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the descriptive text shown to operators.
+    /// </summary>
+    public LocalizedString Description { get; set; }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyOptions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Localization;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// Holds the registered set of web-crawl strategy descriptors, used to populate the strategy dropdown in
+/// the crawler editor.
+/// </summary>
+public sealed class WebCrawlerStrategyOptions
+{
+    /// <summary>
+    /// Gets the configured strategy descriptors.
+    /// </summary>
+    public List<WebCrawlerStrategyDescriptor> Strategies { get; } = [];
+
+    /// <summary>
+    /// Adds or updates a strategy descriptor.
+    /// </summary>
+    /// <param name="strategy">The strategy identifier.</param>
+    /// <param name="displayName">The display name.</param>
+    /// <param name="description">The description.</param>
+    public void AddOrUpdate(string strategy, LocalizedString displayName, LocalizedString description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(strategy);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName.Value);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description.Value);
+
+        var descriptor = Strategies.FirstOrDefault(item =>
+            string.Equals(item.Strategy, strategy, StringComparison.OrdinalIgnoreCase));
+
+        descriptor ??= new WebCrawlerStrategyDescriptor();
+        descriptor.Strategy = strategy;
+        descriptor.DisplayName = displayName;
+        descriptor.Description = description;
+
+        if (!Strategies.Contains(descriptor))
+        {
+            Strategies.Add(descriptor);
+        }
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyResolver.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/Strategies/WebCrawlerStrategyResolver.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CrestApps.Core.AI.WebCrawlers.Strategies;
+
+/// <summary>
+/// The default <see cref="IWebCrawlerStrategyResolver"/>. It resolves strategies from the keyed service
+/// registrations by their identifier.
+/// </summary>
+public sealed class WebCrawlerStrategyResolver : IWebCrawlerStrategyResolver
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerStrategyResolver"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    public WebCrawlerStrategyResolver(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc />
+    public IWebCrawlerStrategy Get(string strategy)
+    {
+        if (string.IsNullOrWhiteSpace(strategy))
+        {
+            return null;
+        }
+
+        return _serviceProvider.GetKeyedService<IWebCrawlerStrategy>(strategy);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebAIDataSourceSourceHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebAIDataSourceSourceHandler.cs
@@ -7,6 +7,7 @@ using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.WebCrawlers.Strategies;
 using CrestApps.Core.Infrastructure.Indexing.Models;
 using CrestApps.Core.Models;
+using Microsoft.Extensions.Logging;
 
 namespace CrestApps.Core.AI.WebCrawlers;
 
@@ -22,6 +23,7 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
     private readonly IWebCrawlStateStore _crawlStateStore;
     private readonly IWebCrawlerStrategyResolver _strategyResolver;
     private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WebAIDataSourceSourceHandler> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WebAIDataSourceSourceHandler"/> class.
@@ -30,16 +32,19 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
     /// <param name="crawlStateStore">The crawl-state store.</param>
     /// <param name="strategyResolver">The strategy resolver.</param>
     /// <param name="timeProvider">The time provider.</param>
+    /// <param name="logger">The logger.</param>
     public WebAIDataSourceSourceHandler(
         IWebCrawlerStore crawlerStore,
         IWebCrawlStateStore crawlStateStore,
         IWebCrawlerStrategyResolver strategyResolver,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        ILogger<WebAIDataSourceSourceHandler> logger)
     {
         _crawlerStore = crawlerStore;
         _crawlStateStore = crawlStateStore;
         _strategyResolver = strategyResolver;
         _timeProvider = timeProvider;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -66,9 +71,20 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
     {
         ArgumentNullException.ThrowIfNull(dataSource);
 
-        var crawlers = await _crawlerStore.GetByDataSourceIdAsync(dataSource.ItemId, cancellationToken);
+        var crawlers = (await _crawlerStore.GetByDataSourceIdAsync(dataSource.ItemId, cancellationToken))
+            .Where(crawler => crawler.Enabled)
+            .ToArray();
 
-        foreach (var crawler in crawlers.Where(crawler => crawler.Enabled))
+        if (crawlers.Length == 0)
+        {
+            _logger.LogWarning(
+                "Web data source '{DataSourceId}' has no enabled web crawlers, so nothing was indexed. Add a crawler in the Web Crawlers area that targets this data source.",
+                dataSource.ItemId);
+
+            yield break;
+        }
+
+        foreach (var crawler in crawlers)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -76,6 +92,8 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
 
             if (strategy is null)
             {
+                _logger.LogWarning("Skipping web crawler '{CrawlerId}' because its strategy '{Strategy}' is not registered.", crawler.ItemId, crawler.Source);
+
                 continue;
             }
 
@@ -83,6 +101,17 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
             await _crawlStateStore.DeleteByCrawlerIdAsync(crawler.ItemId, cancellationToken);
 
             var refs = await strategy.DiscoverAsync(crawler, cancellationToken);
+
+            if (refs.Count == 0)
+            {
+                _logger.LogWarning(
+                    "Web crawler '{CrawlerId}' discovered no pages. Verify the base/sitemap URL is reachable and exposes a sitemap, and that the include/exclude filters are not excluding everything.",
+                    crawler.ItemId);
+
+                continue;
+            }
+
+            var produced = 0;
 
             foreach (var pageRef in refs)
             {
@@ -96,8 +125,26 @@ public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
                 }
 
                 await _crawlStateStore.CreateAsync(BuildState(crawler.ItemId, pageRef.Url, pageRef.LastModifiedUtc?.UtcDateTime, pageRef.ChangeFrequency, page.Content), cancellationToken);
+                produced++;
 
                 yield return CreateDocument(pageRef.Url, page);
+            }
+
+            if (produced == 0)
+            {
+                _logger.LogWarning(
+                    "Web crawler '{CrawlerId}' discovered {Discovered} page(s) but none could be fetched or produced text (they may be blocking the crawler, returning errors, or have no readable content).",
+                    crawler.ItemId,
+                    refs.Count);
+            }
+            else if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Web crawler '{CrawlerId}' produced {Produced} page document(s) of {Discovered} discovered for data source '{DataSourceId}'.",
+                    crawler.ItemId,
+                    produced,
+                    refs.Count,
+                    dataSource.ItemId);
             }
         }
     }

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebAIDataSourceSourceHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebAIDataSourceSourceHandler.cs
@@ -1,0 +1,219 @@
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using CrestApps.Core;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+using CrestApps.Core.Models;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// The <c>Web</c> AI data source source handler. A <c>Web</c> data source is a target bucket that
+/// aggregates every enabled <see cref="WebCrawler"/> pointing at it: a full read runs each crawler's
+/// strategy (discover then fetch) and yields one source document per page, keyed by the page URL, which
+/// becomes the knowledge-base reference id used for citations.
+/// </summary>
+public sealed class WebAIDataSourceSourceHandler : IAIDataSourceSourceHandler
+{
+    private readonly IWebCrawlerStore _crawlerStore;
+    private readonly IWebCrawlStateStore _crawlStateStore;
+    private readonly IWebCrawlerStrategyResolver _strategyResolver;
+    private readonly TimeProvider _timeProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebAIDataSourceSourceHandler"/> class.
+    /// </summary>
+    /// <param name="crawlerStore">The crawler store.</param>
+    /// <param name="crawlStateStore">The crawl-state store.</param>
+    /// <param name="strategyResolver">The strategy resolver.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    public WebAIDataSourceSourceHandler(
+        IWebCrawlerStore crawlerStore,
+        IWebCrawlStateStore crawlStateStore,
+        IWebCrawlerStrategyResolver strategyResolver,
+        TimeProvider timeProvider)
+    {
+        _crawlerStore = crawlerStore;
+        _crawlStateStore = crawlStateStore;
+        _strategyResolver = strategyResolver;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public string SourceType => AIDataSourceSourceTypes.Web;
+
+    /// <inheritdoc />
+    public ValueTask<string> GetReferenceTypeAsync(AIDataSource dataSource, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(SourceType);
+    }
+
+    /// <inheritdoc />
+    public ValueTask ValidateAsync(AIDataSource dataSource, ValidationResultDetails result, CancellationToken cancellationToken = default)
+    {
+        // A Web data source needs no source-specific settings; the sites to scrape are managed as separate
+        // web-crawler records that point at it.
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<KeyValuePair<string, SourceDocument>> ReadAsync(
+        AIDataSource dataSource,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dataSource);
+
+        var crawlers = await _crawlerStore.GetByDataSourceIdAsync(dataSource.ItemId, cancellationToken);
+
+        foreach (var crawler in crawlers.Where(crawler => crawler.Enabled))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var strategy = _strategyResolver.Get(crawler.Source);
+
+            if (strategy is null)
+            {
+                continue;
+            }
+
+            // A full read is authoritative: reset the crawler's state and rebuild it as pages are indexed.
+            await _crawlStateStore.DeleteByCrawlerIdAsync(crawler.ItemId, cancellationToken);
+
+            var refs = await strategy.DiscoverAsync(crawler, cancellationToken);
+
+            foreach (var pageRef in refs)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var page = await strategy.FetchAsync(crawler, pageRef.Url, cancellationToken);
+
+                if (page is null)
+                {
+                    continue;
+                }
+
+                await _crawlStateStore.CreateAsync(BuildState(crawler.ItemId, pageRef.Url, pageRef.LastModifiedUtc?.UtcDateTime, pageRef.ChangeFrequency, page.Content), cancellationToken);
+
+                yield return CreateDocument(pageRef.Url, page);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<KeyValuePair<string, SourceDocument>> ReadByIdsAsync(
+        AIDataSource dataSource,
+        IEnumerable<string> documentIds,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dataSource);
+
+        var urls = documentIds?
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+
+        if (urls.Length == 0)
+        {
+            yield break;
+        }
+
+        var urlSet = new HashSet<string>(urls, StringComparer.OrdinalIgnoreCase);
+        var crawlers = await _crawlerStore.GetByDataSourceIdAsync(dataSource.ItemId, cancellationToken);
+
+        // Map each requested URL to the crawler that owns it (via its recorded crawl state).
+        var owners = new Dictionary<string, (WebCrawler Crawler, WebCrawlState State)>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var crawler in crawlers.Where(crawler => crawler.Enabled))
+        {
+            var states = await _crawlStateStore.GetAsync(crawler.ItemId, cancellationToken);
+
+            foreach (var state in states)
+            {
+                if (urlSet.Contains(state.Url))
+                {
+                    owners.TryAdd(state.Url, (crawler, state));
+                }
+            }
+        }
+
+        foreach (var url in urls)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!owners.TryGetValue(url, out var owner))
+            {
+                continue;
+            }
+
+            var strategy = _strategyResolver.Get(owner.Crawler.Source);
+
+            if (strategy is null)
+            {
+                continue;
+            }
+
+            var page = await strategy.FetchAsync(owner.Crawler, url, cancellationToken);
+
+            if (page is null)
+            {
+                continue;
+            }
+
+            owner.State.ContentHash = ComputeHash(page.Content);
+            owner.State.LastIndexedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+            owner.State.LastSeenUtc = owner.State.LastIndexedUtc;
+            await _crawlStateStore.UpdateAsync(owner.State, cancellationToken);
+
+            yield return CreateDocument(url, page);
+        }
+    }
+
+    private WebCrawlState BuildState(string crawlerId, string url, DateTime? lastModifiedUtc, string changeFrequency, string content)
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        return new WebCrawlState
+        {
+            ItemId = UniqueId.GenerateId(),
+            Source = crawlerId,
+            Url = url,
+            LastModifiedUtc = lastModifiedUtc,
+            ChangeFrequency = changeFrequency,
+            ContentHash = ComputeHash(content),
+            LastIndexedUtc = now,
+            LastSeenUtc = now,
+        };
+    }
+
+    private static KeyValuePair<string, SourceDocument> CreateDocument(string url, CrawledPage page)
+    {
+        var fields = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+        {
+            [WebCrawlerConstants.UrlFieldName] = url,
+        };
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            fields[WebCrawlerConstants.HostFieldName] = uri.Host;
+        }
+
+        return new KeyValuePair<string, SourceDocument>(
+            url,
+            new SourceDocument
+            {
+                Title = page.Title,
+                Content = page.Content,
+                Fields = fields,
+            });
+    }
+
+    private static string ComputeHash(string content)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content ?? string.Empty));
+
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerConstants.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerConstants.cs
@@ -1,0 +1,33 @@
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Well-known identifiers for the web-crawler feature.
+/// </summary>
+public static class WebCrawlerConstants
+{
+    /// <summary>
+    /// The name of the named <see cref="System.Net.Http.HttpClient"/> used to crawl and fetch pages.
+    /// </summary>
+    public const string HttpClientName = "CrestApps.WebCrawler";
+
+    /// <summary>
+    /// The knowledge-base filter field that stores the scraped page URL, used to build citations.
+    /// </summary>
+    public const string UrlFieldName = "url";
+
+    /// <summary>
+    /// The knowledge-base filter field that stores the scraped page host.
+    /// </summary>
+    public const string HostFieldName = "host";
+
+    /// <summary>
+    /// Well-known crawl strategy identifiers.
+    /// </summary>
+    public static class Strategies
+    {
+        /// <summary>
+        /// Discovers pages through a site's sitemap(s).
+        /// </summary>
+        public const string Sitemap = "Sitemap";
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerOptions.cs
@@ -1,0 +1,40 @@
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Global defaults for web crawlers. A crawler's own strategy settings override these per site; unset
+/// values fall back here.
+/// </summary>
+public sealed class WebCrawlerOptions
+{
+    /// <summary>
+    /// Gets or sets the default maximum number of pages scraped per crawler.
+    /// </summary>
+    public int DefaultMaxPages { get; set; } = 500;
+
+    /// <summary>
+    /// Gets or sets the default maximum number of concurrent page requests per crawler.
+    /// </summary>
+    public int DefaultMaxConcurrentRequests { get; set; } = 4;
+
+    /// <summary>
+    /// Gets or sets the default per-request timeout, in seconds, when fetching a page.
+    /// </summary>
+    public int DefaultRequestTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Gets or sets the default <c>User-Agent</c> header presented while crawling.
+    /// </summary>
+    public string DefaultUserAgent { get; set; } = "CrestApps-WebCrawler/1.0 (+https://crestapps.com)";
+
+    /// <summary>
+    /// Gets or sets the default re-index interval, in minutes, applied when a crawler does not specify its
+    /// own.
+    /// </summary>
+    public int DefaultReindexIntervalMinutes { get; set; } = (int)TimeSpan.FromHours(24).TotalMinutes;
+
+    /// <summary>
+    /// Gets or sets how often, in minutes, the background service wakes to check whether any crawler is due
+    /// for a re-index.
+    /// </summary>
+    public int ReindexCheckIntervalMinutes { get; set; } = 15;
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReferenceLinkResolver.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReferenceLinkResolver.cs
@@ -1,0 +1,32 @@
+using CrestApps.Core.AI.Profiles;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Resolves citation links for <c>Web</c> data source references. The reference id is the scraped page's
+/// own URL, so the link is the reference id itself when it is a valid absolute HTTP(S) URL.
+/// </summary>
+public sealed class WebCrawlerReferenceLinkResolver : IAIReferenceLinkResolver
+{
+    /// <summary>
+    /// Resolves the citation link for a scraped page.
+    /// </summary>
+    /// <param name="referenceId">The reference id, which is the scraped page URL.</param>
+    /// <param name="metadata">Optional reference metadata (unused).</param>
+    /// <returns>The page URL when valid; otherwise, <see langword="null"/>.</returns>
+    public string ResolveLink(string referenceId, IDictionary<string, object> metadata)
+    {
+        if (string.IsNullOrWhiteSpace(referenceId))
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(referenceId.Trim(), UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+        {
+            return uri.ToString();
+        }
+
+        return null;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexBackgroundService.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexBackgroundService.cs
@@ -1,0 +1,159 @@
+using CrestApps.Core.AI.DataSources;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Periodically re-crawls every enabled <see cref="Models.WebCrawler"/> and re-indexes only the pages
+/// that changed since the last run. It is a thin scheduler around <see cref="IWebCrawlerReindexPlanner"/>,
+/// mirroring the framework's data-source alignment background service so the reusable diffing logic can be
+/// driven by any host that prefers its own scheduling.
+/// </summary>
+internal sealed class WebCrawlerReindexBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly TimeProvider _timeProvider;
+    private readonly WebCrawlerOptions _options;
+    private readonly ILogger<WebCrawlerReindexBackgroundService> _logger;
+    private readonly Dictionary<string, DateTimeOffset> _lastRunUtc = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerReindexBackgroundService"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="options">The web-crawler options.</param>
+    /// <param name="logger">The logger.</param>
+    public WebCrawlerReindexBackgroundService(
+        IServiceProvider serviceProvider,
+        TimeProvider timeProvider,
+        IOptions<WebCrawlerOptions> options,
+        ILogger<WebCrawlerReindexBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _timeProvider = timeProvider;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromMinutes(Math.Max(1, _options.ReindexCheckIntervalMinutes));
+        using var timer = new PeriodicTimer(interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                await ReindexDueCrawlersAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while re-indexing web crawlers.");
+            }
+        }
+    }
+
+    private async Task ReindexDueCrawlersAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var crawlerStore = scope.ServiceProvider.GetService<IWebCrawlerStore>();
+
+        if (crawlerStore is null)
+        {
+            return;
+        }
+
+        var crawlers = (await crawlerStore.GetAllAsync(cancellationToken))
+            .Where(crawler => crawler.Enabled)
+            .ToArray();
+
+        if (crawlers.Length == 0)
+        {
+            return;
+        }
+
+        var planner = scope.ServiceProvider.GetRequiredService<IWebCrawlerReindexPlanner>();
+        var crawlStateStore = scope.ServiceProvider.GetRequiredService<IWebCrawlStateStore>();
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var crawler in crawlers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var reindexInterval = ResolveReindexInterval(crawler.ReindexIntervalMinutes);
+            var lastRun = await GetLastRunAsync(crawler.ItemId, crawlStateStore, cancellationToken);
+
+            if (now - lastRun < reindexInterval)
+            {
+                continue;
+            }
+
+            try
+            {
+                await planner.PlanAndEnqueueAsync(crawler, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to re-index web crawler '{CrawlerId}'.", crawler.ItemId);
+            }
+
+            _lastRunUtc[crawler.ItemId] = now;
+        }
+    }
+
+    private TimeSpan ResolveReindexInterval(int? crawlerInterval)
+    {
+        var minutes = crawlerInterval ?? _options.DefaultReindexIntervalMinutes;
+
+        if (minutes <= 0)
+        {
+            minutes = _options.DefaultReindexIntervalMinutes;
+        }
+
+        return TimeSpan.FromMinutes(Math.Max(1, minutes));
+    }
+
+    private async Task<DateTimeOffset> GetLastRunAsync(string crawlerId, IWebCrawlStateStore crawlStateStore, CancellationToken cancellationToken)
+    {
+        if (_lastRunUtc.TryGetValue(crawlerId, out var cached))
+        {
+            return cached;
+        }
+
+        // Seed the last-run time from the persisted crawl state so a restart does not force an immediate
+        // re-crawl of every configured site.
+        var states = await crawlStateStore.GetAsync(crawlerId, cancellationToken);
+        var lastSeen = states.Count == 0
+            ? DateTimeOffset.MinValue
+            : new DateTimeOffset(states.Max(state => state.LastSeenUtc), TimeSpan.Zero);
+
+        _lastRunUtc[crawlerId] = lastSeen;
+
+        return lastSeen;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexBackgroundService.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexBackgroundService.cs
@@ -1,4 +1,3 @@
-using CrestApps.Core.AI.DataSources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -7,34 +6,28 @@ using Microsoft.Extensions.Options;
 namespace CrestApps.Core.AI.WebCrawlers;
 
 /// <summary>
-/// Periodically re-crawls every enabled <see cref="Models.WebCrawler"/> and re-indexes only the pages
-/// that changed since the last run. It is a thin scheduler around <see cref="IWebCrawlerReindexPlanner"/>,
-/// mirroring the framework's data-source alignment background service so the reusable diffing logic can be
-/// driven by any host that prefers its own scheduling.
+/// A thin hosted job that periodically drives <see cref="IWebCrawlerReindexService.ReindexDueAsync"/>. All
+/// of the re-index logic lives in the service, so a host that prefers its own scheduling (or a manual
+/// trigger) can invoke the service directly without this background job.
 /// </summary>
 internal sealed class WebCrawlerReindexBackgroundService : BackgroundService
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly TimeProvider _timeProvider;
     private readonly WebCrawlerOptions _options;
     private readonly ILogger<WebCrawlerReindexBackgroundService> _logger;
-    private readonly Dictionary<string, DateTimeOffset> _lastRunUtc = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WebCrawlerReindexBackgroundService"/> class.
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>
-    /// <param name="timeProvider">The time provider.</param>
     /// <param name="options">The web-crawler options.</param>
     /// <param name="logger">The logger.</param>
     public WebCrawlerReindexBackgroundService(
         IServiceProvider serviceProvider,
-        TimeProvider timeProvider,
         IOptions<WebCrawlerOptions> options,
         ILogger<WebCrawlerReindexBackgroundService> logger)
     {
         _serviceProvider = serviceProvider;
-        _timeProvider = timeProvider;
         _options = options.Value;
         _logger = logger;
     }
@@ -61,7 +54,15 @@ internal sealed class WebCrawlerReindexBackgroundService : BackgroundService
 
             try
             {
-                await ReindexDueCrawlersAsync(stoppingToken);
+                using var scope = _serviceProvider.CreateScope();
+                var reindexService = scope.ServiceProvider.GetService<IWebCrawlerReindexService>();
+
+                if (reindexService is null)
+                {
+                    continue;
+                }
+
+                await reindexService.ReindexDueAsync(stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -72,88 +73,5 @@ internal sealed class WebCrawlerReindexBackgroundService : BackgroundService
                 _logger.LogError(ex, "An error occurred while re-indexing web crawlers.");
             }
         }
-    }
-
-    private async Task ReindexDueCrawlersAsync(CancellationToken cancellationToken)
-    {
-        using var scope = _serviceProvider.CreateScope();
-        var crawlerStore = scope.ServiceProvider.GetService<IWebCrawlerStore>();
-
-        if (crawlerStore is null)
-        {
-            return;
-        }
-
-        var crawlers = (await crawlerStore.GetAllAsync(cancellationToken))
-            .Where(crawler => crawler.Enabled)
-            .ToArray();
-
-        if (crawlers.Length == 0)
-        {
-            return;
-        }
-
-        var planner = scope.ServiceProvider.GetRequiredService<IWebCrawlerReindexPlanner>();
-        var crawlStateStore = scope.ServiceProvider.GetRequiredService<IWebCrawlStateStore>();
-        var now = _timeProvider.GetUtcNow();
-
-        foreach (var crawler in crawlers)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var reindexInterval = ResolveReindexInterval(crawler.ReindexIntervalMinutes);
-            var lastRun = await GetLastRunAsync(crawler.ItemId, crawlStateStore, cancellationToken);
-
-            if (now - lastRun < reindexInterval)
-            {
-                continue;
-            }
-
-            try
-            {
-                await planner.PlanAndEnqueueAsync(crawler, cancellationToken);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to re-index web crawler '{CrawlerId}'.", crawler.ItemId);
-            }
-
-            _lastRunUtc[crawler.ItemId] = now;
-        }
-    }
-
-    private TimeSpan ResolveReindexInterval(int? crawlerInterval)
-    {
-        var minutes = crawlerInterval ?? _options.DefaultReindexIntervalMinutes;
-
-        if (minutes <= 0)
-        {
-            minutes = _options.DefaultReindexIntervalMinutes;
-        }
-
-        return TimeSpan.FromMinutes(Math.Max(1, minutes));
-    }
-
-    private async Task<DateTimeOffset> GetLastRunAsync(string crawlerId, IWebCrawlStateStore crawlStateStore, CancellationToken cancellationToken)
-    {
-        if (_lastRunUtc.TryGetValue(crawlerId, out var cached))
-        {
-            return cached;
-        }
-
-        // Seed the last-run time from the persisted crawl state so a restart does not force an immediate
-        // re-crawl of every configured site.
-        var states = await crawlStateStore.GetAsync(crawlerId, cancellationToken);
-        var lastSeen = states.Count == 0
-            ? DateTimeOffset.MinValue
-            : new DateTimeOffset(states.Max(state => state.LastSeenUtc), TimeSpan.Zero);
-
-        _lastRunUtc[crawlerId] = lastSeen;
-
-        return lastSeen;
     }
 }

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexPlanner.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexPlanner.cs
@@ -62,7 +62,44 @@ public sealed class WebCrawlerReindexPlanner : IWebCrawlerReindexPlanner
             return WebCrawlerReindexResult.Empty;
         }
 
-        var discovered = (await strategy.DiscoverAsync(crawler, cancellationToken))
+        IReadOnlyList<CrawledPageRef> discoveredRefs;
+
+        try
+        {
+            discoveredRefs = await strategy.DiscoverAsync(crawler, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Web-crawler discovery failed for crawler '{CrawlerId}' → data source '{DataSourceId}'. The site could not be crawled.",
+                crawler.ItemId,
+                crawler.AIDataSourceId);
+
+            return WebCrawlerReindexResult.Failed(
+                $"The site could not be crawled: {ex.Message} Verify the site is reachable and that it is not blocking the crawler's user agent.");
+        }
+
+        if (discoveredRefs.Count == 0)
+        {
+            // Discovery came back empty. Do NOT diff against the stored state here: treating every known page
+            // as "removed" would wipe the knowledge base whenever a site transiently blocks the crawler or its
+            // sitemap is briefly unreachable. Leave the existing state untouched and report the condition so the
+            // user can check their configuration or unblock the crawler.
+            _logger.LogWarning(
+                "Web-crawler discovery for crawler '{CrawlerId}' → data source '{DataSourceId}' returned no pages; existing crawl state was left untouched.",
+                crawler.ItemId,
+                crawler.AIDataSourceId);
+
+            return WebCrawlerReindexResult.NoPagesDiscovered(
+                "No pages were discovered. The site may be blocking the crawler (ensure your server and robots.txt allow the crawler's user agent), or the configured base/sitemap URL may be wrong, unreachable, or empty.");
+        }
+
+        var discovered = discoveredRefs
             .GroupBy(pageRef => pageRef.Url, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
@@ -108,6 +145,15 @@ public sealed class WebCrawlerReindexPlanner : IWebCrawlerReindexPlanner
                 toIndex.Add(url);
                 changedCount++;
             }
+            else if (!IsIndexed(state))
+            {
+                // The page is already tracked but has never been successfully indexed — a prior attempt was
+                // queued and then failed (for example the knowledge-base provider was unavailable), so its
+                // crawl state still carries the "never indexed" marker. Re-enqueue it so it is retried; the
+                // handler stamps LastIndexedUtc once indexing actually succeeds.
+                toIndex.Add(url);
+                changedCount++;
+            }
             else
             {
                 unchanged++;
@@ -131,7 +177,10 @@ public sealed class WebCrawlerReindexPlanner : IWebCrawlerReindexPlanner
             await _crawlStateStore.DeleteByUrlsAsync(crawler.ItemId, removed, cancellationToken);
         }
 
-        var result = new WebCrawlerReindexResult(newCount, changedCount, removed.Length, unchanged);
+        var result = new WebCrawlerReindexResult(newCount, changedCount, removed.Length, unchanged)
+        {
+            DiscoveredCount = discovered.Count,
+        };
 
         if (_logger.IsEnabled(LogLevel.Information) && (result.NewCount > 0 || result.ChangedCount > 0 || result.RemovedCount > 0))
         {
@@ -146,6 +195,14 @@ public sealed class WebCrawlerReindexPlanner : IWebCrawlerReindexPlanner
         }
 
         return result;
+    }
+
+    private static bool IsIndexed(WebCrawlState state)
+    {
+        // A never-indexed placeholder carries DateTime.MinValue (year 1). Comparing on the year keeps this
+        // robust against time-zone/serialization round-tripping that can shift the stored min value by a few
+        // hours without ever reaching a real (post-year-1) indexing timestamp.
+        return state.LastIndexedUtc.Year > 1;
     }
 
     private static bool HasChanged(CrawledPageRef pageRef, WebCrawlState state)

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexPlanner.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexPlanner.cs
@@ -1,0 +1,162 @@
+using CrestApps.Core;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// The default <see cref="IWebCrawlerReindexPlanner"/>. It re-runs a crawler's strategy discovery,
+/// compares it against the stored crawl state, and enqueues only the pages that changed: new and modified
+/// pages are queued for re-indexing into the crawler's target data source, pages missing from the crawl
+/// are queued for deletion and their crawl state is removed. Change detection is generic (a page changed
+/// when its advertised last-modified timestamp is newer than the recorded one), so it works for any
+/// strategy; pages without a timestamp are refreshed by the nightly full data-source alignment instead.
+/// </summary>
+public sealed class WebCrawlerReindexPlanner : IWebCrawlerReindexPlanner
+{
+    private readonly IWebCrawlerStrategyResolver _strategyResolver;
+    private readonly IWebCrawlStateStore _crawlStateStore;
+    private readonly IAIDataSourceIndexingQueue _indexingQueue;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WebCrawlerReindexPlanner> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerReindexPlanner"/> class.
+    /// </summary>
+    /// <param name="strategyResolver">The strategy resolver.</param>
+    /// <param name="crawlStateStore">The crawl-state store.</param>
+    /// <param name="indexingQueue">The data source indexing queue.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="logger">The logger.</param>
+    public WebCrawlerReindexPlanner(
+        IWebCrawlerStrategyResolver strategyResolver,
+        IWebCrawlStateStore crawlStateStore,
+        IAIDataSourceIndexingQueue indexingQueue,
+        TimeProvider timeProvider,
+        ILogger<WebCrawlerReindexPlanner> logger)
+    {
+        _strategyResolver = strategyResolver;
+        _crawlStateStore = crawlStateStore;
+        _indexingQueue = indexingQueue;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<WebCrawlerReindexResult> PlanAndEnqueueAsync(WebCrawler crawler, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+
+        if (!crawler.Enabled || string.IsNullOrWhiteSpace(crawler.AIDataSourceId))
+        {
+            return WebCrawlerReindexResult.Empty;
+        }
+
+        var strategy = _strategyResolver.Get(crawler.Source);
+
+        if (strategy is null)
+        {
+            return WebCrawlerReindexResult.Empty;
+        }
+
+        var discovered = (await strategy.DiscoverAsync(crawler, cancellationToken))
+            .GroupBy(pageRef => pageRef.Url, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        var existingByUrl = (await _crawlStateStore.GetAsync(crawler.ItemId, cancellationToken))
+            .GroupBy(state => state.Url, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var toIndex = new List<string>();
+        var unchanged = 0;
+        var newCount = 0;
+        var changedCount = 0;
+
+        foreach (var (url, pageRef) in discovered)
+        {
+            if (!existingByUrl.TryGetValue(url, out var state))
+            {
+                await _crawlStateStore.CreateAsync(
+                    new WebCrawlState
+                    {
+                        ItemId = UniqueId.GenerateId(),
+                        Source = crawler.ItemId,
+                        Url = url,
+                        LastModifiedUtc = pageRef.LastModifiedUtc?.UtcDateTime,
+                        ChangeFrequency = pageRef.ChangeFrequency,
+                        LastSeenUtc = now,
+                        LastIndexedUtc = DateTime.MinValue,
+                    },
+                    cancellationToken);
+
+                toIndex.Add(url);
+                newCount++;
+
+                continue;
+            }
+
+            state.LastSeenUtc = now;
+
+            if (HasChanged(pageRef, state))
+            {
+                state.LastModifiedUtc = pageRef.LastModifiedUtc?.UtcDateTime ?? state.LastModifiedUtc;
+                state.ChangeFrequency = pageRef.ChangeFrequency ?? state.ChangeFrequency;
+                toIndex.Add(url);
+                changedCount++;
+            }
+            else
+            {
+                unchanged++;
+            }
+
+            await _crawlStateStore.UpdateAsync(state, cancellationToken);
+        }
+
+        var removed = existingByUrl.Keys
+            .Where(url => !discovered.ContainsKey(url))
+            .ToArray();
+
+        if (toIndex.Count > 0)
+        {
+            await _indexingQueue.QueueSyncDataSourceDocumentsAsync(crawler.AIDataSourceId, toIndex, cancellationToken);
+        }
+
+        if (removed.Length > 0)
+        {
+            await _indexingQueue.QueueRemoveDataSourceDocumentsAsync(crawler.AIDataSourceId, removed, cancellationToken);
+            await _crawlStateStore.DeleteByUrlsAsync(crawler.ItemId, removed, cancellationToken);
+        }
+
+        var result = new WebCrawlerReindexResult(newCount, changedCount, removed.Length, unchanged);
+
+        if (_logger.IsEnabled(LogLevel.Information) && (result.NewCount > 0 || result.ChangedCount > 0 || result.RemovedCount > 0))
+        {
+            _logger.LogInformation(
+                "Web-crawler re-index planned for crawler '{CrawlerId}' → data source '{DataSourceId}': {New} new, {Changed} changed, {Removed} removed, {Unchanged} unchanged.",
+                crawler.ItemId,
+                crawler.AIDataSourceId,
+                result.NewCount,
+                result.ChangedCount,
+                result.RemovedCount,
+                result.UnchangedCount);
+        }
+
+        return result;
+    }
+
+    private static bool HasChanged(CrawledPageRef pageRef, WebCrawlState state)
+    {
+        // With no advertised timestamp there is no reliable change signal, so an already-indexed page is
+        // left alone; the periodic full data-source alignment still refreshes it.
+        if (pageRef.LastModifiedUtc is null)
+        {
+            return false;
+        }
+
+        return state.LastModifiedUtc is null || pageRef.LastModifiedUtc.Value.UtcDateTime > state.LastModifiedUtc.Value;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexResult.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexResult.cs
@@ -1,8 +1,37 @@
 namespace CrestApps.Core.AI.WebCrawlers;
 
 /// <summary>
+/// The outcome status of a web-crawler re-index plan.
+/// </summary>
+public enum WebCrawlerReindexStatus
+{
+    /// <summary>
+    /// The crawler was discovered and its changes (if any) were planned and enqueued.
+    /// </summary>
+    Completed,
+
+    /// <summary>
+    /// The crawler is disabled, unconfigured, or its strategy is not registered, so no work was planned.
+    /// </summary>
+    Skipped,
+
+    /// <summary>
+    /// Discovery ran but returned no pages. The existing crawl state was left untouched (so a transient
+    /// block does not wipe the knowledge base). The site is likely blocking the crawler, or the base/sitemap
+    /// URL is wrong, unreachable, or empty.
+    /// </summary>
+    NoPagesDiscovered,
+
+    /// <summary>
+    /// Discovery threw. The site could not be crawled at all (network failure, or the crawler was blocked).
+    /// </summary>
+    DiscoveryFailed,
+}
+
+/// <summary>
 /// Summarizes the outcome of a web-crawler re-index plan: how many pages were newly discovered, changed,
-/// removed, or left unchanged since the previous run.
+/// removed, or left unchanged since the previous run, along with an overall <see cref="Status"/> so callers
+/// can surface blocked or unreachable sites to the user.
 /// </summary>
 /// <param name="NewCount">The number of newly discovered pages queued for indexing.</param>
 /// <param name="ChangedCount">The number of changed pages queued for re-indexing.</param>
@@ -17,5 +46,35 @@ public sealed record WebCrawlerReindexResult(
     /// <summary>
     /// An empty result for crawlers that produced no work.
     /// </summary>
-    public static readonly WebCrawlerReindexResult Empty = new(0, 0, 0, 0);
+    public static readonly WebCrawlerReindexResult Empty = new(0, 0, 0, 0) { Status = WebCrawlerReindexStatus.Skipped };
+
+    /// <summary>
+    /// The overall outcome of the plan.
+    /// </summary>
+    public WebCrawlerReindexStatus Status { get; init; } = WebCrawlerReindexStatus.Completed;
+
+    /// <summary>
+    /// The total number of pages discovered by the crawler on this run.
+    /// </summary>
+    public int DiscoveredCount { get; init; }
+
+    /// <summary>
+    /// A human-readable message describing a non-completed outcome (blocked, unreachable, failed), or
+    /// <see langword="null"/> when the plan completed normally.
+    /// </summary>
+    public string Message { get; init; }
+
+    /// <summary>
+    /// Creates a result indicating discovery returned no pages.
+    /// </summary>
+    /// <param name="message">The human-readable explanation.</param>
+    public static WebCrawlerReindexResult NoPagesDiscovered(string message)
+        => new(0, 0, 0, 0) { Status = WebCrawlerReindexStatus.NoPagesDiscovered, Message = message };
+
+    /// <summary>
+    /// Creates a result indicating discovery failed.
+    /// </summary>
+    /// <param name="message">The human-readable explanation.</param>
+    public static WebCrawlerReindexResult Failed(string message)
+        => new(0, 0, 0, 0) { Status = WebCrawlerReindexStatus.DiscoveryFailed, Message = message };
 }

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexResult.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexResult.cs
@@ -1,0 +1,21 @@
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// Summarizes the outcome of a web-crawler re-index plan: how many pages were newly discovered, changed,
+/// removed, or left unchanged since the previous run.
+/// </summary>
+/// <param name="NewCount">The number of newly discovered pages queued for indexing.</param>
+/// <param name="ChangedCount">The number of changed pages queued for re-indexing.</param>
+/// <param name="RemovedCount">The number of removed pages queued for deletion.</param>
+/// <param name="UnchangedCount">The number of discovered pages that did not change.</param>
+public sealed record WebCrawlerReindexResult(
+    int NewCount,
+    int ChangedCount,
+    int RemovedCount,
+    int UnchangedCount)
+{
+    /// <summary>
+    /// An empty result for crawlers that produced no work.
+    /// </summary>
+    public static readonly WebCrawlerReindexResult Empty = new(0, 0, 0, 0);
+}

--- a/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexService.cs
+++ b/src/Primitives/CrestApps.Core.AI.WebCrawlers/WebCrawlerReindexService.cs
@@ -1,0 +1,115 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.AI.WebCrawlers;
+
+/// <summary>
+/// The default <see cref="IWebCrawlerReindexService"/>. It loads every enabled crawler and, for
+/// <see cref="ReindexDueAsync"/>, re-indexes only those due per their re-index interval — where "due" is
+/// derived from the persisted crawl state (the most recent time a page was seen), so the decision survives
+/// restarts and does not depend on the caller keeping any state.
+/// </summary>
+public sealed class WebCrawlerReindexService : IWebCrawlerReindexService
+{
+    private readonly IWebCrawlerStore _crawlerStore;
+    private readonly IWebCrawlStateStore _crawlStateStore;
+    private readonly IWebCrawlerReindexPlanner _planner;
+    private readonly WebCrawlerOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<WebCrawlerReindexService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerReindexService"/> class.
+    /// </summary>
+    /// <param name="crawlerStore">The crawler store.</param>
+    /// <param name="crawlStateStore">The crawl-state store.</param>
+    /// <param name="planner">The re-index planner.</param>
+    /// <param name="options">The web-crawler options.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="logger">The logger.</param>
+    public WebCrawlerReindexService(
+        IWebCrawlerStore crawlerStore,
+        IWebCrawlStateStore crawlStateStore,
+        IWebCrawlerReindexPlanner planner,
+        IOptions<WebCrawlerOptions> options,
+        TimeProvider timeProvider,
+        ILogger<WebCrawlerReindexService> logger)
+    {
+        _crawlerStore = crawlerStore;
+        _crawlStateStore = crawlStateStore;
+        _planner = planner;
+        _options = options.Value;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task ReindexDueAsync(CancellationToken cancellationToken = default)
+        => ReindexAsync(dueOnly: true, cancellationToken);
+
+    /// <inheritdoc />
+    public Task ReindexAllAsync(CancellationToken cancellationToken = default)
+        => ReindexAsync(dueOnly: false, cancellationToken);
+
+    private async Task ReindexAsync(bool dueOnly, CancellationToken cancellationToken)
+    {
+        var crawlers = (await _crawlerStore.GetAllAsync(cancellationToken))
+            .Where(crawler => crawler.Enabled)
+            .ToArray();
+
+        if (crawlers.Length == 0)
+        {
+            return;
+        }
+
+        var now = _timeProvider.GetUtcNow();
+
+        foreach (var crawler in crawlers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (dueOnly && !await IsDueAsync(crawler, now, cancellationToken))
+            {
+                continue;
+            }
+
+            try
+            {
+                await _planner.PlanAndEnqueueAsync(crawler, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to re-index web crawler '{CrawlerId}'.", crawler.ItemId);
+            }
+        }
+    }
+
+    private async Task<bool> IsDueAsync(WebCrawler crawler, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var reindexInterval = ResolveReindexInterval(crawler.ReindexIntervalMinutes);
+        var states = await _crawlStateStore.GetAsync(crawler.ItemId, cancellationToken);
+        var lastRun = states.Count == 0
+            ? DateTimeOffset.MinValue
+            : new DateTimeOffset(states.Max(state => state.LastSeenUtc), TimeSpan.Zero);
+
+        return now - lastRun >= reindexInterval;
+    }
+
+    private TimeSpan ResolveReindexInterval(int? crawlerInterval)
+    {
+        var minutes = crawlerInterval ?? _options.DefaultReindexIntervalMinutes;
+
+        if (minutes <= 0)
+        {
+            minutes = _options.DefaultReindexIntervalMinutes;
+        }
+
+        return TimeSpan.FromMinutes(Math.Max(1, minutes));
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Crawling/ISitemapCrawler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Crawling/ISitemapCrawler.cs
@@ -1,4 +1,4 @@
-namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+namespace CrestApps.Core.AI.Crawling;
 
 /// <summary>
 /// Discovers page URLs for a site by walking its sitemap graph. The crawler understands the full

--- a/src/Primitives/CrestApps.Core.AI/Crawling/SitemapCrawlRequest.cs
+++ b/src/Primitives/CrestApps.Core.AI/Crawling/SitemapCrawlRequest.cs
@@ -1,4 +1,4 @@
-namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+namespace CrestApps.Core.AI.Crawling;
 
 /// <summary>
 /// Describes a single sitemap discovery run for the <see cref="ISitemapCrawler"/>. Either

--- a/src/Primitives/CrestApps.Core.AI/Crawling/SitemapCrawler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Crawling/SitemapCrawler.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 
-namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+namespace CrestApps.Core.AI.Crawling;
 
 /// <summary>
 /// The default <see cref="ISitemapCrawler"/>. It resolves the sitemap seeds for a site, walks any

--- a/src/Primitives/CrestApps.Core.AI/Crawling/SitemapEntry.cs
+++ b/src/Primitives/CrestApps.Core.AI/Crawling/SitemapEntry.cs
@@ -1,4 +1,4 @@
-namespace CrestApps.Core.AI.WebCrawlers.Crawling;
+namespace CrestApps.Core.AI.Crawling;
 
 /// <summary>
 /// Represents a single page discovered while walking a site's sitemap graph, together with the change

--- a/src/Primitives/CrestApps.Core.AI/Handlers/AIDataSourceCatalogHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Handlers/AIDataSourceCatalogHandler.cs
@@ -87,14 +87,17 @@ internal sealed class AIDataSourceCatalogHandler : CatalogEntryHandlerBase<AIDat
             context.Result.Fail(new ValidationResult("AI knowledge base index profile is required.", [nameof(AIDataSource.AIKnowledgeBaseIndexProfileName)]));
         }
 
-        if (string.IsNullOrWhiteSpace(context.Model.ContentFieldName))
-        {
-            context.Result.Fail(new ValidationResult("Content field name is required.", [nameof(AIDataSource.ContentFieldName)]));
-        }
-
         context.Model.Source = string.IsNullOrWhiteSpace(context.Model.Source)
             ? AIDataSourceSourceTypes.SearchIndexProfile
             : context.Model.Source.Trim();
+
+        // The Web source derives each page's key, title, and content from the crawled page, so it does not
+        // require the field mapping that external index sources need.
+        if (!string.Equals(context.Model.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase) &&
+            string.IsNullOrWhiteSpace(context.Model.ContentFieldName))
+        {
+            context.Result.Fail(new ValidationResult("Content field name is required.", [nameof(AIDataSource.ContentFieldName)]));
+        }
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Handlers/DataSourcePreemptiveRagHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Handlers/DataSourcePreemptiveRagHandler.cs
@@ -189,7 +189,14 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
     {
         var orchestrationContext = context.OrchestrationContext;
         var dataSourceId = orchestrationContext.CompletionContext.DataSourceId;
-        var embeddings = await embeddingGenerator.GenerateAsync(context.Queries);
+        var searchQueries = GetSearchQueries(orchestrationContext.UserMessage, context.Queries);
+
+        if (searchQueries.Count == 0)
+        {
+            return;
+        }
+
+        var embeddings = await embeddingGenerator.GenerateAsync(searchQueries);
 
         if (embeddings == null || embeddings.Count == 0)
         {
@@ -210,8 +217,10 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
             }
         }
 
-        var allResults = new List<DataSourceSearchResult>();
+        var minimumScore = _options.GetMinimumScore(ragMetadata?.Strictness);
+        var finalResults = new List<DataSourceSearchResult>();
         var seenChunkIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var candidateCount = DataSourceSearchResultSelector.GetCandidateCount(topN);
 
         foreach (var embedding in embeddings)
         {
@@ -224,7 +233,7 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
                 indexProfile,
                 embedding.Vector.ToArray(),
                 dataSourceId,
-                topN,
+                candidateCount,
                 providerFilter);
 
             if (results == null)
@@ -232,30 +241,26 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
                 continue;
             }
 
-            foreach (var result in results)
+            foreach (var result in DataSourceSearchResultSelector.SelectTopResults(results, candidateCount, minimumScore))
             {
                 var chunkKey = $"{result.ReferenceId}:{result.ChunkIndex}";
 
                 if (seenChunkIds.Add(chunkKey))
                 {
-                    allResults.Add(result);
+                    finalResults.Add(result);
+
+                    if (finalResults.Count >= topN)
+                    {
+                        break;
+                    }
                 }
             }
+
+            if (finalResults.Count >= topN)
+            {
+                break;
+            }
         }
-
-        var strictness = _options.GetStrictness(ragMetadata?.Strictness);
-        var query = allResults.AsEnumerable();
-
-        if (strictness > 0)
-        {
-            var threshold = strictness / (float)AIDataSourceOptions.MaxStrictness;
-            query = query.Where(result => result.Score >= threshold);
-        }
-
-        var finalResults = query
-            .OrderByDescending(result => result.Score)
-            .Take(topN)
-            .ToList();
 
         if (finalResults.Count == 0)
         {
@@ -368,6 +373,39 @@ internal sealed class DataSourcePreemptiveRagHandler : IPreemptiveRagHandler
         }
 
         return normalizedTitle;
+    }
+
+    private static List<string> GetSearchQueries(string userMessage, IList<string> derivedQueries)
+    {
+        var queries = new List<string>();
+        var seenQueries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        static void AddQuery(ICollection<string> queries, ISet<string> seenQueries, string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
+            var trimmedValue = value.Trim();
+
+            if (seenQueries.Add(trimmedValue))
+            {
+                queries.Add(trimmedValue);
+            }
+        }
+
+        AddQuery(queries, seenQueries, userMessage);
+
+        if (derivedQueries != null)
+        {
+            foreach (var query in derivedQueries)
+            {
+                AddQuery(queries, seenQueries, query);
+            }
+        }
+
+        return queries;
     }
 
     private static AIDataSourceRagMetadata GetRagMetadata(object resource)

--- a/src/Primitives/CrestApps.Core.AI/Models/AIDataSourceOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI/Models/AIDataSourceOptions.cs
@@ -103,4 +103,16 @@ public sealed class AIDataSourceOptions
 
         return 3;
     }
+
+    /// <summary>
+    /// Gets the minimum vector-search score required for a result to pass the current strictness level.
+    /// Strictness 1 keeps the broadest recall, while 5 applies the narrowest filter.
+    /// </summary>
+    /// <param name="strictness">The configured strictness override.</param>
+    public float GetMinimumScore(int? strictness)
+    {
+        var resolvedStrictness = GetStrictness(strictness);
+
+        return Math.Max(0f, (resolvedStrictness - 1f) / MaxStrictness);
+    }
 }

--- a/src/Primitives/CrestApps.Core.AI/Services/AIDataSourceIndexingBackgroundService.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/AIDataSourceIndexingBackgroundService.cs
@@ -1,3 +1,4 @@
+using CrestApps.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -63,6 +64,19 @@ internal sealed class AIDataSourceIndexingBackgroundService : BackgroundService
                     case AIDataSourceIndexingWorkItemType.RemoveDataSourceDocuments:
                         await indexingService.RemoveDataSourceDocumentsAsync(workItem.DataSourceId, workItem.DocumentIds, stoppingToken);
                         break;
+                }
+
+                // External index writes (Elasticsearch, pgvector, …) commit immediately, but any writes made
+                // to the transactional store during indexing — e.g. the Web data-source handler stamping
+                // crawl state with the successful-index timestamp — only flush when the session is committed.
+                // A request commits via StoreCommitterActionFilter; this background scope has no such filter,
+                // so commit explicitly here. On failure the scope is disposed without committing, rolling those
+                // writes back so the work is retried on the next pass.
+                var committer = scope.ServiceProvider.GetService<IStoreCommitter>();
+
+                if (committer is not null)
+                {
+                    await committer.CommitAsync(stoppingToken);
                 }
 
                 if (_logger.IsEnabled(LogLevel.Trace))

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceSearchResultSelector.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceSearchResultSelector.cs
@@ -1,0 +1,134 @@
+using System.IO;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+
+namespace CrestApps.Core.AI.Services;
+
+/// <summary>
+/// Filters and trims data-source search results before they are injected into prompts or returned by tools.
+/// </summary>
+internal static class DataSourceSearchResultSelector
+{
+    private static readonly HashSet<string> NonPageExtensions =
+    [
+        ".atom",
+        ".csv",
+        ".gz",
+        ".ics",
+        ".json",
+        ".kml",
+        ".pdf",
+        ".rss",
+        ".txt",
+        ".xml",
+        ".zip",
+    ];
+
+    /// <summary>
+    /// Gets the candidate count to request from the vector store so result filtering has enough headroom.
+    /// </summary>
+    /// <param name="topN">The final result count requested by the caller.</param>
+    /// <returns>The expanded candidate count.</returns>
+    public static int GetCandidateCount(int topN)
+    {
+        if (topN <= 0)
+        {
+            return 0;
+        }
+
+        return Math.Min(
+            AIDataSourceOptions.MaxTopNDocuments,
+            Math.Max(topN, topN * 3));
+    }
+
+    /// <summary>
+    /// Selects the highest-quality results after applying the minimum score and web-page quality filters.
+    /// </summary>
+    /// <param name="results">The raw search results.</param>
+    /// <param name="topN">The maximum number of results to return.</param>
+    /// <param name="minimumScore">The minimum score threshold.</param>
+    /// <returns>The filtered and trimmed results.</returns>
+    public static IReadOnlyList<DataSourceSearchResult> SelectTopResults(
+        IEnumerable<DataSourceSearchResult> results,
+        int topN,
+        float minimumScore)
+    {
+        if (results == null || topN <= 0)
+        {
+            return [];
+        }
+
+        return results
+            .Where(result => result != null)
+            .Where(result => !string.IsNullOrWhiteSpace(result.Content))
+            .Where(result => minimumScore <= 0 || result.Score >= minimumScore)
+            .Where(result => !ShouldExclude(result))
+            .OrderByDescending(result => result.Score)
+            .Take(topN)
+            .ToList();
+    }
+
+    private static bool ShouldExclude(DataSourceSearchResult result)
+    {
+        if (!string.Equals(result.ReferenceType, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (LooksLikeNonPageAsset(result.ReferenceId))
+        {
+            return true;
+        }
+
+        return LooksLikeErrorPage(result.Title, result.Content);
+    }
+
+    private static bool LooksLikeNonPageAsset(string referenceId)
+    {
+        if (string.IsNullOrWhiteSpace(referenceId))
+        {
+            return false;
+        }
+
+        var path = referenceId;
+
+        if (Uri.TryCreate(referenceId, UriKind.Absolute, out var uri))
+        {
+            path = uri.AbsolutePath;
+        }
+        else
+        {
+            var fragmentIndex = path.IndexOf('#');
+
+            if (fragmentIndex >= 0)
+            {
+                path = path[..fragmentIndex];
+            }
+
+            var queryIndex = path.IndexOf('?');
+
+            if (queryIndex >= 0)
+            {
+                path = path[..queryIndex];
+            }
+        }
+
+        var extension = Path.GetExtension(path);
+
+        return !string.IsNullOrEmpty(extension) &&
+            NonPageExtensions.Contains(extension);
+    }
+
+    private static bool LooksLikeErrorPage(string title, string content)
+    {
+        if (!string.IsNullOrWhiteSpace(title) &&
+            (title.StartsWith("404", StringComparison.OrdinalIgnoreCase) ||
+             title.Contains("Page Not Found", StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(content) &&
+            content.Contains("404 - Page Not Found", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceIndexingService.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDataSourceIndexingService.cs
@@ -350,7 +350,14 @@ public sealed class DefaultAIDataSourceIndexingService : IAIDataSourceIndexingSe
         var success = await context.DocumentManager.AddOrUpdateAsync(context.KnowledgeBaseProfile, documents.ToArray(), cancellationToken);
         if (!success)
         {
+            // The knowledge-base write failed. Surface it as an exception instead of swallowing it: a caller
+            // that records progress after indexing (e.g. the Web data-source handler stamping crawl state
+            // with a successful-index timestamp) must not treat a failed write as success, or the affected
+            // pages would be marked indexed and never retried even though nothing was stored.
             _logger.LogWarning("Knowledge-base indexing reported a failure for data source '{DataSourceId}' in index '{IndexName}'.", context.DataSource.ItemId, context.KnowledgeBaseProfile.IndexFullName);
+
+            throw new InvalidOperationException(
+                $"Knowledge-base indexing failed for data source '{context.DataSource.ItemId}' in index '{context.KnowledgeBaseProfile.IndexFullName}'.");
         }
 
         documents.Clear();

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/DocumentationToolInstanceServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/DocumentationToolInstanceServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.Builders;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -154,6 +155,7 @@ public static class DocumentationToolInstanceServiceCollectionExtensions
     {
         builder.Services.TryAddSingleton(TimeProvider.System);
         builder.Services.TryAddSingleton<IDocumentationSourceMaterializer, DefaultDocumentationSourceMaterializer>();
+        builder.Services.TryAddSingleton<ISitemapCrawler, SitemapCrawler>();
 
         builder.Services
             .AddHttpClient(DocumentationToolConstants.HttpClientName, client =>

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/SitemapDocumentationSource.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/SitemapDocumentationSource.cs
@@ -1,7 +1,5 @@
-using System.IO.Compression;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
+using CrestApps.Core.AI.Crawling;
 using Microsoft.Extensions.Logging;
 
 namespace CrestApps.Core.AI.Tooling.Instances.Documentation;
@@ -9,29 +7,18 @@ namespace CrestApps.Core.AI.Tooling.Instances.Documentation;
 /// <summary>
 /// A built-in <see cref="IDocumentationSource"/> that indexes a public documentation site by reading
 /// its sitemap, fetching each page, and ranking pages against a query using lightweight keyword scoring.
-/// The crawler understands the full sitemaps.org protocol as it appears on the market: a flat
-/// <c>&lt;urlset&gt;</c>, a <c>&lt;sitemapindex&gt;</c> that nests child sitemaps (for example those
-/// emitted by Yoast, Rank Math, or Google), gzip-compressed sitemaps (<c>.xml.gz</c>), plain-text
-/// sitemaps, and sitemaps advertised through <c>robots.txt</c>. The crawled corpus is cached in memory
-/// and refreshed based on <see cref="DocumentationSearchOptions.CacheDuration"/>.
+/// Sitemap discovery is delegated to the shared <see cref="ISitemapCrawler"/>, so the crawler understands
+/// the full sitemaps.org protocol as it appears on the market (flat <c>&lt;urlset&gt;</c>, nested
+/// <c>&lt;sitemapindex&gt;</c>, gzip-compressed and plain-text sitemaps, RSS/Atom feeds, and
+/// <c>robots.txt</c> advertisements). The crawled corpus is cached in memory and refreshed based on
+/// <see cref="DocumentationSearchOptions.CacheDuration"/>.
 /// </summary>
 public sealed partial class SitemapDocumentationSource : CachingDocumentationSource
 {
-    /// <summary>
-    /// The maximum number of nested sitemap levels the crawler follows. A sitemap index may point at
-    /// child indexes; this bounds that recursion so a misconfigured or hostile site cannot loop forever.
-    /// </summary>
-    private const int MaxSitemapDepth = 5;
-
-    /// <summary>
-    /// The maximum number of sitemap documents (indexes and leaf sitemaps combined) the crawler downloads
-    /// while discovering page URLs for a single site.
-    /// </summary>
-    private const int MaxSitemapDocuments = 50;
-
     private readonly DocumentationSite _site;
     private readonly DocumentationSearchOptions _options;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ISitemapCrawler _sitemapCrawler;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -40,12 +27,14 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
     /// <param name="site">The site configuration.</param>
     /// <param name="options">The global documentation search options.</param>
     /// <param name="httpClientFactory">The HTTP client factory.</param>
+    /// <param name="sitemapCrawler">The shared sitemap crawler used to discover page URLs.</param>
     /// <param name="timeProvider">The time provider.</param>
     /// <param name="logger">The logger.</param>
     public SitemapDocumentationSource(
         DocumentationSite site,
         DocumentationSearchOptions options,
         IHttpClientFactory httpClientFactory,
+        ISitemapCrawler sitemapCrawler,
         TimeProvider timeProvider,
         ILogger logger)
         : base(site.Name, options.CacheDuration, timeProvider, options.FirstSearchWaitBudget)
@@ -53,6 +42,7 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
         _site = site;
         _options = options;
         _httpClientFactory = httpClientFactory;
+        _sitemapCrawler = sitemapCrawler;
         _logger = logger;
     }
 
@@ -71,9 +61,18 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
     {
         var client = _httpClientFactory.CreateClient(DocumentationToolConstants.HttpClientName);
         var maxPages = Math.Max(1, _site.MaxPages ?? _options.MaxPagesPerSite);
-        var urls = await GetSitemapUrlsAsync(client, maxPages, cancellationToken);
 
-        if (urls.Count == 0)
+        var discovered = await _sitemapCrawler.DiscoverAsync(
+            client,
+            new SitemapCrawlRequest
+            {
+                BaseUrl = _site.BaseUrl,
+                SitemapUrl = _site.SitemapUrl,
+                MaxPages = maxPages,
+            },
+            cancellationToken);
+
+        if (discovered.Count == 0)
         {
             _logger.LogWarning(
                 "Documentation source '{SourceName}' discovered no page URLs from its sitemap. Verify the sitemap URL and that the site is reachable.",
@@ -82,16 +81,16 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
             return [];
         }
 
-        var pages = new List<DocumentationCorpus.Entry>(urls.Count);
+        var pages = new List<DocumentationCorpus.Entry>(discovered.Count);
         using var throttle = new SemaphoreSlim(Math.Max(1, _options.MaxConcurrentRequests));
 
-        var tasks = urls.Select(async url =>
+        var tasks = discovered.Select(async entry =>
         {
             await throttle.WaitAsync(cancellationToken);
 
             try
             {
-                return await FetchPageAsync(client, url, cancellationToken);
+                return await FetchPageAsync(client, entry.Url, cancellationToken);
             }
             finally
             {
@@ -108,326 +107,6 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
         }
 
         return pages;
-    }
-
-    /// <summary>
-    /// Discovers the page URLs for the configured site by walking its sitemap graph. Sitemap index files
-    /// are followed into their child sitemaps, gzip-compressed and plain-text sitemaps are supported, and
-    /// discovery falls back to <c>robots.txt</c> and the well-known sitemap locations when no explicit
-    /// sitemap URL is configured.
-    /// </summary>
-    private async Task<IReadOnlyList<string>> GetSitemapUrlsAsync(HttpClient client, int maxPages, CancellationToken cancellationToken)
-    {
-        var seeds = await ResolveSitemapSeedsAsync(client, cancellationToken);
-
-        var pageUrls = new List<string>();
-        var seenPages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var visitedSitemaps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var queue = new Queue<(string Url, int Depth)>();
-
-        foreach (var seed in seeds)
-        {
-            if (visitedSitemaps.Add(seed))
-            {
-                queue.Enqueue((seed, 0));
-            }
-        }
-
-        var processedSitemaps = 0;
-
-        while (queue.Count > 0 && pageUrls.Count < maxPages && processedSitemaps < MaxSitemapDocuments)
-        {
-            var (sitemapUrl, depth) = queue.Dequeue();
-            processedSitemaps++;
-
-            var content = await DownloadSitemapContentAsync(client, sitemapUrl, cancellationToken);
-
-            if (content is null)
-            {
-                continue;
-            }
-
-            var (childSitemaps, pages) = ParseSitemap(content);
-
-            foreach (var page in pages)
-            {
-                if (pageUrls.Count >= maxPages)
-                {
-                    break;
-                }
-
-                if (seenPages.Add(page))
-                {
-                    pageUrls.Add(page);
-                }
-            }
-
-            if (depth < MaxSitemapDepth)
-            {
-                foreach (var child in childSitemaps)
-                {
-                    if (visitedSitemaps.Add(child))
-                    {
-                        queue.Enqueue((child, depth + 1));
-                    }
-                }
-            }
-        }
-
-        return pageUrls;
-    }
-
-    /// <summary>
-    /// Determines the sitemap URLs to start crawling from. An explicitly configured sitemap URL wins;
-    /// otherwise the crawler consults <c>robots.txt</c> and the conventional sitemap locations under the
-    /// base URL.
-    /// </summary>
-    private async Task<IReadOnlyList<string>> ResolveSitemapSeedsAsync(HttpClient client, CancellationToken cancellationToken)
-    {
-        var seeds = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        void Add(string url)
-        {
-            if (!string.IsNullOrWhiteSpace(url) && seen.Add(url.Trim()))
-            {
-                seeds.Add(url.Trim());
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(_site.SitemapUrl))
-        {
-            Add(_site.SitemapUrl);
-
-            return seeds;
-        }
-
-        if (!string.IsNullOrWhiteSpace(_site.BaseUrl))
-        {
-            foreach (var advertised in await GetRobotsSitemapsAsync(client, cancellationToken))
-            {
-                Add(advertised);
-            }
-
-            var baseUrl = _site.BaseUrl.TrimEnd('/');
-
-            // The two conventional locations. Yoast/Rank Math sites typically redirect /sitemap.xml to
-            // their index; HttpClient follows those redirects, and unreachable candidates fail gracefully.
-            Add($"{baseUrl}/sitemap.xml");
-            Add($"{baseUrl}/sitemap_index.xml");
-        }
-
-        return seeds;
-    }
-
-    /// <summary>
-    /// Reads any <c>Sitemap:</c> directives advertised in the site's <c>robots.txt</c>.
-    /// </summary>
-    private async Task<IReadOnlyList<string>> GetRobotsSitemapsAsync(HttpClient client, CancellationToken cancellationToken)
-    {
-        const string directive = "Sitemap:";
-        var baseUrl = _site.BaseUrl.TrimEnd('/');
-        var robotsUrl = $"{baseUrl}/robots.txt";
-
-        try
-        {
-            var content = await client.GetStringAsync(robotsUrl, cancellationToken);
-            var results = new List<string>();
-
-            foreach (var line in content.Split('\n'))
-            {
-                var trimmed = line.Trim();
-
-                if (trimmed.StartsWith(directive, StringComparison.OrdinalIgnoreCase))
-                {
-                    var value = trimmed[directive.Length..].Trim();
-
-                    if (!string.IsNullOrEmpty(value))
-                    {
-                        results.Add(value);
-                    }
-                }
-            }
-
-            return results;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                _logger.LogDebug(ex, "Failed to read robots.txt '{RobotsUrl}' for documentation source '{SourceName}'.", robotsUrl, _site.Name);
-            }
-
-            return [];
-        }
-    }
-
-    /// <summary>
-    /// Downloads a sitemap document and returns its decoded text, transparently decompressing gzip
-    /// payloads (both <c>.xml.gz</c> files and gzip-encoded responses).
-    /// </summary>
-    private async Task<string> DownloadSitemapContentAsync(HttpClient client, string url, CancellationToken cancellationToken)
-    {
-        try
-        {
-            var bytes = await client.GetByteArrayAsync(url, cancellationToken);
-
-            if (bytes.Length == 0)
-            {
-                return null;
-            }
-
-            // Gzip files begin with the magic bytes 0x1F 0x8B. This covers .xml.gz sitemaps served with a
-            // binary content type, which HttpClient's automatic decompression does not unwrap.
-            if (bytes.Length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B)
-            {
-                bytes = Decompress(bytes);
-            }
-
-            return DecodeText(bytes);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to read sitemap '{SitemapUrl}' for documentation source '{SourceName}'.", url, _site.Name);
-
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Parses a sitemap document, separating child sitemap URLs (from a sitemap index) from page URLs.
-    /// Supports the standard <c>&lt;urlset&gt;</c> and <c>&lt;sitemapindex&gt;</c> XML formats (including
-    /// the News/Image/Video extensions, whose page URL is the <c>&lt;url&gt;&lt;loc&gt;</c>), RSS 2.0 and
-    /// Atom 1.0 feeds (which Google also accepts as sitemaps), and plain-text sitemaps. Page URLs are
-    /// classified by their parent element so that asset locations such as <c>&lt;image:loc&gt;</c> and
-    /// <c>&lt;video:loc&gt;</c> are ignored.
-    /// </summary>
-    private static (IReadOnlyList<string> ChildSitemaps, IReadOnlyList<string> Pages) ParseSitemap(string content)
-    {
-        var childSitemaps = new List<string>();
-        var pages = new List<string>();
-
-        XDocument document = null;
-
-        try
-        {
-            document = XDocument.Parse(content);
-        }
-        catch
-        {
-            // Not XML. Fall through to the plain-text sitemap handling below.
-        }
-
-        if (document is not null)
-        {
-            foreach (var loc in document.Descendants().Where(element => string.Equals(element.Name.LocalName, "loc", StringComparison.OrdinalIgnoreCase)))
-            {
-                var value = loc.Value?.Trim();
-
-                if (string.IsNullOrEmpty(value))
-                {
-                    continue;
-                }
-
-                var parentName = loc.Parent?.Name.LocalName;
-
-                if (string.Equals(parentName, "sitemap", StringComparison.OrdinalIgnoreCase))
-                {
-                    childSitemaps.Add(value);
-                }
-                else if (string.Equals(parentName, "url", StringComparison.OrdinalIgnoreCase))
-                {
-                    pages.Add(value);
-                }
-
-                // Any other parent (image, video, news, ...) is asset metadata and is intentionally skipped.
-            }
-
-            // No sitemaps.org <loc> elements were found. The document may be an RSS 2.0 or Atom 1.0 feed,
-            // which Google also accepts as a sitemap format.
-            if (childSitemaps.Count == 0 && pages.Count == 0)
-            {
-                ExtractFeedUrls(document, pages);
-            }
-
-            return (childSitemaps, pages);
-        }
-
-        // Plain-text sitemap: one absolute URL per line.
-        foreach (var line in content.Split('\n'))
-        {
-            var trimmed = line.Trim();
-
-            if (trimmed.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-                || trimmed.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-            {
-                pages.Add(trimmed);
-            }
-        }
-
-        return (childSitemaps, pages);
-    }
-
-    /// <summary>
-    /// Extracts item/entry URLs from an RSS 2.0 or Atom 1.0 feed. RSS items carry the URL as the text of a
-    /// <c>&lt;link&gt;</c> element; Atom entries carry it in the <c>href</c> attribute of an
-    /// <c>&lt;link&gt;</c> element, preferring the <c>alternate</c> relation. Feed-level links (the channel
-    /// or feed homepage) are ignored because only <c>&lt;item&gt;</c> and <c>&lt;entry&gt;</c> links are read.
-    /// </summary>
-    private static void ExtractFeedUrls(XDocument document, List<string> pages)
-    {
-        foreach (var element in document.Descendants())
-        {
-            var name = element.Name.LocalName;
-
-            if (string.Equals(name, "item", StringComparison.OrdinalIgnoreCase))
-            {
-                var link = element.Elements()
-                    .FirstOrDefault(child => string.Equals(child.Name.LocalName, "link", StringComparison.OrdinalIgnoreCase));
-
-                // RSS uses the element text; some feeds instead carry an Atom-style href.
-                var url = link?.Value?.Trim();
-
-                if (string.IsNullOrEmpty(url))
-                {
-                    url = link?.Attribute("href")?.Value?.Trim();
-                }
-
-                if (!string.IsNullOrEmpty(url))
-                {
-                    pages.Add(url);
-                }
-            }
-            else if (string.Equals(name, "entry", StringComparison.OrdinalIgnoreCase))
-            {
-                var links = element.Elements()
-                    .Where(child => string.Equals(child.Name.LocalName, "link", StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-
-                // Prefer the alternate (or unspecified) relation; never the self/edit/enclosure links.
-                var preferred = links.FirstOrDefault(child =>
-                {
-                    var rel = child.Attribute("rel")?.Value;
-
-                    return string.IsNullOrEmpty(rel) || string.Equals(rel, "alternate", StringComparison.OrdinalIgnoreCase);
-                }) ?? links.FirstOrDefault();
-
-                var url = preferred?.Attribute("href")?.Value?.Trim();
-
-                if (!string.IsNullOrEmpty(url))
-                {
-                    pages.Add(url);
-                }
-            }
-        }
     }
 
     private async Task<DocumentationCorpus.Entry> FetchPageAsync(HttpClient client, string url, CancellationToken cancellationToken)
@@ -458,25 +137,6 @@ public sealed partial class SitemapDocumentationSource : CachingDocumentationSou
 
             return null;
         }
-    }
-
-    private static byte[] Decompress(byte[] input)
-    {
-        using var source = new MemoryStream(input);
-        using var gzip = new GZipStream(source, CompressionMode.Decompress);
-        using var destination = new MemoryStream();
-
-        gzip.CopyTo(destination);
-
-        return destination.ToArray();
-    }
-
-    private static string DecodeText(byte[] bytes)
-    {
-        var text = Encoding.UTF8.GetString(bytes);
-
-        // Strip a leading UTF-8 byte-order mark (U+FEFF) so XDocument.Parse does not choke on it.
-        return text.TrimStart('﻿');
     }
 
     private static string ExtractTitle(string html)

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/SitemapDocumentationToolSource.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/Documentation/SitemapDocumentationToolSource.cs
@@ -1,3 +1,4 @@
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.AI.Tooling;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,10 +47,13 @@ public sealed class SitemapDocumentationToolSource : IAIToolInstanceSource
             var options = services.GetService<IOptions<DocumentationSearchOptions>>()?.Value ?? new DocumentationSearchOptions();
             var httpClientFactory = services.GetRequiredService<IHttpClientFactory>();
             var timeProvider = services.GetService<TimeProvider>() ?? TimeProvider.System;
+            var sitemapCrawler = services.GetService<ISitemapCrawler>()
+                ?? new SitemapCrawler(services.GetService<ILoggerFactory>()?.CreateLogger<SitemapCrawler>()
+                    ?? NullLogger<SitemapCrawler>.Instance);
             var logger = services.GetService<ILoggerFactory>()?.CreateLogger<SitemapDocumentationSource>()
                 ?? NullLogger<SitemapDocumentationSource>.Instance;
 
-            return new SitemapDocumentationSource(site, options, httpClientFactory, timeProvider, logger);
+            return new SitemapDocumentationSource(site, options, httpClientFactory, sitemapCrawler, timeProvider, logger);
         });
     }
 }

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -185,6 +185,7 @@ public sealed class DataSourceSearchTool : AIFunction
 
             var ragMetadata = GetRagMetadata(executionContext);
             var siteSettings = arguments.Services.GetRequiredService<IOptionsMonitor<AIDataSourceOptions>>().CurrentValue;
+            var topN = siteSettings.GetTopNDocuments(ragMetadata?.TopNDocuments);
 
             string providerFilter = null;
 
@@ -205,10 +206,10 @@ public sealed class DataSourceSearchTool : AIFunction
             var results = await contentManager.SearchAsync(
                 masterIndexProfile,
                 embeddings[0].Vector.ToArray(),
-            dataSourceId,
-            siteSettings.GetTopNDocuments(ragMetadata?.TopNDocuments),
-            providerFilter,
-            cancellationToken);
+                dataSourceId,
+                DataSourceSearchResultSelector.GetCandidateCount(topN),
+                providerFilter,
+                cancellationToken);
 
             if (results == null || !results.Any())
             {
@@ -217,19 +218,14 @@ public sealed class DataSourceSearchTool : AIFunction
                     : "No relevant content was found in the data source for this query. Answer using your general knowledge instead.";
             }
 
-            var strictness = siteSettings.GetStrictness(ragMetadata?.Strictness);
+            var minimumScore = siteSettings.GetMinimumScore(ragMetadata?.Strictness);
+            results = DataSourceSearchResultSelector.SelectTopResults(results, topN, minimumScore);
 
-            if (strictness > 0)
+            if (!results.Any())
             {
-                var threshold = strictness / (float)AIDataSourceOptions.MaxStrictness;
-                results = results.Where(result => result.Score >= threshold);
-
-                if (!results.Any())
-                {
-                    return ragMetadata?.IsInScope == true
-                        ? "No results met the strictness threshold. The answer is not available in the configured data source."
-                        : "No results met the strictness threshold. Answer using your general knowledge instead.";
-                }
+                return ragMetadata?.IsInScope == true
+                    ? "No results met the strictness and quality thresholds. The answer is not available in the configured data source."
+                    : "No results met the strictness and quality thresholds. Answer using your general knowledge instead.";
             }
 
             using var builder = ZString.CreateStringBuilder();

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -141,14 +141,18 @@ public sealed class DataSourceSearchTool : AIFunction
             var aiClientFactory = arguments.Services.GetRequiredService<IAIClientFactory>();
             var deploymentManager = arguments.Services.GetRequiredService<IAIDeploymentManager>();
 
-            if (!masterIndexProfile.TryGet(out DataSourceIndexProfileMetadata profileMetadata))
+            // Resolve the query-embedding deployment exactly the way the indexing service does: it lives on
+            // the index profile itself (masterIndexProfile.EmbeddingDeploymentName) and is only optionally
+            // overridden by the data-source metadata. The metadata being absent must NOT fail search, or a
+            // profile that indexed fine using the top-level embedding deployment could never be queried.
+            masterIndexProfile.TryGet(out DataSourceIndexProfileMetadata profileMetadata);
+
+            var deploymentName = masterIndexProfile.EmbeddingDeploymentName;
+
+            if (profileMetadata != null && !string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
             {
-                logger.LogWarning("AI Tool '{ToolName}' failed: embedding configuration is missing for the knowledge base index.", Name);
-
-                return "Embedding configuration is missing for the knowledge base index.";
+                deploymentName = profileMetadata.EmbeddingDeploymentName;
             }
-
-            var deploymentName = profileMetadata.EmbeddingDeploymentName ?? masterIndexProfile.EmbeddingDeploymentName;
 
             if (string.IsNullOrWhiteSpace(deploymentName))
             {

--- a/src/Primitives/CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj
+++ b/src/Primitives/CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" />
     <PackageReference Include="Microsoft.Extensions.DataIngestion" />
   </ItemGroup>
 

--- a/src/Primitives/CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj
+++ b/src/Primitives/CrestApps.Core.DataIngestion/CrestApps.Core.DataIngestion.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>CrestApps.Core.DataIngestion</RootNamespace>
+    <Title>CrestApps Data Ingestion</Title>
+    <Description>
+      $(CrestAppsDescription)
+
+      Reusable document readers for Microsoft.Extensions.DataIngestion, starting with an HTML reader that
+      cleans markup into plain text for chunking and embedding.
+    </Description>
+    <PackageTags>$(PackageTags) data-ingestion html reader rag</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DataIngestion" />
+  </ItemGroup>
+
+</Project>

--- a/src/Primitives/CrestApps.Core.DataIngestion/HtmlIngestionDocumentReader.cs
+++ b/src/Primitives/CrestApps.Core.DataIngestion/HtmlIngestionDocumentReader.cs
@@ -1,18 +1,26 @@
-using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
 using Microsoft.Extensions.DataIngestion;
 
 namespace CrestApps.Core.DataIngestion;
 
 /// <summary>
-/// Reads an HTML document into an <see cref="IngestionDocument"/> for normalization and chunking. It
-/// removes <c>&lt;script&gt;</c> and <c>&lt;style&gt;</c> blocks, strips the remaining tags, decodes HTML
-/// entities, and collapses insignificant whitespace, producing a single plain-text paragraph. The page
-/// <c>&lt;title&gt;</c> is exposed separately through <see cref="ExtractTitle(string)"/>.
+/// Reads an HTML document into an <see cref="IngestionDocument"/> for normalization and chunking. The
+/// content comes from public websites and is therefore untrusted, so the document is parsed with a
+/// standards-compliant HTML5 parser (AngleSharp) rather than pattern matching: script, style, and other
+/// non-content nodes are removed together with their contents, and only the resulting text is kept.
+/// AngleSharp is a parser only — it never executes scripts — so no markup or code survives into the text
+/// that is embedded and stored. The page <c>&lt;title&gt;</c> is exposed separately through
+/// <see cref="ExtractTitle(string)"/>.
 /// </summary>
 public sealed partial class HtmlIngestionDocumentReader : IngestionDocumentReader
 {
+    // Elements whose text content must never be indexed. Their nodes (and everything inside them) are
+    // removed before any text is read, so executable or presentational payloads cannot leak through.
+    private const string NonContentSelector = "script, style, noscript, template, iframe, object, embed, svg, canvas, head";
+
     /// <summary>
     /// Reads an HTML stream into an <see cref="IngestionDocument"/>.
     /// </summary>
@@ -62,59 +70,67 @@ public sealed partial class HtmlIngestionDocumentReader : IngestionDocumentReade
     }
 
     /// <summary>
-    /// Extracts the page title from the <c>&lt;title&gt;</c> element.
+    /// Extracts the page title from the parsed <c>&lt;title&gt;</c> element.
     /// </summary>
     /// <param name="html">The raw HTML.</param>
-    /// <returns>The decoded, trimmed title, or <see langword="null"/> when the page has no title.</returns>
+    /// <returns>The plain-text title, or <see langword="null"/> when the page has no title.</returns>
     public static string ExtractTitle(string html)
     {
-        if (string.IsNullOrEmpty(html))
+        if (string.IsNullOrWhiteSpace(html))
         {
             return null;
         }
 
-        var match = TitleRegex().Match(html);
+        var parser = new HtmlParser();
+        using var document = parser.ParseDocument(html);
 
-        if (!match.Success)
-        {
-            return null;
-        }
+        // The title is RCDATA, so it cannot carry executable content, but it may contain angle-bracket text
+        // (for example "Hi <b>there</b>"). Strip any tag-like sequences so nothing HTML-looking is stored.
+        var title = CollapseWhitespace(TagRegex().Replace(document.Title ?? string.Empty, " "));
 
-        return WebUtility.HtmlDecode(match.Groups[1].Value).Trim();
+        return string.IsNullOrWhiteSpace(title) ? null : title;
     }
 
     /// <summary>
-    /// Strips scripts, styles, and markup from HTML and returns the collapsed plain text.
+    /// Parses the HTML and returns the plain text of its body, with all script, style, and other
+    /// non-content nodes removed.
     /// </summary>
     /// <param name="html">The raw HTML.</param>
     /// <returns>The plain-text body.</returns>
     public static string ExtractText(string html)
     {
-        if (string.IsNullOrEmpty(html))
+        if (string.IsNullOrWhiteSpace(html))
         {
             return null;
         }
 
-        var withoutScripts = ScriptRegex().Replace(html, " ");
-        var withoutStyles = StyleRegex().Replace(withoutScripts, " ");
-        var withoutTags = TagRegex().Replace(withoutStyles, " ");
-        var decoded = WebUtility.HtmlDecode(withoutTags);
+        var parser = new HtmlParser();
+        using var document = parser.ParseDocument(html);
 
-        return WhitespaceRegex().Replace(decoded, " ").Trim();
+        foreach (var node in document.QuerySelectorAll(NonContentSelector).ToArray())
+        {
+            node.Remove();
+        }
+
+        var root = (INode)document.Body ?? document.DocumentElement;
+        var text = CollapseWhitespace(root?.TextContent);
+
+        return string.IsNullOrEmpty(text) ? null : text;
     }
 
-    [GeneratedRegex(@"<script\b[^>]*>.*?</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
-    private static partial Regex ScriptRegex();
+    private static string CollapseWhitespace(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
 
-    [GeneratedRegex(@"<style\b[^>]*>.*?</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
-    private static partial Regex StyleRegex();
-
-    [GeneratedRegex(@"<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
-    private static partial Regex TitleRegex();
-
-    [GeneratedRegex("<[^>]+>")]
-    private static partial Regex TagRegex();
+        return WhitespaceRegex().Replace(text, " ").Trim();
+    }
 
     [GeneratedRegex(@"\s+")]
     private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex TagRegex();
 }

--- a/src/Primitives/CrestApps.Core.DataIngestion/HtmlIngestionDocumentReader.cs
+++ b/src/Primitives/CrestApps.Core.DataIngestion/HtmlIngestionDocumentReader.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DataIngestion;
+
+namespace CrestApps.Core.DataIngestion;
+
+/// <summary>
+/// Reads an HTML document into an <see cref="IngestionDocument"/> for normalization and chunking. It
+/// removes <c>&lt;script&gt;</c> and <c>&lt;style&gt;</c> blocks, strips the remaining tags, decodes HTML
+/// entities, and collapses insignificant whitespace, producing a single plain-text paragraph. The page
+/// <c>&lt;title&gt;</c> is exposed separately through <see cref="ExtractTitle(string)"/>.
+/// </summary>
+public sealed partial class HtmlIngestionDocumentReader : IngestionDocumentReader
+{
+    /// <summary>
+    /// Reads an HTML stream into an <see cref="IngestionDocument"/>.
+    /// </summary>
+    /// <param name="source">The HTML source stream.</param>
+    /// <param name="identifier">The document identifier (typically the page URL).</param>
+    /// <param name="mediaType">The media type (ignored; the content is treated as HTML).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public override async Task<IngestionDocument> ReadAsync(
+        Stream source,
+        string identifier,
+        string mediaType,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var reader = new StreamReader(source, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+        var html = await reader.ReadToEndAsync(cancellationToken);
+
+        return Read(html, identifier);
+    }
+
+    /// <summary>
+    /// Reads an in-memory HTML string into an <see cref="IngestionDocument"/>.
+    /// </summary>
+    /// <param name="html">The raw HTML.</param>
+    /// <param name="identifier">The document identifier (typically the page URL).</param>
+    /// <returns>The ingestion document.</returns>
+    public static IngestionDocument Read(string html, string identifier)
+    {
+        var document = new IngestionDocument(identifier);
+        var text = ExtractText(html);
+
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            var section = new IngestionDocumentSection();
+            section.Elements.Add(new IngestionDocumentParagraph(text)
+            {
+                Text = text,
+            });
+
+            document.Sections.Add(section);
+        }
+
+        return document;
+    }
+
+    /// <summary>
+    /// Extracts the page title from the <c>&lt;title&gt;</c> element.
+    /// </summary>
+    /// <param name="html">The raw HTML.</param>
+    /// <returns>The decoded, trimmed title, or <see langword="null"/> when the page has no title.</returns>
+    public static string ExtractTitle(string html)
+    {
+        if (string.IsNullOrEmpty(html))
+        {
+            return null;
+        }
+
+        var match = TitleRegex().Match(html);
+
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        return WebUtility.HtmlDecode(match.Groups[1].Value).Trim();
+    }
+
+    /// <summary>
+    /// Strips scripts, styles, and markup from HTML and returns the collapsed plain text.
+    /// </summary>
+    /// <param name="html">The raw HTML.</param>
+    /// <returns>The plain-text body.</returns>
+    public static string ExtractText(string html)
+    {
+        if (string.IsNullOrEmpty(html))
+        {
+            return null;
+        }
+
+        var withoutScripts = ScriptRegex().Replace(html, " ");
+        var withoutStyles = StyleRegex().Replace(withoutScripts, " ");
+        var withoutTags = TagRegex().Replace(withoutStyles, " ");
+        var decoded = WebUtility.HtmlDecode(withoutTags);
+
+        return WhitespaceRegex().Replace(decoded, " ").Trim();
+    }
+
+    [GeneratedRegex(@"<script\b[^>]*>.*?</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex ScriptRegex();
+
+    [GeneratedRegex(@"<style\b[^>]*>.*?</style>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex StyleRegex();
+
+    [GeneratedRegex(@"<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
+    private static partial Regex TitleRegex();
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/src/Primitives/CrestApps.Core.PostgreSQL/PostgreSQLHelpers.cs
+++ b/src/Primitives/CrestApps.Core.PostgreSQL/PostgreSQLHelpers.cs
@@ -74,7 +74,12 @@ public static partial class PostgreSQLHelpers
             throw new InvalidOperationException($"The PostgreSQL identifier '{trimmedName}' contains unsupported characters.");
         }
 
-        return $""""{trimmedName.Replace("\"", "\"\"", StringComparison.Ordinal)}"""";
+        // Wrap the identifier in double quotes (doubling any embedded quote) so names that are not valid
+        // unquoted identifiers — e.g. a table derived from an index profile named "data-sources", whose
+        // hyphen would otherwise raise "42601: syntax error at or near '-'" — are emitted correctly.
+        var escapedName = trimmedName.Replace("\"", "\"\"", StringComparison.Ordinal);
+
+        return $"\"{escapedName}\"";
     }
 
     [GeneratedRegex("^[A-Za-z0-9_-]+$")]

--- a/src/Startup/CrestApps.Core.Aspire.AppHost/Program.cs
+++ b/src/Startup/CrestApps.Core.Aspire.AppHost/Program.cs
@@ -73,7 +73,7 @@ var mvcWeb = builder.AddProject<Projects.CrestApps_Core_Mvc_Web>("MvcWeb")
     .WithReference(redis)
     .WithReference(ollama)
     .WithReference(postgres)
-    .WithHttpsEndpoint(5001, name: "HttpsMvcWeb")
+    .WithHttpsEndpoint(7150, name: "HttpsMvcWeb")
     .WithEnvironment((options) =>
     {
         options.EnvironmentVariables.Add("CrestApps__AI__Providers__Ollama__DefaultDeploymentName", ollamaModelName);
@@ -121,7 +121,7 @@ builder.AddProject<Projects.CrestApps_Core_Mvc_Samples_McpClient>("McpClientSamp
     .WithHttpsEndpoint(5002, name: "HttpsMvcMcpClient")
     .WithEnvironment("Mcp__DefaultServer", "MvcWeb")
     .WithEnvironment("Mcp__Servers__MvcWeb__DisplayName", "MVC Web")
-    .WithEnvironment("Mcp__Servers__MvcWeb__Endpoint", "https://localhost:5001/mcp")
+    .WithEnvironment("Mcp__Servers__MvcWeb__Endpoint", "https://localhost:7150/mcp")
     .WithEnvironment("Mcp__Servers__BlazorWeb__DisplayName", "Blazor Web")
     .WithEnvironment("Mcp__Servers__BlazorWeb__Endpoint", "https://localhost:5201/mcp");
 
@@ -133,7 +133,7 @@ builder.AddProject<Projects.CrestApps_Core_Mvc_Samples_A2AClient>("A2AClientSamp
     .WithHttpsEndpoint(5003, name: "HttpsMvcA2AClient")
     .WithEnvironment("A2A__DefaultServer", "MvcWeb")
     .WithEnvironment("A2A__Servers__MvcWeb__DisplayName", "MVC Web")
-    .WithEnvironment("A2A__Servers__MvcWeb__Endpoint", "https://localhost:5001")
+    .WithEnvironment("A2A__Servers__MvcWeb__Endpoint", "https://localhost:7150")
     .WithEnvironment("A2A__Servers__BlazorWeb__DisplayName", "Blazor Web")
     .WithEnvironment("A2A__Servers__BlazorWeb__Endpoint", "https://localhost:5201");
 

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Layout/NavMenu.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Layout/NavMenu.razor
@@ -42,6 +42,11 @@
             </NavLink>
         </li>
         <li class="nav-item">
+            <NavLink class="nav-link" href="/webcrawlers">
+                <i class="bi bi-globe"></i> Web Crawlers
+            </NavLink>
+        </li>
+        <li class="nav-item">
             <NavLink class="nav-link" href="/ai/templates">
                 <i class="bi bi-file-earmark-text"></i> Templates
             </NavLink>

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Create.razor
@@ -244,26 +244,29 @@
                 <div class="form-text">The index where chunked and embedded documents are stored for AI retrieval.</div>
             </div>
 
-            <hr />
-            <h5>Field Mapping</h5>
+            @if (!IsWebSource())
+            {
+                <hr />
+                <h5>Field Mapping</h5>
 
-            <div class="mb-3">
-                <label class="form-label">Key field name <span class="text-danger">*</span></label>
-                <InputText @bind-Value="_model.KeyFieldName" class="form-control" placeholder="e.g., id" />
-                <div class="form-text">The source index field that maps to the document key.</div>
-            </div>
+                <div class="mb-3">
+                    <label class="form-label">Key field name <span class="text-danger">*</span></label>
+                    <InputText @bind-Value="_model.KeyFieldName" class="form-control" placeholder="e.g., id" />
+                    <div class="form-text">The source index field that maps to the document key.</div>
+                </div>
 
-            <div class="mb-3">
-                <label class="form-label">Title field name <span class="text-danger">*</span></label>
-                <InputText @bind-Value="_model.TitleFieldName" class="form-control" placeholder="e.g., title" />
-                <div class="form-text">The source index field that maps to the document title. Without it, citations fall back to the document ID.</div>
-            </div>
+                <div class="mb-3">
+                    <label class="form-label">Title field name <span class="text-danger">*</span></label>
+                    <InputText @bind-Value="_model.TitleFieldName" class="form-control" placeholder="e.g., title" />
+                    <div class="form-text">The source index field that maps to the document title. Without it, citations fall back to the document ID.</div>
+                </div>
 
-            <div class="mb-3">
-                <label class="form-label">Content field name <span class="text-danger">*</span></label>
-                <InputText @bind-Value="_model.ContentFieldName" class="form-control" placeholder="e.g., content" />
-                <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
-            </div>
+                <div class="mb-3">
+                    <label class="form-label">Content field name <span class="text-danger">*</span></label>
+                    <InputText @bind-Value="_model.ContentFieldName" class="form-control" placeholder="e.g., content" />
+                    <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                </div>
+            }
 
             <div class="mt-4">
                 <button type="submit" class="btn btn-primary">
@@ -320,19 +323,22 @@
             _errors.Add("Source type is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+        if (!IsWebSource())
         {
-            _errors.Add("Key field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+            {
+                _errors.Add("Key field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.TitleFieldName))
-        {
-            _errors.Add("Title field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.TitleFieldName))
+            {
+                _errors.Add("Title field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.ContentFieldName))
-        {
-            _errors.Add("Content field name is required.");
+            if (string.IsNullOrWhiteSpace(model.ContentFieldName))
+            {
+                _errors.Add("Content field name is required.");
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(model.AIKnowledgeBaseIndexProfileName))
@@ -425,4 +431,7 @@
 
     private bool IsPostgreSQLSource()
         => string.Equals(_model.Source, AIDataSourceSourceTypes.PostgreSQL, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsWebSource()
+        => string.Equals(_model.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Edit.razor
@@ -253,26 +253,29 @@ else
                     <div class="form-text">The index where chunked and embedded documents are stored for AI retrieval.</div>
                 </div>
 
-                <hr />
-                <h5>Field Mapping</h5>
+                @if (!IsWebSource())
+                {
+                    <hr />
+                    <h5>Field Mapping</h5>
 
-                <div class="mb-3">
-                    <label class="form-label">Key field name <span class="text-danger">*</span></label>
-                    <InputText @bind-Value="_model.KeyFieldName" class="form-control" placeholder="e.g., id" />
-                    <div class="form-text">The source index field that maps to the document key.</div>
-                </div>
+                    <div class="mb-3">
+                        <label class="form-label">Key field name <span class="text-danger">*</span></label>
+                        <InputText @bind-Value="_model.KeyFieldName" class="form-control" placeholder="e.g., id" />
+                        <div class="form-text">The source index field that maps to the document key.</div>
+                    </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Title field name <span class="text-danger">*</span></label>
-                    <InputText @bind-Value="_model.TitleFieldName" class="form-control" placeholder="e.g., title" />
-                    <div class="form-text">The source index field that maps to the document title. Without it, citations fall back to the document ID.</div>
-                </div>
+                    <div class="mb-3">
+                        <label class="form-label">Title field name <span class="text-danger">*</span></label>
+                        <InputText @bind-Value="_model.TitleFieldName" class="form-control" placeholder="e.g., title" />
+                        <div class="form-text">The source index field that maps to the document title. Without it, citations fall back to the document ID.</div>
+                    </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Content field name <span class="text-danger">*</span></label>
-                    <InputText @bind-Value="_model.ContentFieldName" class="form-control" placeholder="e.g., content" />
-                    <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
-                </div>
+                    <div class="mb-3">
+                        <label class="form-label">Content field name <span class="text-danger">*</span></label>
+                        <InputText @bind-Value="_model.ContentFieldName" class="form-control" placeholder="e.g., content" />
+                        <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                    </div>
+                }
 
                 <div class="mt-4">
                     <button type="submit" class="btn btn-primary">
@@ -348,19 +351,22 @@ else
             _errors.Add("Source type is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+        if (!IsWebSource())
         {
-            _errors.Add("Key field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+            {
+                _errors.Add("Key field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.TitleFieldName))
-        {
-            _errors.Add("Title field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.TitleFieldName))
+            {
+                _errors.Add("Title field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.ContentFieldName))
-        {
-            _errors.Add("Content field name is required.");
+            if (string.IsNullOrWhiteSpace(model.ContentFieldName))
+            {
+                _errors.Add("Content field name is required.");
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(model.AIKnowledgeBaseIndexProfileName))
@@ -453,4 +459,7 @@ else
 
     private bool IsPostgreSQLSource()
         => string.Equals(_model?.Source, AIDataSourceSourceTypes.PostgreSQL, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsWebSource()
+        => string.Equals(_model?.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Home/Index.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Home/Index.razor
@@ -130,6 +130,34 @@
             </div>
         </div>
     </div>
+    <div class="col">
+        <div class="card h-100 border-info">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-3">
+                    <i class="bi bi-plugin fs-2 text-info me-3"></i>
+                    <h5 class="card-title mb-0">AI Tool Instances</h5>
+                </div>
+                <p class="card-text">Configure reusable tool instances that AI profiles and agents can call during a conversation.</p>
+                <a href="/tooling/instances" class="btn btn-info text-white">
+                    <i class="bi bi-arrow-right"></i> Manage Tool Instances
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100" style="border-color: #20c997;">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-3">
+                    <i class="bi bi-globe fs-2 me-3" style="color: #20c997;"></i>
+                    <h5 class="card-title mb-0">Web Crawlers</h5>
+                </div>
+                <p class="card-text">Scrape websites into a Web data source, mapping many sites into one knowledge base for retrieval.</p>
+                <a href="/webcrawlers" class="btn text-white" style="background-color: #20c997;">
+                    <i class="bi bi-arrow-right"></i> Manage Web Crawlers
+                </a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <section class="mt-5">

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Create.razor
@@ -1,0 +1,186 @@
+@page "/webcrawlers/create"
+@attribute [Authorize(Policy = "Admin")]
+@using CrestApps.Core.AI.DataSources
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.WebCrawlers
+@using CrestApps.Core.AI.WebCrawlers.Strategies
+@using CrestApps.Core.Blazor.Web.ViewModels
+@using CrestApps.Core.Services
+@using Microsoft.Extensions.Options
+@inject ISourceCatalogManager<WebCrawler> Manager
+@inject IAIDataSourceStore DataSourceStore
+@inject IStoreCommitter StoreCommitter
+@inject NavigationManager Navigation
+@inject IOptions<WebCrawlerStrategyOptions> StrategyOptions
+
+<PageTitle>Create Web Crawler</PageTitle>
+
+<h2><i class="bi bi-plus-lg"></i> Create Web Crawler</h2>
+<hr />
+
+<EditForm FormName="webcrawlers-create" Model="_model" OnValidSubmit="HandleSubmitAsync">
+    <div class="row">
+        <div class="col-md-8">
+            @if (_errors.Count > 0)
+            {
+                <div class="alert alert-danger">
+                    @foreach (var error in _errors)
+                    {
+                        <div>@error</div>
+                    }
+                </div>
+            }
+
+            <div class="mb-3">
+                <label class="form-label">Title <span class="text-danger">*</span></label>
+                <InputText @bind-Value="_model.DisplayText" class="form-control" placeholder="e.g., Docs site" />
+                <div class="form-text">A human-readable name for this crawler.</div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Target Web data source <span class="text-danger">*</span></label>
+                <InputSelect @bind-Value="_model.AIDataSourceId" class="form-select">
+                    <option value="">Select data source</option>
+                    @foreach (var item in _dataSources)
+                    {
+                        <option value="@item.Key">@item.Value</option>
+                    }
+                </InputSelect>
+                <div class="form-text">The Web data source whose knowledge base receives the scraped pages. Create one under Data Sources using the <strong>Web</strong> source type.</div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Strategy <span class="text-danger">*</span></label>
+                <InputSelect @bind-Value="_model.Source" class="form-select">
+                    <option value="">Select strategy</option>
+                    @foreach (var item in _strategies)
+                    {
+                        <option value="@item.Key">@item.Value</option>
+                    }
+                </InputSelect>
+                <div class="form-text">How the site is discovered and fetched.</div>
+            </div>
+
+            <div class="mb-3 form-check">
+                <InputCheckbox @bind-Value="_model.Enabled" class="form-check-input" />
+                <label class="form-check-label">Enabled</label>
+                <div class="form-text">Disabled crawlers are skipped by the re-index background service.</div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Re-index interval (minutes)</label>
+                <InputNumber @bind-Value="_model.ReindexIntervalMinutes" class="form-control" placeholder="1440" />
+                <div class="form-text">How often the background service re-crawls this site and re-indexes changed pages.</div>
+            </div>
+
+            @if (IsSitemapStrategy())
+            {
+                <hr />
+                <h5>Sitemap Settings</h5>
+                <div class="alert alert-info">
+                    Discover pages through the site's sitemap(s). Provide a base URL or an explicit sitemap URL; each page is fetched, cleaned to text, and indexed with its URL kept for citations.
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Base URL</label>
+                    <InputText @bind-Value="_model.SitemapBaseUrl" class="form-control" placeholder="https://docs.example.com" />
+                    <div class="form-text">Used to resolve the sitemap from robots.txt and the conventional locations when no explicit sitemap URL is given.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Sitemap URL</label>
+                    <InputText @bind-Value="_model.SitemapUrl" class="form-control" placeholder="https://docs.example.com/sitemap.xml" />
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4 mb-3">
+                        <label class="form-label">Max pages</label>
+                        <InputNumber @bind-Value="_model.SitemapMaxPages" class="form-control" placeholder="500" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label class="form-label">Max concurrent requests</label>
+                        <InputNumber @bind-Value="_model.SitemapMaxConcurrentRequests" class="form-control" placeholder="4" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label class="form-label">Request timeout (seconds)</label>
+                        <InputNumber @bind-Value="_model.SitemapRequestTimeoutSeconds" class="form-control" placeholder="30" />
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">User agent</label>
+                    <InputText @bind-Value="_model.SitemapUserAgent" class="form-control" placeholder="CrestApps-WebCrawler/1.0 (+https://crestapps.com)" />
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Include URL patterns</label>
+                    <InputTextArea @bind-Value="_model.SitemapIncludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line" />
+                    <div class="form-text">Optional. A page URL must match at least one pattern to be scraped. Leave empty to include every discovered page.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Exclude URL patterns</label>
+                    <InputTextArea @bind-Value="_model.SitemapExcludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line" />
+                    <div class="form-text">Optional. A page URL matching any pattern is skipped.</div>
+                </div>
+            }
+
+            <div class="mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-lg"></i> Create
+                </button>
+                <a href="/webcrawlers" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
+        </div>
+    </div>
+</EditForm>
+
+@code {
+    private readonly WebCrawlerViewModel _model = new();
+    private List<string> _errors = [];
+    private List<KeyValuePair<string, string>> _strategies = [];
+    private List<KeyValuePair<string, string>> _dataSources = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await PopulateDropdownsAsync();
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        _errors.Clear();
+
+        var crawler = await Manager.NewAsync(_model.Source);
+        _model.ApplyTo(crawler);
+
+        var validation = await Manager.ValidateAsync(crawler);
+
+        if (!validation.Succeeded)
+        {
+            _errors = validation.Errors.Select(error => error.ErrorMessage).ToList();
+
+            return;
+        }
+
+        await Manager.CreateAsync(crawler);
+        await StoreCommitter.CommitAsync();
+        Navigation.NavigateTo("/webcrawlers");
+    }
+
+    private bool IsSitemapStrategy()
+        => string.Equals(_model.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase);
+
+    private async Task PopulateDropdownsAsync()
+    {
+        _strategies = StrategyOptions.Value.Strategies
+            .OrderBy(strategy => strategy.DisplayName.Value, StringComparer.OrdinalIgnoreCase)
+            .Select(strategy => new KeyValuePair<string, string>(strategy.Strategy, strategy.DisplayName.Value))
+            .ToList();
+
+        var dataSources = await DataSourceStore.GetAsync(AIDataSourceSourceTypes.Web);
+
+        _dataSources = dataSources
+            .Select(dataSource => new KeyValuePair<string, string>(dataSource.ItemId, dataSource.DisplayText))
+            .ToList();
+    }
+}

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Edit.razor
@@ -1,0 +1,219 @@
+@page "/webcrawlers/edit/{Id}"
+@attribute [Authorize(Policy = "Admin")]
+@using CrestApps.Core.AI.DataSources
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.WebCrawlers
+@using CrestApps.Core.AI.WebCrawlers.Strategies
+@using CrestApps.Core.Blazor.Web.ViewModels
+@using CrestApps.Core.Services
+@using Microsoft.Extensions.Options
+@inject ISourceCatalogManager<WebCrawler> Manager
+@inject IAIDataSourceStore DataSourceStore
+@inject IStoreCommitter StoreCommitter
+@inject NavigationManager Navigation
+@inject IOptions<WebCrawlerStrategyOptions> StrategyOptions
+
+<PageTitle>Edit Web Crawler</PageTitle>
+
+<h2><i class="bi bi-pencil"></i> Edit Web Crawler</h2>
+<hr />
+
+@if (_notFound)
+{
+    <div class="alert alert-warning">The web crawler could not be found.</div>
+}
+else if (_model == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <EditForm FormName="webcrawlers-edit" Model="_model" OnValidSubmit="HandleSubmitAsync">
+        <div class="row">
+            <div class="col-md-8">
+                @if (_errors.Count > 0)
+                {
+                    <div class="alert alert-danger">
+                        @foreach (var error in _errors)
+                        {
+                            <div>@error</div>
+                        }
+                    </div>
+                }
+
+                <div class="mb-3">
+                    <label class="form-label">Title <span class="text-danger">*</span></label>
+                    <InputText @bind-Value="_model.DisplayText" class="form-control" placeholder="e.g., Docs site" />
+                    <div class="form-text">A human-readable name for this crawler.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Target Web data source <span class="text-danger">*</span></label>
+                    <InputSelect @bind-Value="_model.AIDataSourceId" class="form-select">
+                        <option value="">Select data source</option>
+                        @foreach (var item in _dataSources)
+                        {
+                            <option value="@item.Key">@item.Value</option>
+                        }
+                    </InputSelect>
+                    <div class="form-text">The Web data source whose knowledge base receives the scraped pages. Create one under Data Sources using the <strong>Web</strong> source type.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Strategy <span class="text-danger">*</span></label>
+                    <InputSelect @bind-Value="_model.Source" class="form-select">
+                        <option value="">Select strategy</option>
+                        @foreach (var item in _strategies)
+                        {
+                            <option value="@item.Key">@item.Value</option>
+                        }
+                    </InputSelect>
+                    <div class="form-text">How the site is discovered and fetched.</div>
+                </div>
+
+                <div class="mb-3 form-check">
+                    <InputCheckbox @bind-Value="_model.Enabled" class="form-check-input" />
+                    <label class="form-check-label">Enabled</label>
+                    <div class="form-text">Disabled crawlers are skipped by the re-index background service.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Re-index interval (minutes)</label>
+                    <InputNumber @bind-Value="_model.ReindexIntervalMinutes" class="form-control" placeholder="1440" />
+                    <div class="form-text">How often the background service re-crawls this site and re-indexes changed pages.</div>
+                </div>
+
+                @if (IsSitemapStrategy())
+                {
+                    <hr />
+                    <h5>Sitemap Settings</h5>
+                    <div class="alert alert-info">
+                        Discover pages through the site's sitemap(s). Provide a base URL or an explicit sitemap URL; each page is fetched, cleaned to text, and indexed with its URL kept for citations.
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Base URL</label>
+                        <InputText @bind-Value="_model.SitemapBaseUrl" class="form-control" placeholder="https://docs.example.com" />
+                        <div class="form-text">Used to resolve the sitemap from robots.txt and the conventional locations when no explicit sitemap URL is given.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Sitemap URL</label>
+                        <InputText @bind-Value="_model.SitemapUrl" class="form-control" placeholder="https://docs.example.com/sitemap.xml" />
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Max pages</label>
+                            <InputNumber @bind-Value="_model.SitemapMaxPages" class="form-control" placeholder="500" />
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Max concurrent requests</label>
+                            <InputNumber @bind-Value="_model.SitemapMaxConcurrentRequests" class="form-control" placeholder="4" />
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label class="form-label">Request timeout (seconds)</label>
+                            <InputNumber @bind-Value="_model.SitemapRequestTimeoutSeconds" class="form-control" placeholder="30" />
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">User agent</label>
+                        <InputText @bind-Value="_model.SitemapUserAgent" class="form-control" placeholder="CrestApps-WebCrawler/1.0 (+https://crestapps.com)" />
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Include URL patterns</label>
+                        <InputTextArea @bind-Value="_model.SitemapIncludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line" />
+                        <div class="form-text">Optional. A page URL must match at least one pattern to be scraped. Leave empty to include every discovered page.</div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label">Exclude URL patterns</label>
+                        <InputTextArea @bind-Value="_model.SitemapExcludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line" />
+                        <div class="form-text">Optional. A page URL matching any pattern is skipped.</div>
+                    </div>
+                }
+
+                <div class="mt-4">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-lg"></i> Save
+                    </button>
+                    <a href="/webcrawlers" class="btn btn-secondary ms-2">Cancel</a>
+                </div>
+            </div>
+        </div>
+    </EditForm>
+}
+
+@code {
+    [Parameter]
+    public string Id { get; set; }
+
+    private WebCrawlerViewModel _model;
+    private bool _notFound;
+    private List<string> _errors = [];
+    private List<KeyValuePair<string, string>> _strategies = [];
+    private List<KeyValuePair<string, string>> _dataSources = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        var crawler = await Manager.FindByIdAsync(Id);
+
+        if (crawler == null)
+        {
+            _notFound = true;
+
+            return;
+        }
+
+        _model = WebCrawlerViewModel.FromCrawler(crawler);
+        await PopulateDropdownsAsync();
+    }
+
+    private async Task HandleSubmitAsync()
+    {
+        _errors.Clear();
+
+        var crawler = await Manager.FindByIdAsync(_model.ItemId);
+
+        if (crawler == null)
+        {
+            _notFound = true;
+
+            return;
+        }
+
+        _model.ApplyTo(crawler);
+
+        var validation = await Manager.ValidateAsync(crawler);
+
+        if (!validation.Succeeded)
+        {
+            _errors = validation.Errors.Select(error => error.ErrorMessage).ToList();
+
+            return;
+        }
+
+        await Manager.UpdateAsync(crawler);
+        await StoreCommitter.CommitAsync();
+        Navigation.NavigateTo("/webcrawlers");
+    }
+
+    private bool IsSitemapStrategy()
+        => string.Equals(_model?.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase);
+
+    private async Task PopulateDropdownsAsync()
+    {
+        _strategies = StrategyOptions.Value.Strategies
+            .OrderBy(strategy => strategy.DisplayName.Value, StringComparer.OrdinalIgnoreCase)
+            .Select(strategy => new KeyValuePair<string, string>(strategy.Strategy, strategy.DisplayName.Value))
+            .ToList();
+
+        var dataSources = await DataSourceStore.GetAsync(AIDataSourceSourceTypes.Web);
+
+        _dataSources = dataSources
+            .Select(dataSource => new KeyValuePair<string, string>(dataSource.ItemId, dataSource.DisplayText))
+            .ToList();
+    }
+}

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
@@ -1,0 +1,144 @@
+@page "/webcrawlers"
+@attribute [Authorize(Policy = "Admin")]
+@using CrestApps.Core.AI.DataSources
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.Services
+@using CrestApps.Core.Services
+@inject ISourceCatalogManager<WebCrawler> Manager
+@inject IAIDataSourceStore DataSourceStore
+@inject IAIDataSourceIndexingQueue IndexingQueue
+@inject IStoreCommitter StoreCommitter
+@inject IJSRuntime JS
+@inject ToastNotificationService ToastNotifications
+
+<PageTitle>Web Crawlers</PageTitle>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2><i class="bi bi-globe"></i> Web Crawlers</h2>
+    <a href="/webcrawlers/create" class="btn btn-success">
+        <i class="bi bi-plus-lg"></i> Create New Web Crawler
+    </a>
+</div>
+
+@if (_crawlers == null)
+{
+    <p><em>Loading...</em></p>
+}
+else if (_crawlers.Count == 0)
+{
+    <div class="alert alert-info">
+        <i class="bi bi-info-circle"></i> No web crawlers found.
+        Create one to scrape a website into a Web data source.
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>Title</th>
+                    <th>Strategy</th>
+                    <th>Enabled</th>
+                    <th style="width: 250px;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in _crawlers)
+                {
+                    <tr>
+                        <td><strong>@item.DisplayText</strong></td>
+                        <td><code>@item.Source</code></td>
+                        <td>
+                            @if (item.Enabled)
+                            {
+                                <span class="badge bg-success">Enabled</span>
+                            }
+                            else
+                            {
+                                <span class="badge bg-secondary">Disabled</span>
+                            }
+                        </td>
+                        <td>
+                            <button type="button" class="btn btn-sm btn-outline-success" @onclick="() => SyncAsync(item.ItemId)">
+                                <i class="bi bi-arrow-repeat"></i> Sync
+                            </button>
+                            <a href="/webcrawlers/edit/@item.ItemId" class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-pencil"></i> Edit
+                            </a>
+                            <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => DeleteAsync(item.ItemId)">
+                                <i class="bi bi-trash"></i> Delete
+                            </button>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<WebCrawler> _crawlers;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var all = await Manager.GetAllAsync();
+
+        _crawlers = all.ToList();
+    }
+
+    private async Task SyncAsync(string id)
+    {
+        var crawler = await Manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            ToastNotifications.ShowError("Web crawler not found.");
+
+            return;
+        }
+
+        var dataSource = string.IsNullOrWhiteSpace(crawler.AIDataSourceId)
+            ? null
+            : await DataSourceStore.FindByIdAsync(crawler.AIDataSourceId);
+
+        if (dataSource == null)
+        {
+            ToastNotifications.ShowError("The target Web data source could not be found.");
+
+            return;
+        }
+
+        await IndexingQueue.QueueSyncDataSourceAsync(dataSource);
+        ToastNotifications.ShowSuccess("Web crawler synchronization has been queued.");
+    }
+
+    private async Task DeleteAsync(string id)
+    {
+        var confirmed = await JS.InvokeAsync<bool>("confirm", "Delete this web crawler?");
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        var crawler = await Manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            ToastNotifications.ShowError("Web crawler not found.");
+
+            return;
+        }
+
+        await Manager.DeleteAsync(crawler);
+        await StoreCommitter.CommitAsync();
+        ToastNotifications.ShowSuccess("Web crawler deleted successfully. Knowledge-base cleanup has been queued.");
+        await LoadAsync();
+    }
+}

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
@@ -1,12 +1,10 @@
 @page "/webcrawlers"
 @attribute [Authorize(Policy = "Admin")]
-@using CrestApps.Core.AI.DataSources
 @using CrestApps.Core.AI.Models
-@using CrestApps.Core.AI.Services
+@using CrestApps.Core.AI.WebCrawlers
 @using CrestApps.Core.Services
 @inject ISourceCatalogManager<WebCrawler> Manager
-@inject IAIDataSourceStore DataSourceStore
-@inject IAIDataSourceIndexingQueue IndexingQueue
+@inject IWebCrawlerReindexPlanner ReindexPlanner
 @inject IStoreCommitter StoreCommitter
 @inject IJSRuntime JS
 @inject ToastNotificationService ToastNotifications
@@ -103,19 +101,10 @@ else
             return;
         }
 
-        var dataSource = string.IsNullOrWhiteSpace(crawler.AIDataSourceId)
-            ? null
-            : await DataSourceStore.FindByIdAsync(crawler.AIDataSourceId);
-
-        if (dataSource == null)
-        {
-            ToastNotifications.ShowError("The target Web data source could not be found.");
-
-            return;
-        }
-
-        await IndexingQueue.QueueSyncDataSourceAsync(dataSource);
-        ToastNotifications.ShowSuccess("Web crawler synchronization has been queued.");
+        // Re-crawl just this site: discover its pages and queue the new/changed ones for indexing into the
+        // target data source, without rebuilding the other crawlers mapped to that data source.
+        var result = await ReindexPlanner.PlanAndEnqueueAsync(crawler);
+        ToastNotifications.ShowSuccess($"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.");
     }
 
     private async Task DeleteAsync(string id)

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor
@@ -104,7 +104,19 @@ else
         // Re-crawl just this site: discover its pages and queue the new/changed ones for indexing into the
         // target data source, without rebuilding the other crawlers mapped to that data source.
         var result = await ReindexPlanner.PlanAndEnqueueAsync(crawler);
-        ToastNotifications.ShowSuccess($"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.");
+
+        // The planner records crawl state through the transactional store; an interactive circuit has no
+        // request filter to flush it, so commit explicitly (the Delete handler below does the same).
+        await StoreCommitter.CommitAsync();
+
+        if (result.Status is WebCrawlerReindexStatus.DiscoveryFailed or WebCrawlerReindexStatus.NoPagesDiscovered)
+        {
+            ToastNotifications.ShowError(result.Message);
+        }
+        else
+        {
+            ToastNotifications.ShowSuccess($"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.");
+        }
     }
 
     private async Task DeleteAsync(string id)

--- a/src/Startup/CrestApps.Core.Blazor.Web/CrestApps.Core.Blazor.Web.csproj
+++ b/src/Startup/CrestApps.Core.Blazor.Web/CrestApps.Core.Blazor.Web.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Documents.OpenXml/CrestApps.Core.AI.Documents.OpenXml.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Documents.Pdf/CrestApps.Core.AI.Documents.Pdf.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Elasticsearch/CrestApps.Core.AI.Elasticsearch.csproj" />
+    <ProjectReference Include="../../Primitives/CrestApps.Core.AI.WebCrawlers/CrestApps.Core.AI.WebCrawlers.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Azure.AISearch/CrestApps.Core.AI.Azure.AISearch.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.PostgreSQL/CrestApps.Core.AI.PostgreSQL.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.Elasticsearch/CrestApps.Core.Elasticsearch.csproj" />

--- a/src/Startup/CrestApps.Core.Blazor.Web/Program.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Program.cs
@@ -1,5 +1,6 @@
 using CrestApps.Core;
 using CrestApps.Core.AI;
+using CrestApps.Core.AI.WebCrawlers;
 using CrestApps.Core.AI.A2A;
 using CrestApps.Core.AI.A2A.Models;
 using CrestApps.Core.AI.Azure.AISearch;
@@ -181,6 +182,11 @@ builder.Services
         )
      )
  );
+
+// Opt into the strategy-based web crawlers feature and its EntityCore stores. Web crawlers scrape sites
+// (starting with sitemap discovery) into any "Web" AI data source.
+builder.Services.AddCoreWebCrawlers();
+builder.Services.AddCoreWebCrawlerStoresEntityCore();
 
 builder.Services.Configure<A2AHostOptions>(
      builder.Configuration.GetSection(nameof(A2AHostOptions)));

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/WebCrawlerViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/WebCrawlerViewModel.cs
@@ -1,0 +1,108 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+
+namespace CrestApps.Core.Blazor.Web.ViewModels;
+
+public sealed class WebCrawlerViewModel
+{
+    public string ItemId { get; set; }
+
+    public string DisplayText { get; set; }
+
+    public string Source { get; set; } = WebCrawlerConstants.Strategies.Sitemap;
+
+    public string AIDataSourceId { get; set; }
+
+    public bool Enabled { get; set; } = true;
+
+    public int? ReindexIntervalMinutes { get; set; }
+
+    public string SitemapBaseUrl { get; set; }
+
+    public string SitemapUrl { get; set; }
+
+    public int? SitemapMaxPages { get; set; }
+
+    public int? SitemapMaxConcurrentRequests { get; set; }
+
+    public int? SitemapRequestTimeoutSeconds { get; set; }
+
+    public string SitemapUserAgent { get; set; }
+
+    public string SitemapIncludeUrlPatterns { get; set; }
+
+    public string SitemapExcludeUrlPatterns { get; set; }
+
+    public static WebCrawlerViewModel FromCrawler(WebCrawler crawler)
+    {
+        var model = new WebCrawlerViewModel
+        {
+            ItemId = crawler.ItemId,
+            DisplayText = crawler.DisplayText,
+            Source = string.IsNullOrWhiteSpace(crawler.Source) ? WebCrawlerConstants.Strategies.Sitemap : crawler.Source,
+            AIDataSourceId = crawler.AIDataSourceId,
+            Enabled = crawler.Enabled,
+            ReindexIntervalMinutes = crawler.ReindexIntervalMinutes,
+        };
+
+        if (crawler.TryGet<SitemapWebCrawlerMetadata>(out var sitemap))
+        {
+            model.SitemapBaseUrl = sitemap.BaseUrl;
+            model.SitemapUrl = sitemap.SitemapUrl;
+            model.SitemapMaxPages = sitemap.MaxPages;
+            model.SitemapMaxConcurrentRequests = sitemap.MaxConcurrentRequests;
+            model.SitemapRequestTimeoutSeconds = sitemap.RequestTimeoutSeconds;
+            model.SitemapUserAgent = sitemap.UserAgent;
+            model.SitemapIncludeUrlPatterns = JoinPatterns(sitemap.IncludeUrlPatterns);
+            model.SitemapExcludeUrlPatterns = JoinPatterns(sitemap.ExcludeUrlPatterns);
+        }
+
+        return model;
+    }
+
+    public void ApplyTo(WebCrawler crawler)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+
+        crawler.DisplayText = DisplayText?.Trim();
+        crawler.Source = string.IsNullOrWhiteSpace(Source) ? WebCrawlerConstants.Strategies.Sitemap : Source.Trim();
+        crawler.AIDataSourceId = AIDataSourceId?.Trim();
+        crawler.Enabled = Enabled;
+        crawler.ReindexIntervalMinutes = ReindexIntervalMinutes;
+
+        crawler.Remove<SitemapWebCrawlerMetadata>();
+
+        if (string.Equals(crawler.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase))
+        {
+            crawler.Put(new SitemapWebCrawlerMetadata
+            {
+                BaseUrl = SitemapBaseUrl?.Trim(),
+                SitemapUrl = SitemapUrl?.Trim(),
+                MaxPages = SitemapMaxPages,
+                MaxConcurrentRequests = SitemapMaxConcurrentRequests,
+                RequestTimeoutSeconds = SitemapRequestTimeoutSeconds,
+                UserAgent = string.IsNullOrWhiteSpace(SitemapUserAgent) ? null : SitemapUserAgent.Trim(),
+                IncludeUrlPatterns = SplitPatterns(SitemapIncludeUrlPatterns),
+                ExcludeUrlPatterns = SplitPatterns(SitemapExcludeUrlPatterns),
+            });
+        }
+    }
+
+    private static string JoinPatterns(IEnumerable<string> patterns)
+    {
+        return patterns is null ? null : string.Join('\n', patterns);
+    }
+
+    private static List<string> SplitPatterns(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        return value
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+    }
+}

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Controllers/AIDataSourceController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Controllers/AIDataSourceController.cs
@@ -174,19 +174,24 @@ public sealed class AIDataSourceController : Controller
             ModelState.AddModelError(nameof(model.Source), "Source type is required.");
         }
 
-        if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+        // The Web source derives its key, title, and content from each crawled page, so field mapping is
+        // not required for it.
+        if (!string.Equals(model.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase))
         {
-            ModelState.AddModelError(nameof(model.KeyFieldName), "Key field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.KeyFieldName))
+            {
+                ModelState.AddModelError(nameof(model.KeyFieldName), "Key field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.TitleFieldName))
-        {
-            ModelState.AddModelError(nameof(model.TitleFieldName), "Title field name is required.");
-        }
+            if (string.IsNullOrWhiteSpace(model.TitleFieldName))
+            {
+                ModelState.AddModelError(nameof(model.TitleFieldName), "Title field name is required.");
+            }
 
-        if (string.IsNullOrWhiteSpace(model.ContentFieldName))
-        {
-            ModelState.AddModelError(nameof(model.ContentFieldName), "Content field name is required.");
+            if (string.IsNullOrWhiteSpace(model.ContentFieldName))
+            {
+                ModelState.AddModelError(nameof(model.ContentFieldName), "Content field name is required.");
+            }
         }
 
         if (!string.IsNullOrWhiteSpace(model.AIKnowledgeBaseIndexProfileName))

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Create.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Create.cshtml
@@ -212,28 +212,30 @@
                 <div class="form-text">The index where chunked and embedded documents are stored for AI retrieval.</div>
             </div>
 
-            <hr />
-            <h5>Field Mapping</h5>
+            <div id="field-mapping-settings"@(string.Equals(Model.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase) ? " hidden" : null)>
+                <hr />
+                <h5>Field Mapping</h5>
 
-            <div class="mb-3">
-                <label asp-for="KeyFieldName" class="form-label">Key field name <span class="text-danger">*</span></label>
-                <input asp-for="KeyFieldName" class="form-control" required placeholder="e.g., id" />
-                <span asp-validation-for="KeyFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document key.</div>
-            </div>
+                <div class="mb-3">
+                    <label asp-for="KeyFieldName" class="form-label">Key field name <span class="text-danger">*</span></label>
+                    <input asp-for="KeyFieldName" class="form-control" required placeholder="e.g., id" />
+                    <span asp-validation-for="KeyFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document key.</div>
+                </div>
 
-            <div class="mb-3">
-                <label asp-for="TitleFieldName" class="form-label">Title field name <span class="text-danger">*</span></label>
-                <input asp-for="TitleFieldName" class="form-control" required placeholder="e.g., title" />
-                <span asp-validation-for="TitleFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document title. Without it, citations fall back to the document ID.</div>
-            </div>
+                <div class="mb-3">
+                    <label asp-for="TitleFieldName" class="form-label">Title field name <span class="text-danger">*</span></label>
+                    <input asp-for="TitleFieldName" class="form-control" required placeholder="e.g., title" />
+                    <span asp-validation-for="TitleFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document title. Without it, citations fall back to the document ID.</div>
+                </div>
 
-            <div class="mb-3">
-                <label asp-for="ContentFieldName" class="form-label">Content field name <span class="text-danger">*</span></label>
-                <input asp-for="ContentFieldName" class="form-control" required placeholder="e.g., content" />
-                <span asp-validation-for="ContentFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                <div class="mb-3">
+                    <label asp-for="ContentFieldName" class="form-label">Content field name <span class="text-danger">*</span></label>
+                    <input asp-for="ContentFieldName" class="form-control" required placeholder="e.g., content" />
+                    <span asp-validation-for="ContentFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                </div>
             </div>
 
             <div class="mt-4">

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Edit.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Edit.cshtml
@@ -213,28 +213,30 @@
                 <div class="form-text">The index where chunked and embedded documents are stored for AI retrieval.</div>
             </div>
 
-            <hr />
-            <h5>Field Mapping</h5>
+            <div id="field-mapping-settings"@(string.Equals(Model.Source, AIDataSourceSourceTypes.Web, StringComparison.OrdinalIgnoreCase) ? " hidden" : null)>
+                <hr />
+                <h5>Field Mapping</h5>
 
-            <div class="mb-3">
-                <label asp-for="KeyFieldName" class="form-label">Key field name <span class="text-danger">*</span></label>
-                <input asp-for="KeyFieldName" class="form-control" required placeholder="e.g., id" />
-                <span asp-validation-for="KeyFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document key.</div>
-            </div>
+                <div class="mb-3">
+                    <label asp-for="KeyFieldName" class="form-label">Key field name <span class="text-danger">*</span></label>
+                    <input asp-for="KeyFieldName" class="form-control" required placeholder="e.g., id" />
+                    <span asp-validation-for="KeyFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document key.</div>
+                </div>
 
-            <div class="mb-3">
-                <label asp-for="TitleFieldName" class="form-label">Title field name <span class="text-danger">*</span></label>
-                <input asp-for="TitleFieldName" class="form-control" required placeholder="e.g., title" />
-                <span asp-validation-for="TitleFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document title. Without it, citations fall back to the document ID.</div>
-            </div>
+                <div class="mb-3">
+                    <label asp-for="TitleFieldName" class="form-label">Title field name <span class="text-danger">*</span></label>
+                    <input asp-for="TitleFieldName" class="form-control" required placeholder="e.g., title" />
+                    <span asp-validation-for="TitleFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document title. Without it, citations fall back to the document ID.</div>
+                </div>
 
-            <div class="mb-3">
-                <label asp-for="ContentFieldName" class="form-label">Content field name <span class="text-danger">*</span></label>
-                <input asp-for="ContentFieldName" class="form-control" required placeholder="e.g., content" />
-                <span asp-validation-for="ContentFieldName" class="text-danger"></span>
-                <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                <div class="mb-3">
+                    <label asp-for="ContentFieldName" class="form-label">Content field name <span class="text-danger">*</span></label>
+                    <input asp-for="ContentFieldName" class="form-control" required placeholder="e.g., content" />
+                    <span asp-validation-for="ContentFieldName" class="text-danger"></span>
+                    <div class="form-text">The source field that maps to the document content (text body). Field mapping is still required for external sources so the knowledge-base pipeline knows which fields hold the key, title, and content.</div>
+                </div>
             </div>
 
             <div class="mt-4">

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/_SourceSettingsScript.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/_SourceSettingsScript.cshtml
@@ -32,6 +32,18 @@
             toggle('elasticsearch-key-id-settings', sourceType === 'Elasticsearch' && elasticAuthType === 'KeyIdAndKey');
             toggle('azure-ai-search-api-key-settings', sourceType === 'AzureAISearch' && azureAuthType === 'ApiKey');
             toggle('azure-ai-search-identity-settings', sourceType === 'AzureAISearch' && azureAuthType !== 'ApiKey');
+
+            // The Web source derives its key, title, and content from each crawled page, so the manual
+            // field mapping is hidden and its inputs are exempted from validation.
+            const usesFieldMapping = sourceType !== 'Web';
+            toggle('field-mapping-settings', usesFieldMapping);
+
+            ['KeyFieldName', 'TitleFieldName', 'ContentFieldName'].forEach((id) => {
+                const element = document.getElementById(id);
+                if (element) {
+                    element.required = usesFieldMapping;
+                }
+            });
         };
 
         sourceTypeField?.addEventListener('change', updateVisibility);

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
@@ -1,6 +1,6 @@
 using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
-using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.WebCrawlers;
 using CrestApps.Core.AI.WebCrawlers.Strategies;
 using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
 using CrestApps.Core.Mvc.Web.Areas.WebCrawlers.ViewModels;
@@ -18,18 +18,18 @@ public sealed class WebCrawlerController : Controller
 {
     private readonly ISourceCatalogManager<WebCrawler> _manager;
     private readonly IAIDataSourceStore _dataSourceStore;
-    private readonly IAIDataSourceIndexingQueue _indexingQueue;
+    private readonly IWebCrawlerReindexPlanner _reindexPlanner;
     private readonly IReadOnlyList<WebCrawlerStrategyDescriptor> _strategies;
 
     public WebCrawlerController(
         ISourceCatalogManager<WebCrawler> manager,
         IAIDataSourceStore dataSourceStore,
-        IAIDataSourceIndexingQueue indexingQueue,
+        IWebCrawlerReindexPlanner reindexPlanner,
         IOptions<WebCrawlerStrategyOptions> strategyOptions)
     {
         _manager = manager;
         _dataSourceStore = dataSourceStore;
-        _indexingQueue = indexingQueue;
+        _reindexPlanner = reindexPlanner;
         _strategies = strategyOptions.Value.Strategies
             .OrderBy(strategy => strategy.DisplayName.Value, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -141,15 +141,10 @@ public sealed class WebCrawlerController : Controller
             return NotFound();
         }
 
-        var dataSource = string.IsNullOrWhiteSpace(crawler.AIDataSourceId)
-            ? null
-            : await _dataSourceStore.FindByIdAsync(crawler.AIDataSourceId);
-
-        if (dataSource != null)
-        {
-            await _indexingQueue.QueueSyncDataSourceAsync(dataSource, HttpContext.RequestAborted);
-            TempData["SuccessMessage"] = "Web crawler synchronization has been queued.";
-        }
+        // Re-crawl just this site: discover its pages and queue the new/changed ones for indexing into the
+        // target data source, without rebuilding the other crawlers mapped to that data source.
+        var result = await _reindexPlanner.PlanAndEnqueueAsync(crawler, HttpContext.RequestAborted);
+        TempData["SuccessMessage"] = $"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.";
 
         return RedirectToAction(nameof(Index));
     }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
@@ -144,7 +144,15 @@ public sealed class WebCrawlerController : Controller
         // Re-crawl just this site: discover its pages and queue the new/changed ones for indexing into the
         // target data source, without rebuilding the other crawlers mapped to that data source.
         var result = await _reindexPlanner.PlanAndEnqueueAsync(crawler, HttpContext.RequestAborted);
-        TempData["SuccessMessage"] = $"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.";
+
+        if (result.Status is WebCrawlerReindexStatus.DiscoveryFailed or WebCrawlerReindexStatus.NoPagesDiscovered)
+        {
+            TempData["ErrorMessage"] = result.Message;
+        }
+        else
+        {
+            TempData["SuccessMessage"] = $"Web crawler synchronization queued: {result.NewCount} new, {result.ChangedCount} changed, {result.RemovedCount} removed.";
+        }
 
         return RedirectToAction(nameof(Index));
     }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Controllers/WebCrawlerController.cs
@@ -1,0 +1,197 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+using CrestApps.Core.Mvc.Web.Areas.WebCrawlers.ViewModels;
+using CrestApps.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.Mvc.Web.Areas.WebCrawlers.Controllers;
+
+[Area("WebCrawlers")]
+[Authorize(Policy = "Admin")]
+public sealed class WebCrawlerController : Controller
+{
+    private readonly ISourceCatalogManager<WebCrawler> _manager;
+    private readonly IAIDataSourceStore _dataSourceStore;
+    private readonly IAIDataSourceIndexingQueue _indexingQueue;
+    private readonly IReadOnlyList<WebCrawlerStrategyDescriptor> _strategies;
+
+    public WebCrawlerController(
+        ISourceCatalogManager<WebCrawler> manager,
+        IAIDataSourceStore dataSourceStore,
+        IAIDataSourceIndexingQueue indexingQueue,
+        IOptions<WebCrawlerStrategyOptions> strategyOptions)
+    {
+        _manager = manager;
+        _dataSourceStore = dataSourceStore;
+        _indexingQueue = indexingQueue;
+        _strategies = strategyOptions.Value.Strategies
+            .OrderBy(strategy => strategy.DisplayName.Value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        var crawlers = await _manager.GetAllAsync();
+
+        return View(crawlers);
+    }
+
+    public async Task<IActionResult> Create()
+    {
+        var model = new WebCrawlerViewModel();
+        await PopulateDropdownsAsync(model);
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(WebCrawlerViewModel model)
+    {
+        var crawler = await _manager.NewAsync(model.Source, cancellationToken: HttpContext.RequestAborted);
+        model.ApplyTo(crawler);
+
+        await ValidateAsync(model, crawler);
+
+        if (!ModelState.IsValid)
+        {
+            await PopulateDropdownsAsync(model);
+
+            return View(model);
+        }
+
+        await _manager.CreateAsync(crawler);
+        TempData["SuccessMessage"] = "Web crawler created successfully. Initial synchronization has been queued.";
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    public async Task<IActionResult> Edit(string id)
+    {
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        var model = WebCrawlerViewModel.FromCrawler(crawler);
+        await PopulateDropdownsAsync(model);
+
+        return View(model);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Edit(WebCrawlerViewModel model)
+    {
+        var crawler = await _manager.FindByIdAsync(model.ItemId);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        model.ApplyTo(crawler);
+
+        await ValidateAsync(model, crawler);
+
+        if (!ModelState.IsValid)
+        {
+            await PopulateDropdownsAsync(model);
+
+            return View(model);
+        }
+
+        await _manager.UpdateAsync(crawler);
+        TempData["SuccessMessage"] = "Web crawler updated successfully. Synchronization has been queued.";
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler != null)
+        {
+            await _manager.DeleteAsync(crawler);
+            TempData["SuccessMessage"] = "Web crawler deleted successfully. Knowledge-base cleanup has been queued.";
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Sync(string id)
+    {
+        var crawler = await _manager.FindByIdAsync(id);
+
+        if (crawler == null)
+        {
+            return NotFound();
+        }
+
+        var dataSource = string.IsNullOrWhiteSpace(crawler.AIDataSourceId)
+            ? null
+            : await _dataSourceStore.FindByIdAsync(crawler.AIDataSourceId);
+
+        if (dataSource != null)
+        {
+            await _indexingQueue.QueueSyncDataSourceAsync(dataSource, HttpContext.RequestAborted);
+            TempData["SuccessMessage"] = "Web crawler synchronization has been queued.";
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    private async Task ValidateAsync(WebCrawlerViewModel model, WebCrawler crawler)
+    {
+        var validation = await _manager.ValidateAsync(crawler);
+
+        foreach (var error in validation.Errors)
+        {
+            var memberNames = error.MemberNames?.Any() == true ? error.MemberNames : [string.Empty];
+
+            foreach (var memberName in memberNames)
+            {
+                ModelState.AddModelError(MapValidationMemberName(memberName), error.ErrorMessage);
+            }
+        }
+    }
+
+    private static string MapValidationMemberName(string memberName)
+    {
+        return memberName switch
+        {
+            nameof(WebCrawler.DisplayText) => nameof(WebCrawlerViewModel.DisplayText),
+            nameof(WebCrawler.AIDataSourceId) => nameof(WebCrawlerViewModel.AIDataSourceId),
+            nameof(WebCrawler.Source) => nameof(WebCrawlerViewModel.Source),
+            nameof(SitemapWebCrawlerMetadata.BaseUrl) => nameof(WebCrawlerViewModel.SitemapBaseUrl),
+            nameof(SitemapWebCrawlerMetadata.SitemapUrl) => nameof(WebCrawlerViewModel.SitemapUrl),
+            _ => memberName,
+        };
+    }
+
+    private async Task PopulateDropdownsAsync(WebCrawlerViewModel model)
+    {
+        var dataSources = await _dataSourceStore.GetAsync(AIDataSourceSourceTypes.Web);
+
+        model.Strategies = _strategies
+            .Select(strategy => new SelectListItem(strategy.DisplayName.Value, strategy.Strategy))
+            .ToList();
+
+        model.DataSources = dataSources
+            .Select(dataSource => new SelectListItem(dataSource.DisplayText, dataSource.ItemId))
+            .ToList();
+    }
+}

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/ViewModels/WebCrawlerViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/ViewModels/WebCrawlerViewModel.cs
@@ -1,0 +1,116 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace CrestApps.Core.Mvc.Web.Areas.WebCrawlers.ViewModels;
+
+public sealed class WebCrawlerViewModel
+{
+    public string ItemId { get; set; }
+
+    public string DisplayText { get; set; }
+
+    public string Source { get; set; } = WebCrawlerConstants.Strategies.Sitemap;
+
+    public string AIDataSourceId { get; set; }
+
+    public bool Enabled { get; set; } = true;
+
+    public int? ReindexIntervalMinutes { get; set; }
+
+    public string SitemapBaseUrl { get; set; }
+
+    public string SitemapUrl { get; set; }
+
+    public int? SitemapMaxPages { get; set; }
+
+    public int? SitemapMaxConcurrentRequests { get; set; }
+
+    public int? SitemapRequestTimeoutSeconds { get; set; }
+
+    public string SitemapUserAgent { get; set; }
+
+    public string SitemapIncludeUrlPatterns { get; set; }
+
+    public string SitemapExcludeUrlPatterns { get; set; }
+
+    [BindNever]
+    public IEnumerable<SelectListItem> Strategies { get; set; } = [];
+
+    [BindNever]
+    public IEnumerable<SelectListItem> DataSources { get; set; } = [];
+
+    public static WebCrawlerViewModel FromCrawler(WebCrawler crawler)
+    {
+        var model = new WebCrawlerViewModel
+        {
+            ItemId = crawler.ItemId,
+            DisplayText = crawler.DisplayText,
+            Source = string.IsNullOrWhiteSpace(crawler.Source) ? WebCrawlerConstants.Strategies.Sitemap : crawler.Source,
+            AIDataSourceId = crawler.AIDataSourceId,
+            Enabled = crawler.Enabled,
+            ReindexIntervalMinutes = crawler.ReindexIntervalMinutes,
+        };
+
+        if (crawler.TryGet<SitemapWebCrawlerMetadata>(out var sitemap))
+        {
+            model.SitemapBaseUrl = sitemap.BaseUrl;
+            model.SitemapUrl = sitemap.SitemapUrl;
+            model.SitemapMaxPages = sitemap.MaxPages;
+            model.SitemapMaxConcurrentRequests = sitemap.MaxConcurrentRequests;
+            model.SitemapRequestTimeoutSeconds = sitemap.RequestTimeoutSeconds;
+            model.SitemapUserAgent = sitemap.UserAgent;
+            model.SitemapIncludeUrlPatterns = JoinPatterns(sitemap.IncludeUrlPatterns);
+            model.SitemapExcludeUrlPatterns = JoinPatterns(sitemap.ExcludeUrlPatterns);
+        }
+
+        return model;
+    }
+
+    public void ApplyTo(WebCrawler crawler)
+    {
+        ArgumentNullException.ThrowIfNull(crawler);
+
+        crawler.DisplayText = DisplayText?.Trim();
+        crawler.Source = string.IsNullOrWhiteSpace(Source) ? WebCrawlerConstants.Strategies.Sitemap : Source.Trim();
+        crawler.AIDataSourceId = AIDataSourceId?.Trim();
+        crawler.Enabled = Enabled;
+        crawler.ReindexIntervalMinutes = ReindexIntervalMinutes;
+
+        crawler.Remove<SitemapWebCrawlerMetadata>();
+
+        if (string.Equals(crawler.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase))
+        {
+            crawler.Put(new SitemapWebCrawlerMetadata
+            {
+                BaseUrl = SitemapBaseUrl?.Trim(),
+                SitemapUrl = SitemapUrl?.Trim(),
+                MaxPages = SitemapMaxPages,
+                MaxConcurrentRequests = SitemapMaxConcurrentRequests,
+                RequestTimeoutSeconds = SitemapRequestTimeoutSeconds,
+                UserAgent = string.IsNullOrWhiteSpace(SitemapUserAgent) ? null : SitemapUserAgent.Trim(),
+                IncludeUrlPatterns = SplitPatterns(SitemapIncludeUrlPatterns),
+                ExcludeUrlPatterns = SplitPatterns(SitemapExcludeUrlPatterns),
+            });
+        }
+    }
+
+    private static string JoinPatterns(IEnumerable<string> patterns)
+    {
+        return patterns is null ? null : string.Join('\n', patterns);
+    }
+
+    private static List<string> SplitPatterns(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return [];
+        }
+
+        return value
+            .Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToList();
+    }
+}

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Create.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Create.cshtml
@@ -1,0 +1,115 @@
+@using CrestApps.Core.AI.WebCrawlers
+@using CrestApps.Core.Mvc.Web.Areas.WebCrawlers.ViewModels
+@model WebCrawlerViewModel
+@{
+    ViewData["Title"] = "Create Web Crawler";
+}
+
+<h2><i class="bi bi-plus-lg"></i> Create Web Crawler</h2>
+<hr />
+
+<form asp-action="Create" method="post">
+    @Html.AntiForgeryToken()
+    <div class="row">
+        <div class="col-md-8">
+            <div class="mb-3">
+                <label asp-for="DisplayText" class="form-label">Title <span class="text-danger">*</span></label>
+                <input asp-for="DisplayText" class="form-control" required placeholder="e.g., Docs site" />
+                <span asp-validation-for="DisplayText" class="text-danger"></span>
+                <div class="form-text">A human-readable name for this crawler.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="AIDataSourceId" class="form-label">Target Web data source <span class="text-danger">*</span></label>
+                <select asp-for="AIDataSourceId" asp-items="Model.DataSources" class="form-select" required>
+                    <option value="">Select data source</option>
+                </select>
+                <span asp-validation-for="AIDataSourceId" class="text-danger"></span>
+                <div class="form-text">The Web data source whose knowledge base receives the scraped pages. Create one under Data Sources using the <strong>Web</strong> source type.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Source" class="form-label">Strategy <span class="text-danger">*</span></label>
+                <select asp-for="Source" asp-items="Model.Strategies" id="Source" class="form-select" required>
+                    <option value="">Select strategy</option>
+                </select>
+                <span asp-validation-for="Source" class="text-danger"></span>
+                <div class="form-text">How the site is discovered and fetched.</div>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input asp-for="Enabled" class="form-check-input" type="checkbox" />
+                <label asp-for="Enabled" class="form-check-label">Enabled</label>
+                <div class="form-text">Disabled crawlers are skipped by the re-index background service.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="ReindexIntervalMinutes" class="form-label">Re-index interval (minutes)</label>
+                <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" placeholder="1440" />
+                <div class="form-text">How often the background service re-crawls this site and re-indexes changed pages.</div>
+            </div>
+
+            <div id="sitemap-strategy-settings"@(string.Equals(Model.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase) ? null : " hidden")>
+                <hr />
+                <h5>Sitemap Settings</h5>
+                <div class="alert alert-info">
+                    Discover pages through the site's sitemap(s). Provide a base URL or an explicit sitemap URL; each page is fetched, cleaned to text, and indexed with its URL kept for citations.
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapBaseUrl" class="form-label">Base URL</label>
+                    <input asp-for="SitemapBaseUrl" class="form-control" placeholder="https://docs.example.com" />
+                    <span asp-validation-for="SitemapBaseUrl" class="text-danger"></span>
+                    <div class="form-text">Used to resolve the sitemap from robots.txt and the conventional locations when no explicit sitemap URL is given.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapUrl" class="form-label">Sitemap URL</label>
+                    <input asp-for="SitemapUrl" class="form-control" placeholder="https://docs.example.com/sitemap.xml" />
+                    <span asp-validation-for="SitemapUrl" class="text-danger"></span>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapMaxPages" class="form-label">Max pages</label>
+                        <input asp-for="SitemapMaxPages" class="form-control" type="number" min="1" placeholder="500" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapMaxConcurrentRequests" class="form-label">Max concurrent requests</label>
+                        <input asp-for="SitemapMaxConcurrentRequests" class="form-control" type="number" min="1" placeholder="4" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapRequestTimeoutSeconds" class="form-label">Request timeout (seconds)</label>
+                        <input asp-for="SitemapRequestTimeoutSeconds" class="form-control" type="number" min="1" placeholder="30" />
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapUserAgent" class="form-label">User agent</label>
+                    <input asp-for="SitemapUserAgent" class="form-control" placeholder="CrestApps-WebCrawler/1.0 (+https://crestapps.com)" />
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapIncludeUrlPatterns" class="form-label">Include URL patterns</label>
+                    <textarea asp-for="SitemapIncludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line"></textarea>
+                    <div class="form-text">Optional. A page URL must match at least one pattern to be scraped. Leave empty to include every discovered page.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapExcludeUrlPatterns" class="form-label">Exclude URL patterns</label>
+                    <textarea asp-for="SitemapExcludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line"></textarea>
+                    <div class="form-text">Optional. A page URL matching any pattern is skipped.</div>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-lg"></i> Create
+                </button>
+                <a asp-action="Index" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
+        </div>
+    </div>
+</form>
+
+@await Html.PartialAsync("_StrategySettingsScript")

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Edit.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Edit.cshtml
@@ -1,0 +1,116 @@
+@using CrestApps.Core.AI.WebCrawlers
+@using CrestApps.Core.Mvc.Web.Areas.WebCrawlers.ViewModels
+@model WebCrawlerViewModel
+@{
+    ViewData["Title"] = "Edit Web Crawler";
+}
+
+<h2><i class="bi bi-pencil"></i> Edit Web Crawler</h2>
+<hr />
+
+<form asp-action="Edit" method="post">
+    @Html.AntiForgeryToken()
+    <input type="hidden" asp-for="ItemId" />
+    <div class="row">
+        <div class="col-md-8">
+            <div class="mb-3">
+                <label asp-for="DisplayText" class="form-label">Title <span class="text-danger">*</span></label>
+                <input asp-for="DisplayText" class="form-control" required placeholder="e.g., Docs site" />
+                <span asp-validation-for="DisplayText" class="text-danger"></span>
+                <div class="form-text">A human-readable name for this crawler.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="AIDataSourceId" class="form-label">Target Web data source <span class="text-danger">*</span></label>
+                <select asp-for="AIDataSourceId" asp-items="Model.DataSources" class="form-select" required>
+                    <option value="">Select data source</option>
+                </select>
+                <span asp-validation-for="AIDataSourceId" class="text-danger"></span>
+                <div class="form-text">The Web data source whose knowledge base receives the scraped pages. Create one under Data Sources using the <strong>Web</strong> source type.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Source" class="form-label">Strategy <span class="text-danger">*</span></label>
+                <select asp-for="Source" asp-items="Model.Strategies" id="Source" class="form-select" required>
+                    <option value="">Select strategy</option>
+                </select>
+                <span asp-validation-for="Source" class="text-danger"></span>
+                <div class="form-text">How the site is discovered and fetched.</div>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input asp-for="Enabled" class="form-check-input" type="checkbox" />
+                <label asp-for="Enabled" class="form-check-label">Enabled</label>
+                <div class="form-text">Disabled crawlers are skipped by the re-index background service.</div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="ReindexIntervalMinutes" class="form-label">Re-index interval (minutes)</label>
+                <input asp-for="ReindexIntervalMinutes" class="form-control" type="number" min="1" placeholder="1440" />
+                <div class="form-text">How often the background service re-crawls this site and re-indexes changed pages.</div>
+            </div>
+
+            <div id="sitemap-strategy-settings"@(string.Equals(Model.Source, WebCrawlerConstants.Strategies.Sitemap, StringComparison.OrdinalIgnoreCase) ? null : " hidden")>
+                <hr />
+                <h5>Sitemap Settings</h5>
+                <div class="alert alert-info">
+                    Discover pages through the site's sitemap(s). Provide a base URL or an explicit sitemap URL; each page is fetched, cleaned to text, and indexed with its URL kept for citations.
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapBaseUrl" class="form-label">Base URL</label>
+                    <input asp-for="SitemapBaseUrl" class="form-control" placeholder="https://docs.example.com" />
+                    <span asp-validation-for="SitemapBaseUrl" class="text-danger"></span>
+                    <div class="form-text">Used to resolve the sitemap from robots.txt and the conventional locations when no explicit sitemap URL is given.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapUrl" class="form-label">Sitemap URL</label>
+                    <input asp-for="SitemapUrl" class="form-control" placeholder="https://docs.example.com/sitemap.xml" />
+                    <span asp-validation-for="SitemapUrl" class="text-danger"></span>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapMaxPages" class="form-label">Max pages</label>
+                        <input asp-for="SitemapMaxPages" class="form-control" type="number" min="1" placeholder="500" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapMaxConcurrentRequests" class="form-label">Max concurrent requests</label>
+                        <input asp-for="SitemapMaxConcurrentRequests" class="form-control" type="number" min="1" placeholder="4" />
+                    </div>
+                    <div class="col-md-4 mb-3">
+                        <label asp-for="SitemapRequestTimeoutSeconds" class="form-label">Request timeout (seconds)</label>
+                        <input asp-for="SitemapRequestTimeoutSeconds" class="form-control" type="number" min="1" placeholder="30" />
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapUserAgent" class="form-label">User agent</label>
+                    <input asp-for="SitemapUserAgent" class="form-control" placeholder="CrestApps-WebCrawler/1.0 (+https://crestapps.com)" />
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapIncludeUrlPatterns" class="form-label">Include URL patterns</label>
+                    <textarea asp-for="SitemapIncludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line"></textarea>
+                    <div class="form-text">Optional. A page URL must match at least one pattern to be scraped. Leave empty to include every discovered page.</div>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="SitemapExcludeUrlPatterns" class="form-label">Exclude URL patterns</label>
+                    <textarea asp-for="SitemapExcludeUrlPatterns" class="form-control" rows="3" placeholder="One regular expression per line"></textarea>
+                    <div class="form-text">Optional. A page URL matching any pattern is skipped.</div>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                <button type="submit" class="btn btn-primary">
+                    <i class="bi bi-check-lg"></i> Save
+                </button>
+                <a asp-action="Index" class="btn btn-secondary ms-2">Cancel</a>
+            </div>
+        </div>
+    </div>
+</form>
+
+@await Html.PartialAsync("_StrategySettingsScript")

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Index.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Index.cshtml
@@ -1,0 +1,74 @@
+@model IReadOnlyCollection<CrestApps.Core.AI.Models.WebCrawler>
+@{
+    ViewData["Title"] = "Web Crawlers";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2><i class="bi bi-globe"></i> Web Crawlers</h2>
+    <a asp-action="Create" class="btn btn-success">
+        <i class="bi bi-plus-lg"></i> Create New Web Crawler
+    </a>
+</div>
+
+@if (!Model.Any())
+{
+    <div class="alert alert-info">
+        <i class="bi bi-info-circle"></i> No web crawlers found.
+        Create one to scrape a website into a Web data source.
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead class="table-dark">
+                <tr>
+                    <th>Title</th>
+                    <th>Strategy</th>
+                    <th>Enabled</th>
+                    <th style="width: 250px;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in Model)
+                {
+                    <tr>
+                        <td><strong>@item.DisplayText</strong></td>
+                        <td><code>@item.Source</code></td>
+                        <td>
+                            @if (item.Enabled)
+                            {
+                                <span class="badge bg-success">Enabled</span>
+                            }
+                            else
+                            {
+                                <span class="badge bg-secondary">Disabled</span>
+                            }
+                        </td>
+                        <td>
+                            <form asp-action="Sync" asp-route-id="@item.ItemId"
+                                  method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-sm btn-outline-success">
+                                    <i class="bi bi-arrow-repeat"></i> Sync
+                                </button>
+                            </form>
+                            <a asp-action="Edit" asp-route-id="@item.ItemId"
+                               class="btn btn-sm btn-outline-primary">
+                                <i class="bi bi-pencil"></i> Edit
+                            </a>
+                            <form asp-action="Delete" asp-route-id="@item.ItemId"
+                                  method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-sm btn-outline-danger"
+                                        onclick="return confirm('Delete this web crawler?')">
+                                    <i class="bi bi-trash"></i> Delete
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/_StrategySettingsScript.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/_StrategySettingsScript.cshtml
@@ -1,0 +1,23 @@
+<script>
+    (() => {
+        const strategyField = document.getElementById('Source');
+
+        const toggle = (id, visible) => {
+            const element = document.getElementById(id);
+            if (!element) {
+                return;
+            }
+
+            element.hidden = !visible;
+        };
+
+        const updateVisibility = () => {
+            const strategy = strategyField?.value ?? '';
+
+            toggle('sitemap-strategy-settings', strategy === 'Sitemap');
+        };
+
+        strategyField?.addEventListener('change', updateVisibility);
+        updateVisibility();
+    })();
+</script>

--- a/src/Startup/CrestApps.Core.Mvc.Web/CrestApps.Core.Mvc.Web.csproj
+++ b/src/Startup/CrestApps.Core.Mvc.Web/CrestApps.Core.Mvc.Web.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Documents.OpenXml/CrestApps.Core.AI.Documents.OpenXml.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Documents.Pdf/CrestApps.Core.AI.Documents.Pdf.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Elasticsearch/CrestApps.Core.AI.Elasticsearch.csproj" />
+    <ProjectReference Include="../../Primitives/CrestApps.Core.AI.WebCrawlers/CrestApps.Core.AI.WebCrawlers.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.Azure.AISearch/CrestApps.Core.AI.Azure.AISearch.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.AI.PostgreSQL/CrestApps.Core.AI.PostgreSQL.csproj" />
     <ProjectReference Include="../../Primitives/CrestApps.Core.Elasticsearch/CrestApps.Core.Elasticsearch.csproj" />

--- a/src/Startup/CrestApps.Core.Mvc.Web/Program.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Program.cs
@@ -1,5 +1,6 @@
 using CrestApps.Core;
 using CrestApps.Core.AI;
+using CrestApps.Core.AI.WebCrawlers;
 using CrestApps.Core.AI.A2A;
 using CrestApps.Core.AI.A2A.Models;
 using CrestApps.Core.AI.Azure.AISearch;
@@ -187,6 +188,11 @@ builder.Services
         )
      )
  );
+
+// Opt into the strategy-based web crawlers feature and its YesSql stores. Web crawlers scrape sites
+// (starting with sitemap discovery) into any "Web" AI data source.
+builder.Services.AddCoreWebCrawlers();
+builder.Services.AddCoreWebCrawlerStoresYesSql();
 
 builder.Services.Configure<A2AHostOptions>(
      builder.Configuration.GetSection(nameof(A2AHostOptions)));

--- a/src/Startup/CrestApps.Core.Mvc.Web/Services/YesSqlServiceCollectionExtensions.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Services/YesSqlServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using CrestApps.Core.Data.YesSql.Indexes.DataSources;
 using CrestApps.Core.Data.YesSql.Indexes.Indexing;
 using CrestApps.Core.Data.YesSql.Indexes.Mcp;
 using CrestApps.Core.Data.YesSql.Indexes.Tooling;
+using CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
 using CrestApps.Core.Elasticsearch;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Mvc.Web.Areas.Admin.Indexes;
@@ -158,6 +159,8 @@ internal static class YesSqlServiceCollectionExtensions
         await TryCreateTableAsync(() => schemaBuilder.CreateAIDocumentChunkIndexSchemaAsync(storeOptions));
         await TryCreateTableAsync(() => schemaBuilder.CreateSearchIndexProfileIndexSchemaAsync(storeOptions));
         await TryCreateTableAsync(() => schemaBuilder.CreateAIDataSourceIndexSchemaAsync(storeOptions));
+        await TryCreateTableAsync(() => schemaBuilder.CreateWebCrawlerIndexSchemaAsync(storeOptions));
+        await TryCreateTableAsync(() => schemaBuilder.CreateWebCrawlStateIndexSchemaAsync(storeOptions));
         await TryCreateTableAsync(() => schemaBuilder.CreateAIMemoryEntryIndexSchemaAsync(storeOptions));
         await TryCreateTableAsync(() => schemaBuilder.CreateChatInteractionIndexSchemaAsync(storeOptions));
         await TryCreateTableAsync(() => schemaBuilder.CreateChatInteractionPromptIndexSchemaAsync(storeOptions));

--- a/src/Startup/CrestApps.Core.Mvc.Web/Views/Home/Index.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Views/Home/Index.cshtml
@@ -128,6 +128,34 @@
             </div>
         </div>
     </div>
+    <div class="col">
+        <div class="card h-100 border-info">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-3">
+                    <i class="bi bi-plugin fs-2 text-info me-3"></i>
+                    <h5 class="card-title mb-0">AI Tool Instances</h5>
+                </div>
+                <p class="card-text">Configure reusable tool instances that AI profiles and agents can call during a conversation.</p>
+                <a asp-area="Tooling" asp-controller="AIToolInstance" asp-action="Index" class="btn btn-info text-white">
+                    <i class="bi bi-arrow-right"></i> Manage Tool Instances
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100" style="border-color: #20c997;">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-3">
+                    <i class="bi bi-globe fs-2 me-3" style="color: #20c997;"></i>
+                    <h5 class="card-title mb-0">Web Crawlers</h5>
+                </div>
+                <p class="card-text">Scrape websites into a Web data source, mapping many sites into one knowledge base for retrieval.</p>
+                <a asp-area="WebCrawlers" asp-controller="WebCrawler" asp-action="Index" class="btn text-white" style="background-color: #20c997;">
+                    <i class="bi bi-arrow-right"></i> Manage Web Crawlers
+                </a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <section class="mt-5">

--- a/src/Startup/CrestApps.Core.Mvc.Web/Views/Shared/_Layout.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Views/Shared/_Layout.cshtml
@@ -105,6 +105,11 @@
                         </a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link" asp-area="WebCrawlers" asp-controller="WebCrawler" asp-action="Index">
+                            <i class="bi bi-globe"></i> Web Crawlers
+                        </a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link" asp-area="AI" asp-controller="AITemplate" asp-action="Index">
                             <i class="bi bi-file-earmark-text"></i> Templates
                         </a>

--- a/src/Stores/CrestApps.Core.Data.EntityCore/ServiceCollectionExtensions.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/ServiceCollectionExtensions.cs
@@ -288,6 +288,26 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Registers EntityCore-backed stores for the web-crawlers feature.
+    /// This includes <see cref="IWebCrawlerStore"/> and <see cref="IWebCrawlStateStore"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddCoreWebCrawlerStoresEntityCore(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.Replace(ServiceDescriptor.Scoped<IWebCrawlerStore, EntityCoreWebCrawlerStore>());
+        services.AddScoped<ICatalog<WebCrawler>>(sp => sp.GetRequiredService<IWebCrawlerStore>());
+        services.AddScoped<ISourceCatalog<WebCrawler>>(sp => sp.GetRequiredService<IWebCrawlerStore>());
+
+        services.Replace(ServiceDescriptor.Scoped<IWebCrawlStateStore, EntityCoreWebCrawlStateStore>());
+        services.AddScoped<ICatalog<WebCrawlState>>(sp => sp.GetRequiredService<IWebCrawlStateStore>());
+        services.AddScoped<ISourceCatalog<WebCrawlState>>(sp => sp.GetRequiredService<IWebCrawlStateStore>());
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers EntityCore-backed stores for the AI memory feature.
     /// This includes <see cref="IAIMemoryStore"/>.
     /// </summary>

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/CatalogRecordFactory.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/CatalogRecordFactory.cs
@@ -83,6 +83,13 @@ internal static class CatalogRecordFactory
                 record.Type = indexProfile.Type;
                 record.CreatedUtc = indexProfile.CreatedUtc;
                 break;
+            case WebCrawler crawler:
+                // The strategy is the crawler's Source (auto-mapped above); the target data source id is
+                // denormalized into the generic reference column so crawlers can be queried per data source.
+                record.ReferenceId = crawler.AIDataSourceId;
+                record.CreatedUtc = crawler.CreatedUtc;
+                record.UpdatedUtc = crawler.ModifiedUtc;
+                break;
         }
 
         return record;

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreWebCrawlStateStore.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreWebCrawlStateStore.cs
@@ -1,0 +1,85 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.Data.EntityCore.Services;
+
+/// <summary>
+/// EntityFramework Core-backed <see cref="IWebCrawlStateStore"/> for web-crawler crawl state. Records are
+/// grouped by the owning crawler, stored as their source.
+/// </summary>
+public sealed class EntityCoreWebCrawlStateStore : SourceDocumentCatalog<WebCrawlState>, IWebCrawlStateStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityCoreWebCrawlStateStore"/> class.
+    /// </summary>
+    /// <param name="dbContext">The db context.</param>
+    /// <param name="logger">The logger.</param>
+    public EntityCoreWebCrawlStateStore(
+        CrestAppsEntityDbContext dbContext,
+        ILogger<DocumentCatalog<WebCrawlState>> logger = null)
+        : base(dbContext, logger)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByCrawlerIdAsync(string webCrawlerId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(webCrawlerId);
+
+        var records = await GetTrackedQuery()
+            .Where(x => x.Source == webCrawlerId)
+            .ToListAsync(cancellationToken);
+
+        if (records.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var record in records)
+        {
+            if (record.Document is not null)
+            {
+                DbContext.Documents.Remove(record.Document);
+            }
+        }
+
+        DbContext.CatalogRecords.RemoveRange(records);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByUrlsAsync(string webCrawlerId, IEnumerable<string> urls, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(webCrawlerId);
+        ArgumentNullException.ThrowIfNull(urls);
+
+        var urlSet = new HashSet<string>(urls.Where(url => !string.IsNullOrWhiteSpace(url)), StringComparer.OrdinalIgnoreCase);
+
+        if (urlSet.Count == 0)
+        {
+            return;
+        }
+
+        var records = await GetTrackedQuery()
+            .Where(x => x.Source == webCrawlerId)
+            .ToListAsync(cancellationToken);
+
+        foreach (var record in records)
+        {
+            var state = CatalogRecordFactory.Materialize<WebCrawlState>(record);
+
+            if (!urlSet.Contains(state.Url))
+            {
+                continue;
+            }
+
+            if (record.Document is not null)
+            {
+                DbContext.Documents.Remove(record.Document);
+            }
+
+            DbContext.CatalogRecords.Remove(record);
+        }
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreWebCrawlerStore.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreWebCrawlerStore.cs
@@ -1,0 +1,38 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.Data.EntityCore.Services;
+
+/// <summary>
+/// EntityFramework Core-backed <see cref="IWebCrawlerStore"/>. The strategy is the crawler's source; the
+/// target data source id is denormalized into the catalog record's reference column so crawlers can be
+/// queried per data source.
+/// </summary>
+public sealed class EntityCoreWebCrawlerStore : SourceDocumentCatalog<WebCrawler>, IWebCrawlerStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityCoreWebCrawlerStore"/> class.
+    /// </summary>
+    /// <param name="dbContext">The db context.</param>
+    /// <param name="logger">The logger.</param>
+    public EntityCoreWebCrawlerStore(
+        CrestAppsEntityDbContext dbContext,
+        ILogger<DocumentCatalog<WebCrawler>> logger = null)
+        : base(dbContext, logger)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<WebCrawler>> GetByDataSourceIdAsync(string dataSourceId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dataSourceId);
+
+        var records = await GetReadQuery()
+            .Where(x => x.ReferenceId == dataSourceId)
+            .ToListAsync(cancellationToken);
+
+        return records.Select(CatalogRecordFactory.Materialize<WebCrawler>).ToArray();
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlStateIndex.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlStateIndex.cs
@@ -1,0 +1,54 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Data.YesSql.Indexes;
+using Microsoft.Extensions.Options;
+using YesSql.Indexes;
+
+namespace CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+
+/// <summary>
+/// YesSql map index for <see cref="WebCrawlState"/>, keyed by the owning crawler (its source) so the
+/// re-index service can efficiently read every recorded page for a crawler.
+/// </summary>
+public sealed class WebCrawlStateIndex : CatalogItemIndex
+{
+    /// <summary>
+    /// Gets or sets the owning crawler identifier (the crawl-state record's source).
+    /// </summary>
+    public string Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scraped page URL.
+    /// </summary>
+    public string Url { get; set; }
+}
+
+/// <summary>
+/// YesSql index provider that maps <see cref="WebCrawlState"/> documents to <see cref="WebCrawlStateIndex"/>
+/// entries in the AI collection.
+/// </summary>
+public sealed class WebCrawlStateIndexProvider : IndexProvider<WebCrawlState>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlStateIndexProvider"/> class.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    public WebCrawlStateIndexProvider(IOptions<YesSqlStoreOptions> options)
+    {
+        CollectionName = options.Value.AICollectionName;
+    }
+
+    /// <summary>
+    /// Describes the index mapping.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    public override void Describe(DescribeContext<WebCrawlState> context)
+    {
+        context.For<WebCrawlStateIndex>()
+            .Map(state => new WebCrawlStateIndex
+            {
+                ItemId = state.ItemId,
+                Source = state.Source,
+                Url = state.Url,
+            });
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlStateIndexSchemaBuilderExtensions.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlStateIndexSchemaBuilderExtensions.cs
@@ -1,0 +1,30 @@
+using YesSql.Sql;
+
+namespace CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+
+/// <summary>
+/// Schema builder for the <see cref="WebCrawlStateIndex"/> table.
+/// </summary>
+public static class WebCrawlStateIndexSchemaBuilderExtensions
+{
+    /// <summary>
+    /// Creates the web crawl-state index schema.
+    /// </summary>
+    /// <param name="schemaBuilder">The schema builder.</param>
+    /// <param name="options">The options.</param>
+    public static async Task CreateWebCrawlStateIndexSchemaAsync(this ISchemaBuilder schemaBuilder, YesSqlStoreOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(schemaBuilder);
+        ArgumentNullException.ThrowIfNull(options);
+
+        await schemaBuilder.CreateMapIndexTableAsync<WebCrawlStateIndex>(table => table
+            .Column<string>(nameof(WebCrawlStateIndex.ItemId), column => column.WithLength(26))
+            .Column<string>(nameof(WebCrawlStateIndex.Source), column => column.WithLength(26))
+            .Column<string>(nameof(WebCrawlStateIndex.Url), column => column.WithLength(2048)),
+            collection: options?.AICollectionName);
+
+        await schemaBuilder.AlterIndexTableAsync<WebCrawlStateIndex>(table => table
+            .CreateIndex("IDX_WebCrawlState_Source", "DocumentId", nameof(WebCrawlStateIndex.Source)),
+            collection: options?.AICollectionName);
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlerIndex.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlerIndex.cs
@@ -1,0 +1,60 @@
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Data.YesSql.Indexes;
+using Microsoft.Extensions.Options;
+using YesSql.Indexes;
+
+namespace CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+
+/// <summary>
+/// YesSql map index for <see cref="WebCrawler"/>, keyed by the target data source so the source handler
+/// and re-index service can find every crawler for a <c>Web</c> data source.
+/// </summary>
+public sealed class WebCrawlerIndex : CatalogItemIndex
+{
+    /// <summary>
+    /// Gets or sets the human-readable display text of the crawler.
+    /// </summary>
+    public string DisplayText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target AI data source identifier.
+    /// </summary>
+    public string AIDataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the crawl strategy identifier (the crawler's source).
+    /// </summary>
+    public string Source { get; set; }
+}
+
+/// <summary>
+/// YesSql index provider that maps <see cref="WebCrawler"/> documents to <see cref="WebCrawlerIndex"/>
+/// entries in the AI collection.
+/// </summary>
+public sealed class WebCrawlerIndexProvider : IndexProvider<WebCrawler>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WebCrawlerIndexProvider"/> class.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    public WebCrawlerIndexProvider(IOptions<YesSqlStoreOptions> options)
+    {
+        CollectionName = options.Value.AICollectionName;
+    }
+
+    /// <summary>
+    /// Describes the index mapping.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    public override void Describe(DescribeContext<WebCrawler> context)
+    {
+        context.For<WebCrawlerIndex>()
+            .Map(crawler => new WebCrawlerIndex
+            {
+                ItemId = crawler.ItemId,
+                DisplayText = crawler.DisplayText,
+                AIDataSourceId = crawler.AIDataSourceId,
+                Source = crawler.Source,
+            });
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlerIndexSchemaBuilderExtensions.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Indexes/WebCrawlers/WebCrawlerIndexSchemaBuilderExtensions.cs
@@ -1,0 +1,31 @@
+using YesSql.Sql;
+
+namespace CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+
+/// <summary>
+/// Schema builder for the <see cref="WebCrawlerIndex"/> table.
+/// </summary>
+public static class WebCrawlerIndexSchemaBuilderExtensions
+{
+    /// <summary>
+    /// Creates the web-crawler index schema.
+    /// </summary>
+    /// <param name="schemaBuilder">The schema builder.</param>
+    /// <param name="options">The options.</param>
+    public static async Task CreateWebCrawlerIndexSchemaAsync(this ISchemaBuilder schemaBuilder, YesSqlStoreOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(schemaBuilder);
+        ArgumentNullException.ThrowIfNull(options);
+
+        await schemaBuilder.CreateMapIndexTableAsync<WebCrawlerIndex>(table => table
+            .Column<string>(nameof(WebCrawlerIndex.ItemId), column => column.WithLength(26))
+            .Column<string>(nameof(WebCrawlerIndex.DisplayText), column => column.WithLength(255))
+            .Column<string>(nameof(WebCrawlerIndex.AIDataSourceId), column => column.WithLength(26))
+            .Column<string>(nameof(WebCrawlerIndex.Source), column => column.WithLength(128)),
+            collection: options?.AICollectionName);
+
+        await schemaBuilder.AlterIndexTableAsync<WebCrawlerIndex>(table => table
+            .CreateIndex("IDX_WebCrawler_DataSourceId", "DocumentId", nameof(WebCrawlerIndex.AIDataSourceId)),
+            collection: options?.AICollectionName);
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/ServiceCollectionExtensions.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using CrestApps.Core.Data.YesSql.Indexes.DataSources;
 using CrestApps.Core.Data.YesSql.Indexes.Indexing;
 using CrestApps.Core.Data.YesSql.Indexes.Mcp;
 using CrestApps.Core.Data.YesSql.Indexes.Tooling;
+using CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
 using CrestApps.Core.Data.YesSql.Services;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Models;
@@ -498,6 +499,29 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ISourceCatalog<AIDataSource>>(sp => sp.GetRequiredService<IAIDataSourceStore>());
 
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IIndexProvider, AIDataSourceIndexProvider>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers YesSql-backed stores for the web-crawlers feature.
+    /// This includes <see cref="IWebCrawlerStore"/> and <see cref="IWebCrawlStateStore"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    public static IServiceCollection AddCoreWebCrawlerStoresYesSql(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<IWebCrawlerStore, YesSqlWebCrawlerStore>();
+        services.AddScoped<ICatalog<WebCrawler>>(sp => sp.GetRequiredService<IWebCrawlerStore>());
+        services.AddScoped<ISourceCatalog<WebCrawler>>(sp => sp.GetRequiredService<IWebCrawlerStore>());
+
+        services.TryAddScoped<IWebCrawlStateStore, YesSqlWebCrawlStateStore>();
+        services.AddScoped<ICatalog<WebCrawlState>>(sp => sp.GetRequiredService<IWebCrawlStateStore>());
+        services.AddScoped<ISourceCatalog<WebCrawlState>>(sp => sp.GetRequiredService<IWebCrawlStateStore>());
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IIndexProvider, WebCrawlerIndexProvider>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IIndexProvider, WebCrawlStateIndexProvider>());
 
         return services;
     }

--- a/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlWebCrawlStateStore.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlWebCrawlStateStore.cs
@@ -1,0 +1,70 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+using Microsoft.Extensions.Options;
+using YesSql;
+
+namespace CrestApps.Core.Data.YesSql.Services;
+
+/// <summary>
+/// YesSql-backed <see cref="IWebCrawlStateStore"/> for web-crawler crawl state.
+/// </summary>
+public sealed class YesSqlWebCrawlStateStore : DocumentCatalog<WebCrawlState, WebCrawlStateIndex>, IWebCrawlStateStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YesSqlWebCrawlStateStore"/> class.
+    /// </summary>
+    /// <param name="session">The session.</param>
+    /// <param name="options">The options.</param>
+    public YesSqlWebCrawlStateStore(
+        ISession session,
+        IOptions<YesSqlStoreOptions> options)
+        : base(session, options.Value.AICollectionName)
+    {
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyCollection<WebCrawlState>> GetAsync(string source, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        return (await Session.Query<WebCrawlState, WebCrawlStateIndex>(x => x.Source == source, collection: CollectionName).ListAsync(cancellationToken)).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByCrawlerIdAsync(string webCrawlerId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(webCrawlerId);
+
+        var states = await Session.Query<WebCrawlState, WebCrawlStateIndex>(x => x.Source == webCrawlerId, collection: CollectionName).ListAsync(cancellationToken);
+
+        foreach (var state in states)
+        {
+            Session.Delete(state, CollectionName);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteByUrlsAsync(string webCrawlerId, IEnumerable<string> urls, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(webCrawlerId);
+        ArgumentNullException.ThrowIfNull(urls);
+
+        var urlSet = new HashSet<string>(urls.Where(url => !string.IsNullOrWhiteSpace(url)), StringComparer.OrdinalIgnoreCase);
+
+        if (urlSet.Count == 0)
+        {
+            return;
+        }
+
+        var states = await Session.Query<WebCrawlState, WebCrawlStateIndex>(x => x.Source == webCrawlerId, collection: CollectionName).ListAsync(cancellationToken);
+
+        foreach (var state in states)
+        {
+            if (urlSet.Contains(state.Url))
+            {
+                Session.Delete(state, CollectionName);
+            }
+        }
+    }
+}

--- a/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlWebCrawlerStore.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlWebCrawlerStore.cs
@@ -1,0 +1,41 @@
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.Data.YesSql.Indexes.WebCrawlers;
+using Microsoft.Extensions.Options;
+using YesSql;
+
+namespace CrestApps.Core.Data.YesSql.Services;
+
+/// <summary>
+/// YesSql-backed <see cref="IWebCrawlerStore"/>.
+/// </summary>
+public sealed class YesSqlWebCrawlerStore : DocumentCatalog<WebCrawler, WebCrawlerIndex>, IWebCrawlerStore
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="YesSqlWebCrawlerStore"/> class.
+    /// </summary>
+    /// <param name="session">The session.</param>
+    /// <param name="options">The options.</param>
+    public YesSqlWebCrawlerStore(
+        ISession session,
+        IOptions<YesSqlStoreOptions> options)
+        : base(session, options.Value.AICollectionName)
+    {
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyCollection<WebCrawler>> GetAsync(string source, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(source);
+
+        return (await Session.Query<WebCrawler, WebCrawlerIndex>(x => x.Source == source, collection: CollectionName).ListAsync(cancellationToken)).ToArray();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<WebCrawler>> GetByDataSourceIdAsync(string dataSourceId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(dataSourceId);
+
+        return (await Session.Query<WebCrawler, WebCrawlerIndex>(x => x.AIDataSourceId == dataSourceId, collection: CollectionName).ListAsync(cancellationToken)).ToArray();
+    }
+}

--- a/tests/CrestApps.Core.Tests.Samples/Tests/SourceParityTests.cs
+++ b/tests/CrestApps.Core.Tests.Samples/Tests/SourceParityTests.cs
@@ -93,6 +93,11 @@ public class SourceParityTests
         { "AIDataSources/Create", "src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Create.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Create.razor" },
         { "AIDataSources/Edit", "src/Startup/CrestApps.Core.Mvc.Web/Areas/DataSources/Views/AIDataSource/Edit.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/DataSources/AIDataSources/Edit.razor" },
 
+        // Web Crawlers
+        { "WebCrawlers/Index", "src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Index.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Index.razor" },
+        { "WebCrawlers/Create", "src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Create.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Create.razor" },
+        { "WebCrawlers/Edit", "src/Startup/CrestApps.Core.Mvc.Web/Areas/WebCrawlers/Views/WebCrawler/Edit.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/WebCrawlers/Edit.razor" },
+
         // Indexing
         { "IndexProfiles/Index", "src/Startup/CrestApps.Core.Mvc.Web/Areas/Indexing/Views/IndexProfile/Index.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Indexing/IndexProfiles/Index.razor" },
         { "IndexProfiles/Create", "src/Startup/CrestApps.Core.Mvc.Web/Areas/Indexing/Views/IndexProfile/Create.cshtml", "src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Indexing/IndexProfiles/Create.razor" },

--- a/tests/CrestApps.Core.Tests/Core/Models/AIDataSourceOptionsTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Models/AIDataSourceOptionsTests.cs
@@ -1,0 +1,21 @@
+using CrestApps.Core.AI.Models;
+
+namespace CrestApps.Core.Tests.Core.Models;
+
+public sealed class AIDataSourceOptionsTests
+{
+    [Theory]
+    [InlineData(1, 0f)]
+    [InlineData(2, 0.2f)]
+    [InlineData(3, 0.4f)]
+    [InlineData(4, 0.6f)]
+    [InlineData(5, 0.8f)]
+    public void GetMinimumScore_MapsStrictnessToCalibratedThreshold(int strictness, float expectedScore)
+    {
+        var options = new AIDataSourceOptions();
+
+        var result = options.GetMinimumScore(strictness);
+
+        Assert.Equal(expectedScore, result);
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/Orchestration/DataSourcePreemptiveRagHandlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Orchestration/DataSourcePreemptiveRagHandlerTests.cs
@@ -1,0 +1,315 @@
+using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Deployments;
+using CrestApps.Core.AI.Handlers;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI;
+using CrestApps.Core.Infrastructure.Indexing;
+using CrestApps.Core.Infrastructure.Indexing.DataSources;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+using CrestApps.Core.Templates.Models;
+using CrestApps.Core.Templates.Services;
+using CrestApps.Core.Tests.Support;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+#pragma warning disable MEAI001
+namespace CrestApps.Core.Tests.Core.Orchestration;
+
+public sealed class DataSourcePreemptiveRagHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_PrioritizesRawUserQueryAndInjectsMatchingContext()
+    {
+        var dataSourceStore = new Mock<IAIDataSourceStore>();
+        dataSourceStore.Setup(store => store.FindByIdAsync("data-source-1"))
+            .ReturnsAsync(new AIDataSource
+            {
+                ItemId = "data-source-1",
+                AIKnowledgeBaseIndexProfileName = "kb-index",
+            });
+
+        var indexProfileStore = new Mock<ISearchIndexProfileStore>();
+        indexProfileStore.Setup(store => store.FindByNameAsync("kb-index"))
+            .ReturnsAsync(new SearchIndexProfile
+            {
+                Name = "kb-index",
+                ProviderName = "test-provider",
+                EmbeddingDeploymentName = "embedding",
+            });
+
+        var deploymentManager = new Mock<IAIDeploymentManager>();
+        deploymentManager.Setup(manager => manager.FindByNameAsync("embedding"))
+            .ReturnsAsync(new AIDeployment
+            {
+                ItemId = "embedding-id",
+                Name = "embedding",
+                ModelName = "embedding",
+                ClientName = "OpenAI",
+                ConnectionName = "Default",
+                Purpose = AIDeploymentPurpose.Embedding,
+            });
+
+        var textNormalizer = new Mock<IAITextNormalizer>();
+        textNormalizer.Setup(normalizer => normalizer.NormalizeTitle(It.IsAny<string>()))
+            .Returns<string>(value => value);
+
+        var services = new ServiceCollection()
+            .AddSingleton<IAIDataSourceStore>(dataSourceStore.Object)
+            .AddSingleton<ISearchIndexProfileStore>(indexProfileStore.Object)
+            .AddSingleton<IAIDeploymentManager>(deploymentManager.Object)
+            .AddSingleton<IAIClientFactory>(new FakeAIClientFactory(new FakeEmbeddingGenerator(new Dictionary<string, float[]>
+            {
+                ["What year did the theater start?"] = [1f],
+                ["theater founding year"] = [2f],
+            })))
+            .AddSingleton<ITemplateService, FakeTemplateService>()
+            .AddSingleton<IAITextNormalizer>(textNormalizer.Object)
+            .AddSingleton<IOptionsMonitor<AIDataSourceOptions>>(new TestOptionsMonitor<AIDataSourceOptions>
+            {
+                CurrentValue = new AIDataSourceOptions
+                {
+                    DefaultStrictness = 3,
+                    DefaultTopNDocuments = 3,
+                },
+            })
+            .AddLogging()
+            .AddKeyedSingleton<IDataSourceContentManager>("test-provider", new FakeDataSourceContentManager())
+            .BuildServiceProvider();
+
+        var handler = new DataSourcePreemptiveRagHandler(
+            services,
+            services.GetRequiredService<IAIClientFactory>(),
+            services.GetRequiredService<ITemplateService>(),
+            services.GetRequiredService<IAIDeploymentManager>(),
+            services.GetRequiredService<IAITextNormalizer>(),
+            services.GetRequiredService<IOptionsMonitor<AIDataSourceOptions>>(),
+            NullLogger<DataSourcePreemptiveRagHandler>.Instance);
+
+        var profile = new AIProfile
+        {
+            ItemId = "profile-1",
+        };
+        profile.Put(new AIDataSourceRagMetadata
+        {
+            IsInScope = true,
+        });
+
+        var context = new OrchestrationContext
+        {
+            UserMessage = "What year did the theater start?",
+            CompletionContext = new AICompletionContext
+            {
+                DataSourceId = "data-source-1",
+            },
+        };
+
+        await handler.HandleAsync(new PreemptiveRagContext(context, profile, ["theater founding year"]));
+
+        var systemMessage = context.SystemMessageBuilder.ToString();
+
+        Assert.Contains("[Retrieved Data Source Context]", systemMessage);
+        Assert.Contains("Since 1941, the 20th Century Theater has been", systemMessage);
+        Assert.DoesNotContain("Directions and parking information.", systemMessage);
+        Assert.True(context.Properties.ContainsKey("DataSourceReferences"));
+    }
+
+    private sealed class FakeAIClientFactory : IAIClientFactory
+    {
+        private readonly IEmbeddingGenerator<string, Embedding<float>> _embeddingGenerator;
+
+        public FakeAIClientFactory(IEmbeddingGenerator<string, Embedding<float>> embeddingGenerator)
+        {
+            _embeddingGenerator = embeddingGenerator;
+        }
+
+        public ValueTask<IChatClient> CreateChatClientAsync(AIDeployment deployment)
+        {
+            return new((IChatClient)null);
+        }
+
+        public ValueTask<IChatClient> CreateChatClientAsync(AIDeployment deployment, Action<ChatClientBuilder> configurePipeline)
+        {
+            return CreateChatClientAsync(deployment);
+        }
+
+        public ValueTask<IEmbeddingGenerator<string, Embedding<float>>> CreateEmbeddingGeneratorAsync(AIDeployment deployment)
+        {
+            return new(_embeddingGenerator);
+        }
+
+        public ValueTask<IEmbeddingGenerator<string, Embedding<float>>> CreateEmbeddingGeneratorAsync(AIDeployment deployment, Action<EmbeddingGeneratorBuilder<string, Embedding<float>>> configurePipeline)
+        {
+            return CreateEmbeddingGeneratorAsync(deployment);
+        }
+
+        public ValueTask<IImageGenerator> CreateImageGeneratorAsync(AIDeployment deployment)
+        {
+            return new((IImageGenerator)null);
+        }
+
+        public ValueTask<IImageGenerator> CreateImageGeneratorAsync(AIDeployment deployment, Action<ImageGeneratorBuilder> configurePipeline)
+        {
+            return CreateImageGeneratorAsync(deployment);
+        }
+
+        public ValueTask<ISpeechToTextClient> CreateSpeechToTextClientAsync(AIDeployment deployment)
+        {
+            return new((ISpeechToTextClient)null);
+        }
+
+        public ValueTask<ISpeechToTextClient> CreateSpeechToTextClientAsync(AIDeployment deployment, Action<SpeechToTextClientBuilder> configurePipeline)
+        {
+            return CreateSpeechToTextClientAsync(deployment);
+        }
+
+        public ValueTask<ITextToSpeechClient> CreateTextToSpeechClientAsync(AIDeployment deployment)
+        {
+            return new((ITextToSpeechClient)null);
+        }
+
+        public ValueTask<ITextToSpeechClient> CreateTextToSpeechClientAsync(AIDeployment deployment, Action<TextToSpeechClientBuilder> configurePipeline)
+        {
+            return CreateTextToSpeechClientAsync(deployment);
+        }
+    }
+
+    private sealed class FakeEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        private readonly IReadOnlyDictionary<string, float[]> _vectors;
+
+        public FakeEmbeddingGenerator(IReadOnlyDictionary<string, float[]> vectors)
+        {
+            _vectors = vectors;
+        }
+
+        public EmbeddingGeneratorMetadata Metadata { get; } = new("fake");
+
+        object IEmbeddingGenerator.GetService(Type serviceType, object serviceKey)
+        {
+            return null;
+        }
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions options = null, CancellationToken cancellationToken = default)
+        {
+            var embeddings = new GeneratedEmbeddings<Embedding<float>>();
+
+            foreach (var value in values)
+            {
+                embeddings.Add(new Embedding<float>(_vectors[value]));
+            }
+
+            return Task.FromResult(embeddings);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class FakeDataSourceContentManager : IDataSourceContentManager
+    {
+        public Task<long> DeleteByDataSourceIdAsync(IIndexProfileInfo indexProfile, string dataSourceId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(0L);
+        }
+
+        public Task<IEnumerable<DataSourceSearchResult>> SearchAsync(IIndexProfileInfo indexProfile, float[] embedding, string dataSourceId, int topN, string filter = null, CancellationToken cancellationToken = default)
+        {
+            IEnumerable<DataSourceSearchResult> results = embedding[0] switch
+            {
+                1f =>
+                [
+                    new()
+                    {
+                        ReferenceId = "about",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "About Us",
+                        Content = "Since 1941, the 20th Century Theater has been part of Cincinnati's story.",
+                        Score = 0.45f,
+                    },
+                    new()
+                    {
+                        ReferenceId = "history",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "History",
+                        Content = "The restored Art Deco theater has hosted events across generations.",
+                        Score = 0.44f,
+                    },
+                    new()
+                    {
+                        ReferenceId = "venue",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "Venue",
+                        Content = "The theater remains a landmark wedding and live-events venue.",
+                        Score = 0.43f,
+                    },
+                ],
+                2f =>
+                [
+                    new()
+                    {
+                        ReferenceId = "parking",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "Plan Your Visit",
+                        Content = "Directions and parking information.",
+                        Score = 0.95f,
+                    },
+                    new()
+                    {
+                        ReferenceId = "contact",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "Contact",
+                        Content = "Call the venue team during business hours.",
+                        Score = 0.94f,
+                    },
+                    new()
+                    {
+                        ReferenceId = "gallery",
+                        ReferenceType = "Web",
+                        ChunkIndex = 0,
+                        Title = "Gallery",
+                        Content = "Photo gallery and event inspiration.",
+                        Score = 0.93f,
+                    },
+                ],
+                _ => [],
+            };
+
+            return Task.FromResult(results);
+        }
+    }
+
+    private sealed class FakeTemplateService : ITemplateService
+    {
+        public Task<Template> GetAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<Template>(null);
+        }
+
+        public Task<IReadOnlyList<Template>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<Template>>([]);
+        }
+
+        public Task<string> MergeAsync(IEnumerable<string> ids, IDictionary<string, object> arguments = null, string separator = "\n\n", CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(string.Join(separator, ids));
+        }
+
+        public Task<string> RenderAsync(string id, IDictionary<string, object> arguments = null, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(id == AITemplateIds.DataSourceContextHeader ? "[Retrieved Data Source Context]" : string.Empty);
+        }
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/Orchestration/DataSourceSearchResultSelectorTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Orchestration/DataSourceSearchResultSelectorTests.cs
@@ -1,0 +1,66 @@
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+
+namespace CrestApps.Core.Tests.Core.Orchestration;
+
+public sealed class DataSourceSearchResultSelectorTests
+{
+    [Fact]
+    public void SelectTopResults_ExcludesAssetsAndErrorPages()
+    {
+        var results = new[]
+        {
+            new DataSourceSearchResult
+            {
+                ReferenceId = "https://www.example.com/locations.kml",
+                ReferenceType = "Web",
+                Title = "Locations",
+                Content = "coordinates",
+                Score = 0.90f,
+            },
+            new DataSourceSearchResult
+            {
+                ReferenceId = "https://www.example.com/404/",
+                ReferenceType = "Web",
+                Title = "404 | Example",
+                Content = "404 - Page Not Found",
+                Score = 0.80f,
+            },
+            new DataSourceSearchResult
+            {
+                ReferenceId = "https://www.example.com/about/",
+                ReferenceType = "Web",
+                Title = "About",
+                Content = "Since 1941, the theater has served the community.",
+                Score = 0.41f,
+            },
+            new DataSourceSearchResult
+            {
+                ReferenceId = "https://www.example.com/history/",
+                ReferenceType = "Web",
+                Title = "History",
+                Content = "The venue later expanded its programming.",
+                Score = 0.40f,
+            },
+        };
+
+        var selected = DataSourceSearchResultSelector.SelectTopResults(results, 2, 0.35f);
+
+        Assert.Equal(2, selected.Count);
+        Assert.All(selected, result => Assert.DoesNotContain(".kml", result.ReferenceId ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+        Assert.All(selected, result => Assert.DoesNotContain("404", result.Title ?? string.Empty, StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(selected, result => result.Content.Contains("1941", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(3, 9)]
+    [InlineData(5, 15)]
+    [InlineData(10, 20)]
+    public void GetCandidateCount_ExpandsAndCapsRequestedTopN(int topN, int expected)
+    {
+        var candidateCount = DataSourceSearchResultSelector.GetCandidateCount(topN);
+
+        Assert.Equal(expected, candidateCount);
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/Services/PostgreSQLHelpersTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Services/PostgreSQLHelpersTests.cs
@@ -53,12 +53,13 @@ public sealed class PostgreSQLHelpersTests
     }
 
     /// <summary>
-    /// Verifies identifier quoting preserves legacy case and trimming behavior.
+    /// Verifies identifier quoting trims, preserves case, and wraps the identifier in double quotes so that
+    /// names which are not valid unquoted identifiers (e.g. a hyphenated table name) are emitted correctly.
     /// </summary>
     [Theory]
-    [InlineData(" Customer_Orders ", "Customer_Orders")]
-    [InlineData("customer-orders", "customer-orders")]
-    public void QuoteIdentifier_ShouldPreserveLegacyOutput(string value, string expected)
+    [InlineData(" Customer_Orders ", "\"Customer_Orders\"")]
+    [InlineData("customer-orders", "\"customer-orders\"")]
+    public void QuoteIdentifier_ShouldWrapIdentifierInDoubleQuotes(string value, string expected)
     {
         var result = PostgreSQLHelpers.QuoteIdentifier(value);
 

--- a/tests/CrestApps.Core.Tests/Core/Tools/DocumentationSearchTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Tools/DocumentationSearchTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.AI;
@@ -616,6 +617,7 @@ public sealed class DocumentationSearchTests
             site,
             new DocumentationSearchOptions(),
             httpClientFactory,
+            new SitemapCrawler(NullLogger<SitemapCrawler>.Instance),
             TimeProvider.System,
             NullLogger<SitemapDocumentationSource>.Instance);
     }

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -153,6 +153,22 @@ public sealed class WebCrawlerTests
     }
 
     [Fact]
+    public async Task Strategy_FetchAsync_SkipsNonHtmlAssets()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            ["https://docs.example.com/locations.kml"] = (Encoding.UTF8.GetBytes("<kml><Placemark /></kml>"), "application/vnd.google-earth.kml+xml"),
+        };
+
+        var strategy = CreateStrategy(routes);
+        var crawler = CreateCrawler();
+
+        var page = await strategy.FetchAsync(crawler, "https://docs.example.com/locations.kml", Ct);
+
+        Assert.Null(page);
+    }
+
+    [Fact]
     public async Task Handler_ReadAsync_AggregatesCrawlersIntoOneDataSourceAndRecordsState()
     {
         var routes = new Dictionary<string, (byte[] Body, string ContentType)>

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -5,7 +5,7 @@ using CrestApps.Core.AI.DataSources;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Services;
 using CrestApps.Core.AI.WebCrawlers;
-using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.Crawling;
 using CrestApps.Core.AI.WebCrawlers.Strategies;
 using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
 using CrestApps.Core.DataIngestion;

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -1,0 +1,462 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.WebCrawlers;
+using CrestApps.Core.AI.WebCrawlers.Crawling;
+using CrestApps.Core.AI.WebCrawlers.Strategies;
+using CrestApps.Core.AI.WebCrawlers.Strategies.Sitemap;
+using CrestApps.Core.DataIngestion;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+using CrestApps.Core.Models;
+using CrestApps.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace CrestApps.Core.Tests.Core.WebCrawlers;
+
+public sealed class WebCrawlerTests
+{
+    private const string Sitemap = "https://docs.example.com/sitemap.xml";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public void HtmlReader_ExtractsTitleAndStripsScriptsStylesTags()
+    {
+        const string html = "<html><head><title>Hello &amp; Bye</title><style>a{}</style></head><body><script>x()</script><p>Body  text</p></body></html>";
+
+        Assert.Equal("Hello & Bye", HtmlIngestionDocumentReader.ExtractTitle(html));
+
+        var text = HtmlIngestionDocumentReader.ExtractText(html);
+        Assert.Contains("Body text", text);
+        Assert.DoesNotContain("x()", text);
+        Assert.DoesNotContain("a{}", text);
+    }
+
+    [Fact]
+    public void HtmlReader_ReadProducesIngestionDocumentWithContent()
+    {
+        var document = HtmlIngestionDocumentReader.Read("<html><body><p>Alpha</p><p>Beta</p></body></html>", "https://x.com/p");
+
+        var text = string.Join(" ", document.EnumerateContent().Select(e => e.Text));
+        Assert.Contains("Alpha", text);
+        Assert.Contains("Beta", text);
+    }
+
+    [Fact]
+    public async Task Crawler_ParsesUrlsetWithLastmod()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            [Sitemap] = (Xml(
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://docs.example.com/a</loc><lastmod>2024-01-02T00:00:00Z</lastmod></url>
+                  <url><loc>https://docs.example.com/b</loc></url>
+                </urlset>
+                """), "application/xml"),
+        };
+
+        var crawler = new SitemapCrawler(NullLogger<SitemapCrawler>.Instance);
+        using var client = new RoutingHttpClientFactory(routes).CreateClient("x");
+
+        var entries = await crawler.DiscoverAsync(client, new SitemapCrawlRequest { SitemapUrl = Sitemap }, Ct);
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero), entries.Single(e => e.Url.EndsWith("/a")).LastModifiedUtc);
+    }
+
+    [Fact]
+    public async Task Crawler_FollowsSitemapIndex()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            [Sitemap] = (Xml(
+                """
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <sitemap><loc>https://docs.example.com/child.xml</loc></sitemap>
+                </sitemapindex>
+                """), "application/xml"),
+            ["https://docs.example.com/child.xml"] = (Xml(
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://docs.example.com/deep</loc></url>
+                </urlset>
+                """), "application/xml"),
+        };
+
+        var crawler = new SitemapCrawler(NullLogger<SitemapCrawler>.Instance);
+        using var client = new RoutingHttpClientFactory(routes).CreateClient("x");
+
+        var entries = await crawler.DiscoverAsync(client, new SitemapCrawlRequest { SitemapUrl = Sitemap }, Ct);
+
+        Assert.Equal("https://docs.example.com/deep", Assert.Single(entries).Url);
+    }
+
+    [Fact]
+    public async Task Strategy_DiscoverAppliesFilterAndFetchCleansPage()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            [Sitemap] = (Xml(
+                """
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                  <url><loc>https://docs.example.com/keep</loc></url>
+                  <url><loc>https://docs.example.com/drop</loc></url>
+                </urlset>
+                """), "application/xml"),
+            ["https://docs.example.com/keep"] = (Html("Keep", "keep body"), "text/html"),
+        };
+
+        var strategy = CreateStrategy(routes);
+        var crawler = CreateCrawler(exclude: ["/drop"]);
+
+        var refs = await strategy.DiscoverAsync(crawler, Ct);
+        Assert.Equal("https://docs.example.com/keep", Assert.Single(refs).Url);
+
+        var page = await strategy.FetchAsync(crawler, "https://docs.example.com/keep", Ct);
+        Assert.NotNull(page);
+        Assert.Equal("Keep", page.Title);
+        Assert.Contains("keep body", page.Content);
+    }
+
+    [Fact]
+    public async Task Handler_ReadAsync_AggregatesCrawlersIntoOneDataSourceAndRecordsState()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            ["https://a.example.com/sitemap.xml"] = (Xml(SingleUrlSitemap("https://a.example.com/1", "2024-05-01T00:00:00Z")), "application/xml"),
+            ["https://a.example.com/1"] = (Html("A1", "alpha body"), "text/html"),
+            ["https://b.example.com/sitemap.xml"] = (Xml(SingleUrlSitemap("https://b.example.com/2", null)), "application/xml"),
+            ["https://b.example.com/2"] = (Html("B2", "beta body"), "text/html"),
+        };
+
+        var crawlerStore = new InMemoryCrawlerStore();
+        crawlerStore.Items.Add(CreateCrawler(itemId: "c1", sitemapUrl: "https://a.example.com/sitemap.xml"));
+        crawlerStore.Items.Add(CreateCrawler(itemId: "c2", sitemapUrl: "https://b.example.com/sitemap.xml"));
+
+        var stateStore = new InMemoryCrawlStateStore();
+        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System);
+
+        var documents = await CollectAsync(handler.ReadAsync(CreateWebDataSource(), Ct));
+
+        Assert.Equal(2, documents.Count);
+        Assert.Contains(documents, d => d.Key == "https://a.example.com/1" && (string)d.Value.Fields[WebCrawlerConstants.UrlFieldName] == "https://a.example.com/1");
+        Assert.Contains(documents, d => d.Key == "https://b.example.com/2");
+        Assert.Equal(2, stateStore.Items.Count);
+        Assert.Contains(stateStore.Items, s => s.Url == "https://a.example.com/1" && s.LastModifiedUtc == new DateTime(2024, 5, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task Handler_ReadByIdsAsync_FetchesRequestedUrlViaOwningCrawler()
+    {
+        var routes = new Dictionary<string, (byte[] Body, string ContentType)>
+        {
+            ["https://a.example.com/1"] = (Html("A1", "alpha body"), "text/html"),
+        };
+
+        var crawlerStore = new InMemoryCrawlerStore();
+        crawlerStore.Items.Add(CreateCrawler(itemId: "c1", sitemapUrl: "https://a.example.com/sitemap.xml"));
+
+        var stateStore = new InMemoryCrawlStateStore();
+        stateStore.Items.Add(new WebCrawlState { ItemId = "s1", Source = "c1", Url = "https://a.example.com/1" });
+
+        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System);
+
+        var documents = await CollectAsync(handler.ReadByIdsAsync(CreateWebDataSource(), ["https://a.example.com/1"], Ct));
+
+        Assert.Equal("https://a.example.com/1", Assert.Single(documents).Key);
+    }
+
+    [Fact]
+    public async Task Planner_DetectsNewChangedAndRemovedPages()
+    {
+        var resolver = new StubResolver(new StubStrategy(
+        [
+            new CrawledPageRef("https://x.com/new"),
+            new CrawledPageRef("https://x.com/changed", new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero)),
+            new CrawledPageRef("https://x.com/same", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+        ]));
+
+        var stateStore = new InMemoryCrawlStateStore();
+        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/changed", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "2", Source = "c1", Url = "https://x.com/same", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "3", Source = "c1", Url = "https://x.com/removed" });
+
+        var queue = new RecordingIndexingQueue();
+        var planner = new WebCrawlerReindexPlanner(resolver, stateStore, queue, TimeProvider.System, NullLogger<WebCrawlerReindexPlanner>.Instance);
+
+        var result = await planner.PlanAndEnqueueAsync(CreateCrawler(itemId: "c1"), Ct);
+
+        Assert.Equal(1, result.NewCount);
+        Assert.Equal(1, result.ChangedCount);
+        Assert.Equal(1, result.RemovedCount);
+        Assert.Equal(1, result.UnchangedCount);
+        Assert.Contains("https://x.com/new", queue.Synced);
+        Assert.Contains("https://x.com/changed", queue.Synced);
+        Assert.Contains("https://x.com/removed", queue.Removed);
+        Assert.DoesNotContain(stateStore.Items, s => s.Url == "https://x.com/removed");
+    }
+
+    [Theory]
+    [InlineData("https://x.com/page", "https://x.com/page")]
+    [InlineData("not-a-url", null)]
+    [InlineData("ftp://x.com/f", null)]
+    public void LinkResolver_ReturnsUrlOnlyForHttpReferences(string referenceId, string expected)
+    {
+        Assert.Equal(expected, new WebCrawlerReferenceLinkResolver().ResolveLink(referenceId, null));
+    }
+
+    private static SitemapWebCrawlerStrategy CreateStrategy(IReadOnlyDictionary<string, (byte[] Body, string ContentType)> routes)
+    {
+        return new SitemapWebCrawlerStrategy(
+            new SitemapCrawler(NullLogger<SitemapCrawler>.Instance),
+            new RoutingHttpClientFactory(routes),
+            Options.Create(new WebCrawlerOptions()),
+            NullLogger<SitemapWebCrawlerStrategy>.Instance);
+    }
+
+    private static StubResolver CreateResolver(IReadOnlyDictionary<string, (byte[] Body, string ContentType)> routes)
+    {
+        return new StubResolver(CreateStrategy(routes));
+    }
+
+    private static WebCrawler CreateCrawler(string itemId = "c1", string sitemapUrl = null, List<string> exclude = null)
+    {
+        var crawler = new WebCrawler
+        {
+            ItemId = itemId,
+            Source = WebCrawlerConstants.Strategies.Sitemap,
+            AIDataSourceId = "ds1",
+            Enabled = true,
+        };
+        crawler.Put(new SitemapWebCrawlerMetadata
+        {
+            SitemapUrl = sitemapUrl ?? Sitemap,
+            ExcludeUrlPatterns = exclude,
+        });
+
+        return crawler;
+    }
+
+    private static AIDataSource CreateWebDataSource()
+    {
+        return new AIDataSource { ItemId = "ds1", Source = AIDataSourceSourceTypes.Web };
+    }
+
+    private static string SingleUrlSitemap(string url, string lastmod)
+    {
+        var lastmodElement = lastmod is null ? string.Empty : $"<lastmod>{lastmod}</lastmod>";
+
+        return $"""
+            <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+              <url><loc>{url}</loc>{lastmodElement}</url>
+            </urlset>
+            """;
+    }
+
+    private static async Task<List<KeyValuePair<string, SourceDocument>>> CollectAsync(IAsyncEnumerable<KeyValuePair<string, SourceDocument>> source)
+    {
+        var items = new List<KeyValuePair<string, SourceDocument>>();
+
+        await foreach (var item in source.WithCancellation(Ct))
+        {
+            items.Add(item);
+        }
+
+        return items;
+    }
+
+    private static byte[] Xml(string content)
+    {
+        return Encoding.UTF8.GetBytes(content);
+    }
+
+    private static byte[] Html(string title, string body)
+    {
+        return Encoding.UTF8.GetBytes($"<html><head><title>{title}</title></head><body>{body}</body></html>");
+    }
+
+    private sealed class StubResolver : IWebCrawlerStrategyResolver
+    {
+        private readonly IWebCrawlerStrategy _strategy;
+
+        public StubResolver(IWebCrawlerStrategy strategy)
+        {
+            _strategy = strategy;
+        }
+
+        public IWebCrawlerStrategy Get(string strategy)
+        {
+            return string.Equals(strategy, _strategy.Name, StringComparison.OrdinalIgnoreCase) ? _strategy : null;
+        }
+    }
+
+    private sealed class StubStrategy : IWebCrawlerStrategy
+    {
+        private readonly IReadOnlyList<CrawledPageRef> _refs;
+
+        public StubStrategy(IReadOnlyList<CrawledPageRef> refs)
+        {
+            _refs = refs;
+        }
+
+        public string Name => WebCrawlerConstants.Strategies.Sitemap;
+
+        public ValueTask ValidateAsync(WebCrawler crawler, ValidationResultDetails result, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default) => Task.FromResult(_refs);
+
+        public Task<CrawledPage> FetchAsync(WebCrawler crawler, string url, CancellationToken cancellationToken = default) => Task.FromResult(new CrawledPage("Title", "content"));
+    }
+
+    private sealed class RecordingIndexingQueue : IAIDataSourceIndexingQueue
+    {
+        public List<string> Synced { get; } = [];
+
+        public List<string> Removed { get; } = [];
+
+        public ValueTask QueueSyncDataSourceAsync(AIDataSource dataSource, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask QueueDeleteDataSourceAsync(AIDataSource dataSource, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask QueueSyncSourceDocumentsAsync(string sourceIndexProfileName, IReadOnlyCollection<string> documentIds, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask QueueRemoveSourceDocumentsAsync(string sourceIndexProfileName, IReadOnlyCollection<string> documentIds, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask QueueSyncDataSourceDocumentsAsync(string dataSourceId, IReadOnlyCollection<string> documentIds, CancellationToken cancellationToken = default)
+        {
+            Synced.AddRange(documentIds);
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask QueueRemoveDataSourceDocumentsAsync(string dataSourceId, IReadOnlyCollection<string> documentIds, CancellationToken cancellationToken = default)
+        {
+            Removed.AddRange(documentIds);
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryCrawlerStore : InMemorySourceCatalog<WebCrawler>, IWebCrawlerStore
+    {
+        public Task<IReadOnlyCollection<WebCrawler>> GetByDataSourceIdAsync(string dataSourceId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyCollection<WebCrawler>>(Items.Where(x => x.AIDataSourceId == dataSourceId).ToArray());
+        }
+    }
+
+    private sealed class InMemoryCrawlStateStore : InMemorySourceCatalog<WebCrawlState>, IWebCrawlStateStore
+    {
+        public Task DeleteByCrawlerIdAsync(string webCrawlerId, CancellationToken cancellationToken = default)
+        {
+            Items.RemoveAll(x => x.Source == webCrawlerId);
+
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteByUrlsAsync(string webCrawlerId, IEnumerable<string> urls, CancellationToken cancellationToken = default)
+        {
+            var set = new HashSet<string>(urls, StringComparer.OrdinalIgnoreCase);
+            Items.RemoveAll(x => x.Source == webCrawlerId && set.Contains(x.Url));
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private abstract class InMemorySourceCatalog<T> : ISourceCatalog<T>
+        where T : CatalogItem, ISourceAwareModel
+    {
+        public List<T> Items { get; } = [];
+
+        public ValueTask<IReadOnlyCollection<T>> GetAsync(string source, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult<IReadOnlyCollection<T>>(Items.Where(x => x.Source == source).ToArray());
+        }
+
+        public ValueTask CreateAsync(T entry, CancellationToken cancellationToken = default)
+        {
+            Items.Add(entry);
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask UpdateAsync(T entry, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<bool> DeleteAsync(T entry, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(Items.Remove(entry));
+        }
+
+        public ValueTask<T> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(Items.FirstOrDefault(x => x.ItemId == id));
+        }
+
+        public ValueTask<IReadOnlyCollection<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult<IReadOnlyCollection<T>>(Items.ToArray());
+        }
+
+        public ValueTask<IReadOnlyCollection<T>> GetAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+        {
+            var set = new HashSet<string>(ids, StringComparer.OrdinalIgnoreCase);
+
+            return ValueTask.FromResult<IReadOnlyCollection<T>>(Items.Where(x => set.Contains(x.ItemId)).ToArray());
+        }
+
+        public ValueTask<PageResult<T>> PageAsync<TQuery>(int page, int pageSize, TQuery context, CancellationToken cancellationToken = default)
+            where TQuery : QueryContext
+        {
+            return ValueTask.FromResult(new PageResult<T> { Count = Items.Count, Entries = Items.ToArray() });
+        }
+    }
+
+    private sealed class RoutingHttpClientFactory : IHttpClientFactory
+    {
+        private readonly IReadOnlyDictionary<string, (byte[] Body, string ContentType)> _routes;
+
+        public RoutingHttpClientFactory(IReadOnlyDictionary<string, (byte[] Body, string ContentType)> routes)
+        {
+            _routes = routes;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient(new RoutingHandler(_routes), disposeHandler: true);
+        }
+
+        private sealed class RoutingHandler : HttpMessageHandler
+        {
+            private readonly IReadOnlyDictionary<string, (byte[] Body, string ContentType)> _routes;
+
+            public RoutingHandler(IReadOnlyDictionary<string, (byte[] Body, string ContentType)> routes)
+            {
+                _routes = routes;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var url = request.RequestUri.ToString();
+
+                if (_routes.TryGetValue(url, out var route))
+                {
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(route.Body),
+                    };
+                    response.Content.Headers.ContentType = new MediaTypeHeaderValue(route.ContentType);
+
+                    return Task.FromResult(response);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+        }
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -48,6 +48,34 @@ public sealed class WebCrawlerTests
     }
 
     [Fact]
+    public void HtmlReader_RemovesUnclosedScriptAndStyleContent()
+    {
+        // A malformed/unclosed script would slip past a regex tag stripper; the parser removes it entirely.
+        var text = HtmlIngestionDocumentReader.ExtractText("<html><body><p>real content</p><script>stealCookies()<style>.x{color:red}");
+
+        Assert.Contains("real content", text);
+        Assert.DoesNotContain("stealCookies", text);
+        Assert.DoesNotContain("color:red", text);
+    }
+
+    [Fact]
+    public void HtmlReader_RemovesCommentsAndInlineHandlers()
+    {
+        var text = HtmlIngestionDocumentReader.ExtractText("<html><body><!-- hidden secret --><img src=x onerror=alert(1)><p>visible</p></body></html>");
+
+        Assert.Equal("visible", text);
+        Assert.DoesNotContain("secret", text);
+        Assert.DoesNotContain("onerror", text);
+        Assert.DoesNotContain("alert", text);
+    }
+
+    [Fact]
+    public void HtmlReader_TitleIsPlainTextWithoutNestedTags()
+    {
+        Assert.Equal("Hi there", HtmlIngestionDocumentReader.ExtractTitle("<html><head><title>Hi <b>there</b></title></head><body>x</body></html>"));
+    }
+
+    [Fact]
     public async Task Crawler_ParsesUrlsetWithLastmod()
     {
         var routes = new Dictionary<string, (byte[] Body, string ContentType)>

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -168,7 +168,7 @@ public sealed class WebCrawlerTests
         crawlerStore.Items.Add(CreateCrawler(itemId: "c2", sitemapUrl: "https://b.example.com/sitemap.xml"));
 
         var stateStore = new InMemoryCrawlStateStore();
-        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System);
+        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System, NullLogger<WebAIDataSourceSourceHandler>.Instance);
 
         var documents = await CollectAsync(handler.ReadAsync(CreateWebDataSource(), Ct));
 
@@ -193,7 +193,7 @@ public sealed class WebCrawlerTests
         var stateStore = new InMemoryCrawlStateStore();
         stateStore.Items.Add(new WebCrawlState { ItemId = "s1", Source = "c1", Url = "https://a.example.com/1" });
 
-        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System);
+        var handler = new WebAIDataSourceSourceHandler(crawlerStore, stateStore, CreateResolver(routes), TimeProvider.System, NullLogger<WebAIDataSourceSourceHandler>.Instance);
 
         var documents = await CollectAsync(handler.ReadByIdsAsync(CreateWebDataSource(), ["https://a.example.com/1"], Ct));
 

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -210,10 +210,11 @@ public sealed class WebCrawlerTests
             new CrawledPageRef("https://x.com/same", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
         ]));
 
+        var indexedUtc = new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc);
         var stateStore = new InMemoryCrawlStateStore();
-        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/changed", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
-        stateStore.Items.Add(new WebCrawlState { ItemId = "2", Source = "c1", Url = "https://x.com/same", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
-        stateStore.Items.Add(new WebCrawlState { ItemId = "3", Source = "c1", Url = "https://x.com/removed" });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/changed", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), LastIndexedUtc = indexedUtc });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "2", Source = "c1", Url = "https://x.com/same", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), LastIndexedUtc = indexedUtc });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "3", Source = "c1", Url = "https://x.com/removed", LastIndexedUtc = indexedUtc });
 
         var queue = new RecordingIndexingQueue();
         var planner = new WebCrawlerReindexPlanner(resolver, stateStore, queue, TimeProvider.System, NullLogger<WebCrawlerReindexPlanner>.Instance);
@@ -228,6 +229,72 @@ public sealed class WebCrawlerTests
         Assert.Contains("https://x.com/changed", queue.Synced);
         Assert.Contains("https://x.com/removed", queue.Removed);
         Assert.DoesNotContain(stateStore.Items, s => s.Url == "https://x.com/removed");
+    }
+
+    [Fact]
+    public async Task Planner_ReenqueuesTrackedPageThatWasNeverIndexed()
+    {
+        var resolver = new StubResolver(new StubStrategy(
+        [
+            new CrawledPageRef("https://x.com/pending", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)),
+        ]));
+
+        // The page is already tracked (a prior sync created its crawl state) but has never been successfully
+        // indexed — LastIndexedUtc is still the default. Its advertised timestamp is unchanged, so the only
+        // reason to re-index it is the missing successful-index marker.
+        var stateStore = new InMemoryCrawlStateStore();
+        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/pending", LastModifiedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) });
+
+        var queue = new RecordingIndexingQueue();
+        var planner = new WebCrawlerReindexPlanner(resolver, stateStore, queue, TimeProvider.System, NullLogger<WebCrawlerReindexPlanner>.Instance);
+
+        var result = await planner.PlanAndEnqueueAsync(CreateCrawler(itemId: "c1"), Ct);
+
+        Assert.Equal(0, result.NewCount);
+        Assert.Equal(0, result.UnchangedCount);
+        Assert.Contains("https://x.com/pending", queue.Synced);
+    }
+
+    [Fact]
+    public async Task Planner_WhenDiscoveryReturnsNoPages_LeavesStateUntouchedAndReportsWarning()
+    {
+        var resolver = new StubResolver(new StubStrategy([]));
+
+        var stateStore = new InMemoryCrawlStateStore();
+        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/a", LastIndexedUtc = new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc) });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "2", Source = "c1", Url = "https://x.com/b", LastIndexedUtc = new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc) });
+
+        var queue = new RecordingIndexingQueue();
+        var planner = new WebCrawlerReindexPlanner(resolver, stateStore, queue, TimeProvider.System, NullLogger<WebCrawlerReindexPlanner>.Instance);
+
+        var result = await planner.PlanAndEnqueueAsync(CreateCrawler(itemId: "c1"), Ct);
+
+        Assert.Equal(WebCrawlerReindexStatus.NoPagesDiscovered, result.Status);
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+        // A transient block must not wipe the knowledge base: nothing is removed and the state is preserved.
+        Assert.Empty(queue.Removed);
+        Assert.Empty(queue.Synced);
+        Assert.Equal(2, stateStore.Items.Count);
+    }
+
+    [Fact]
+    public async Task Planner_WhenDiscoveryThrows_ReportsFailureAndEnqueuesNothing()
+    {
+        var resolver = new StubResolver(new StubStrategy([], new HttpRequestException("403 Forbidden")));
+
+        var stateStore = new InMemoryCrawlStateStore();
+        stateStore.Items.Add(new WebCrawlState { ItemId = "1", Source = "c1", Url = "https://x.com/a", LastIndexedUtc = new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc) });
+
+        var queue = new RecordingIndexingQueue();
+        var planner = new WebCrawlerReindexPlanner(resolver, stateStore, queue, TimeProvider.System, NullLogger<WebCrawlerReindexPlanner>.Instance);
+
+        var result = await planner.PlanAndEnqueueAsync(CreateCrawler(itemId: "c1"), Ct);
+
+        Assert.Equal(WebCrawlerReindexStatus.DiscoveryFailed, result.Status);
+        Assert.Contains("403 Forbidden", result.Message);
+        Assert.Empty(queue.Removed);
+        Assert.Empty(queue.Synced);
+        Assert.Single(stateStore.Items);
     }
 
     [Theory]
@@ -386,17 +453,20 @@ public sealed class WebCrawlerTests
     private sealed class StubStrategy : IWebCrawlerStrategy
     {
         private readonly IReadOnlyList<CrawledPageRef> _refs;
+        private readonly Exception _discoverException;
 
-        public StubStrategy(IReadOnlyList<CrawledPageRef> refs)
+        public StubStrategy(IReadOnlyList<CrawledPageRef> refs, Exception discoverException = null)
         {
             _refs = refs;
+            _discoverException = discoverException;
         }
 
         public string Name => WebCrawlerConstants.Strategies.Sitemap;
 
         public ValueTask ValidateAsync(WebCrawler crawler, ValidationResultDetails result, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
-        public Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default) => Task.FromResult(_refs);
+        public Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default)
+            => _discoverException is not null ? Task.FromException<IReadOnlyList<CrawledPageRef>>(_discoverException) : Task.FromResult(_refs);
 
         public Task<CrawledPage> FetchAsync(WebCrawler crawler, string url, CancellationToken cancellationToken = default) => Task.FromResult(new CrawledPage("Title", "content"));
     }

--- a/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/WebCrawlers/WebCrawlerTests.cs
@@ -211,6 +211,65 @@ public sealed class WebCrawlerTests
         Assert.Equal(expected, new WebCrawlerReferenceLinkResolver().ResolveLink(referenceId, null));
     }
 
+    [Fact]
+    public async Task ReindexService_ReindexDue_OnlyRunsDueCrawlers()
+    {
+        var crawlerStore = new InMemoryCrawlerStore();
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "due", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = true });
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "notdue", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = true });
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "disabled", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = false });
+
+        var stateStore = new InMemoryCrawlStateStore();
+        // "notdue" was seen just now, so it is inside its default re-index interval.
+        stateStore.Items.Add(new WebCrawlState { ItemId = "s1", Source = "notdue", Url = "https://x.com/1", LastSeenUtc = DateTime.UtcNow });
+
+        var planner = new RecordingPlanner();
+        var service = CreateReindexService(crawlerStore, stateStore, planner);
+
+        await service.ReindexDueAsync(Ct);
+
+        Assert.Contains("due", planner.Reindexed);
+        Assert.DoesNotContain("notdue", planner.Reindexed);
+        Assert.DoesNotContain("disabled", planner.Reindexed);
+    }
+
+    [Fact]
+    public async Task ReindexService_ReindexAll_RunsEveryEnabledCrawler()
+    {
+        var crawlerStore = new InMemoryCrawlerStore();
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "a", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = true });
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "b", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = true });
+        crawlerStore.Items.Add(new WebCrawler { ItemId = "disabled", Source = WebCrawlerConstants.Strategies.Sitemap, AIDataSourceId = "ds1", Enabled = false });
+
+        var stateStore = new InMemoryCrawlStateStore();
+        // Both enabled crawlers were seen just now, so neither is "due"; ReindexAll ignores that.
+        stateStore.Items.Add(new WebCrawlState { ItemId = "s1", Source = "a", Url = "https://x.com/1", LastSeenUtc = DateTime.UtcNow });
+        stateStore.Items.Add(new WebCrawlState { ItemId = "s2", Source = "b", Url = "https://x.com/2", LastSeenUtc = DateTime.UtcNow });
+
+        var planner = new RecordingPlanner();
+        var service = CreateReindexService(crawlerStore, stateStore, planner);
+
+        await service.ReindexAllAsync(Ct);
+
+        Assert.Contains("a", planner.Reindexed);
+        Assert.Contains("b", planner.Reindexed);
+        Assert.DoesNotContain("disabled", planner.Reindexed);
+    }
+
+    private static WebCrawlerReindexService CreateReindexService(
+        InMemoryCrawlerStore crawlerStore,
+        InMemoryCrawlStateStore stateStore,
+        IWebCrawlerReindexPlanner planner)
+    {
+        return new WebCrawlerReindexService(
+            crawlerStore,
+            stateStore,
+            planner,
+            Options.Create(new WebCrawlerOptions()),
+            TimeProvider.System,
+            NullLogger<WebCrawlerReindexService>.Instance);
+    }
+
     private static SitemapWebCrawlerStrategy CreateStrategy(IReadOnlyDictionary<string, (byte[] Body, string ContentType)> routes)
     {
         return new SitemapWebCrawlerStrategy(
@@ -312,6 +371,18 @@ public sealed class WebCrawlerTests
         public Task<IReadOnlyList<CrawledPageRef>> DiscoverAsync(WebCrawler crawler, CancellationToken cancellationToken = default) => Task.FromResult(_refs);
 
         public Task<CrawledPage> FetchAsync(WebCrawler crawler, string url, CancellationToken cancellationToken = default) => Task.FromResult(new CrawledPage("Title", "content"));
+    }
+
+    private sealed class RecordingPlanner : IWebCrawlerReindexPlanner
+    {
+        public List<string> Reindexed { get; } = [];
+
+        public Task<WebCrawlerReindexResult> PlanAndEnqueueAsync(WebCrawler crawler, CancellationToken cancellationToken = default)
+        {
+            Reindexed.Add(crawler.ItemId);
+
+            return Task.FromResult(WebCrawlerReindexResult.Empty);
+        }
     }
 
     private sealed class RecordingIndexingQueue : IAIDataSourceIndexingQueue


### PR DESCRIPTION
Introduces a strategy-agnostic web-crawler feature in the opt-in CrestApps.Core.AI.WebCrawlers package. A new "Web" AI data source acts as a target bucket; separate web-crawler records each choose a scraping strategy (today, sitemap discovery), configure it, and point at a Web data source, so many sites can populate a single knowledge base.

The sitemap strategy discovers pages across all common sitemap formats (flat urlset, nested sitemapindex, gzip, plain-text, RSS/Atom, robots.txt), fetches each page, and cleans it through a reusable HtmlIngestionDocumentReader in the new CrestApps.Core.DataIngestion package (a Microsoft.Extensions.DataIngestion reader). Cleaned text flows into the existing data-source indexing pipeline with the page URL kept for citations.

A background service re-crawls each crawler on its own cadence and re-indexes only the pages whose <lastmod> changed (adding new pages, removing deleted ones), backed by per-crawler crawl-state stores (YesSql + EntityCore). Both sample hosts ship a Web Crawlers management UI (MVC + Blazor at parity). Includes unit tests, docs, and a changelog entry.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
