### PR TITLE
Configure model parameters for the utility deployment

### DIFF
--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Capabilities/AIDeploymentParameterScope.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Capabilities/AIDeploymentParameterScope.cs
@@ -1,0 +1,18 @@
+namespace CrestApps.Core.AI.Capabilities;
+
+/// <summary>
+/// Identifies which set of selected model parameter values applies to a request.
+/// </summary>
+public enum AIDeploymentParameterScope
+{
+    /// <summary>
+    /// The values selected for the chat deployment.
+    /// </summary>
+    Chat,
+
+    /// <summary>
+    /// The values selected for the utility deployment, which backs background completions such as
+    /// title generation, data extraction, and post-session processing.
+    /// </summary>
+    Utility,
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Capabilities/IAIDeploymentParameterApplier.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Capabilities/IAIDeploymentParameterApplier.cs
@@ -1,0 +1,30 @@
+using CrestApps.Core.AI.Models;
+using Microsoft.Extensions.AI;
+
+namespace CrestApps.Core.AI.Capabilities;
+
+/// <summary>
+/// Applies the model parameter values selected for a request onto the outgoing
+/// <see cref="ChatOptions"/>. Only the parameters exposed by the resolved deployment are applied, so
+/// an unsupported parameter is never sent to a provider. Callers that issue a completion outside the
+/// completion pipeline — such as the background utility completions used for planning, data
+/// extraction, and post-session processing — use this service so their requests honor the same
+/// operator selections as the chat pipeline.
+/// </summary>
+public interface IAIDeploymentParameterApplier
+{
+    /// <summary>
+    /// Applies the values selected in the given scope to the supplied chat options.
+    /// </summary>
+    /// <param name="options">The chat options to mutate.</param>
+    /// <param name="deployment">The deployment resolved for the request. When <see langword="null"/>, the deployment named by the scope on the completion context is resolved instead.</param>
+    /// <param name="completionContext">The completion context holding the selected values.</param>
+    /// <param name="scope">The set of selected values to apply.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    Task ApplyAsync(
+        ChatOptions options,
+        AIDeployment deployment,
+        AICompletionContext completionContext,
+        AIDeploymentParameterScope scope,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Completions/AICompletionContextExtensions.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Completions/AICompletionContextExtensions.cs
@@ -8,8 +8,8 @@ namespace CrestApps.Core.AI.Completions;
 public static class AICompletionContextExtensions
 {
     /// <summary>
-    /// Copies the model parameter values held by the given metadata onto the completion context.
-    /// Empty values are ignored so a stored blank never overrides a deployment default.
+    /// Copies the chat and utility model parameter values held by the given metadata onto the completion
+    /// context. Empty values are ignored so a stored blank never overrides a deployment default.
     /// </summary>
     /// <param name="context">The completion context to populate.</param>
     /// <param name="metadata">The metadata holding the selected model parameter values.</param>
@@ -17,19 +17,30 @@ public static class AICompletionContextExtensions
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (metadata?.Values is not { Count: > 0 })
+        if (metadata is null)
         {
             return;
         }
 
-        foreach (var (name, value) in metadata.Values)
+        Copy(metadata.Values, context.ModelParameters);
+        Copy(metadata.UtilityValues, context.UtilityModelParameters);
+    }
+
+    private static void Copy(Dictionary<string, string> source, Dictionary<string, string> destination)
+    {
+        if (source is not { Count: > 0 })
+        {
+            return;
+        }
+
+        foreach (var (name, value) in source)
         {
             if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(value))
             {
                 continue;
             }
 
-            context.ModelParameters[name] = value;
+            destination[name] = value;
         }
     }
 }

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AICompletionContext.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AICompletionContext.cs
@@ -95,6 +95,14 @@ public sealed class AICompletionContext
     /// </summary>
     public string UtilityDeploymentName { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether this request is a background utility completion, such as
+    /// title generation, data extraction, or post-session processing. When <see langword="true"/>, the
+    /// utility deployment is resolved instead of the chat deployment and the parameter values held by
+    /// <see cref="UtilityModelParameters"/> are applied instead of <see cref="ModelParameters"/>.
+    /// </summary>
+    public bool IsUtilityCompletion { get; set; }
+
     [JsonInclude]
     [JsonPropertyName("DeploymentId")]
     private string _deploymentIdBackingField
@@ -122,6 +130,14 @@ public sealed class AICompletionContext
     /// expose are discarded before the request is sent to the provider.
     /// </summary>
     public Dictionary<string, string> ModelParameters { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the model parameter values selected for the utility deployment, keyed by the registered
+    /// parameter technical name. These values are applied only to background utility completions, and
+    /// values for parameters that the resolved utility deployment does not expose are discarded before
+    /// the request is sent to the provider.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Gets the additional provider-specific properties applied to the completion request.

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AIDeploymentParametersMetadata.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Models/AIDeploymentParametersMetadata.cs
@@ -8,22 +8,47 @@ namespace CrestApps.Core.AI.Models;
 public sealed class AIDeploymentParametersMetadata
 {
     /// <summary>
-    /// Gets or sets the selected parameter values keyed by their registered technical name.
+    /// Gets or sets the parameter values selected for the chat deployment, keyed by their registered
+    /// technical name.
     /// </summary>
     public Dictionary<string, string> Values { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Gets the value selected for the given parameter, or <see langword="null"/> when none was selected.
+    /// Gets or sets the parameter values selected for the utility deployment, keyed by their registered
+    /// technical name. The utility deployment backs background completions such as title generation,
+    /// data extraction, and post-session processing, so it is configured independently of the chat
+    /// deployment.
+    /// </summary>
+    public Dictionary<string, string> UtilityValues { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the value selected for the given chat deployment parameter, or <see langword="null"/> when
+    /// none was selected.
     /// </summary>
     /// <param name="parameterName">The technical name of the parameter.</param>
     public string GetValue(string parameterName)
     {
-        if (string.IsNullOrWhiteSpace(parameterName) || Values is null)
+        return GetValue(Values, parameterName);
+    }
+
+    /// <summary>
+    /// Gets the value selected for the given utility deployment parameter, or <see langword="null"/>
+    /// when none was selected.
+    /// </summary>
+    /// <param name="parameterName">The technical name of the parameter.</param>
+    public string GetUtilityValue(string parameterName)
+    {
+        return GetValue(UtilityValues, parameterName);
+    }
+
+    private static string GetValue(Dictionary<string, string> values, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(parameterName) || values is null)
         {
             return null;
         }
 
-        return Values.TryGetValue(parameterName, out var value) && !string.IsNullOrWhiteSpace(value)
+        return values.TryGetValue(parameterName, out var value) && !string.IsNullOrWhiteSpace(value)
             ? value
             : null;
     }

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -126,17 +126,58 @@ guide.
   alphabetically, pre-checks the default features on new deployments, and renders the allowed-values
   selectors with the
   [`@crestapps/bootstrap-select`](https://github.com/CrestApps/bootstrap-select) searchable
-  multi-select. The AI profile, profile template, and chat interaction editors show the selected
-  deployment's declared trained capabilities as read-only badges that update when the deployment changes
+  multi-select. The AI profile, profile template, and chat interaction editors render only the editable
+  parameters the selected deployment declares — no read-only capability badges and no "nothing to
+  configure" notice — and the whole block, heading included, is hidden when the deployment exposes none
 - updates `CrestApps.Core.Blazor.Web` with the equivalent `ModelCapabilitiesEditor` and
   `ModelParametersEditor` components, which re-render when the selected deployment changes and prune
   values the new deployment does not support. The capabilities editor uses the **Trained features**
   heading, sorts the trained features alphabetically, and pre-selects the default features on new
-  deployments, and the parameters editor shows the deployment's declared trained capabilities as
-  read-only badges. The allowed-values selectors use the same
+  deployments, and the parameters editor renders only the editable parameters, hiding itself entirely
+  when the selected deployment declares none. The allowed-values selectors use the same
   [`@crestapps/bootstrap-select`](https://github.com/CrestApps/bootstrap-select) searchable multi-select
   as the MVC editor through an isolated `BootstrapMultiSelect` component and JS interop module, so both
   hosts present the same editing experience
+
+## Model parameters for the utility deployment
+
+A profile, profile template, or chat interaction selects a **chat** deployment and a **utility**
+deployment, but only the chat deployment's model parameters (such as `reasoningEffort`) could be
+configured. The utility deployment — which backs title generation, orchestration planning, data
+extraction, and post-session processing — silently ran with provider defaults even when its model
+declared `reasoning`. Both deployments are now configurable, and both are honored at runtime.
+
+- adds `AIDeploymentParametersMetadata.UtilityValues`, which stores the values selected for the utility
+  deployment alongside the existing `Values` for the chat deployment. Existing stored metadata keeps
+  working unchanged; the new dictionary is simply empty
+- adds `AICompletionContext.UtilityModelParameters` and `AICompletionContext.IsUtilityCompletion`. The
+  profile and chat interaction context builder handlers copy both value sets onto the context, and a
+  caller marks a request as a background utility completion with `IsUtilityCompletion`
+- resolves the utility deployment (falling back to the chat deployment) in `NamedAICompletionClient`
+  when `IsUtilityCompletion` is set, so a utility completion runs on the deployment it was configured
+  for. Chat title generation now sets this flag
+- extracts the parameter-binding loop out of `ModelParametersAICompletionServiceHandler` into the new
+  `IAIDeploymentParameterApplier` / `DefaultAIDeploymentParameterApplier`, which takes an
+  `AIDeploymentParameterScope` (`Chat` or `Utility`) to select which stored values to read. The handler
+  is now a thin wrapper that picks the scope from the completion context
+- adds `ChatClientBuilder.UseModelParameters` and `UseUtilityModelParameters` so background completions
+  that resolve an `IChatClient` directly from `IAIClientFactory` — orchestration planning, data
+  extraction, and post-session processing — apply the same operator selections as the completion
+  pipeline
+- adds a `UtilityModelParameters` front-matter key to the markdown profile template parser, accepting
+  the same `name=value` pairs as `ModelParameters`
+- renders a second **Utility model parameters** editor on the AI profile, AI profile template, and chat
+  interaction screens in both `CrestApps.Core.Mvc.Web` and `CrestApps.Core.Blazor.Web`, bound to the
+  selected utility deployment. Each editor shows only the parameters its own deployment declares, so a
+  reasoning-capable utility model exposes its reasoning effort selector even when the chat model does
+  not (and the reverse). Each editor now owns its own heading and hides itself completely — heading
+  included — when the deployment it is bound to declares no configurable parameter
+- adds a **Utility deployment** selector to the chat interaction editor in both hosts, which previously
+  offered only the chat deployment
+- fixes the `CrestApps.Core.Blazor.Web` editors passing the *literal string* `"_model.ChatDeploymentName"`
+  to `ModelParametersEditor.DeploymentName`. Razor treats an unprefixed attribute value as a literal for
+  a `string` parameter, so the component never resolved a deployment and rendered no parameters at all.
+  The pages now pass `@_model.ChatDeploymentName` (and `@_model.UtilityDeploymentName`)
 
 ## Realtime (speech-to-speech)
 

--- a/src/CrestApps.Core.Docs/docs/core/ai-model-capabilities.md
+++ b/src/CrestApps.Core.Docs/docs/core/ai-model-capabilities.md
@@ -239,15 +239,51 @@ This works on `AIProfile`, `AIProfileTemplate`, and `ChatInteraction`. Profile a
 context builder handlers copy the stored values onto `AICompletionContext.ModelParameters` before the
 request is built.
 
+### Utility deployment values
+
+A profile, profile template, or chat interaction selects two deployments: a **chat** deployment and a
+**utility** deployment. The utility deployment backs the background completions the framework runs on
+its own — title generation, orchestration planning, data extraction, and post-session processing — and
+is often a different, cheaper model with different capabilities.
+
+`AIDeploymentParametersMetadata.UtilityValues` holds the values selected for the utility deployment,
+alongside `Values`, which holds the values selected for the chat deployment:
+
+```csharp
+profile.Put(new AIDeploymentParametersMetadata
+{
+    Values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        [AIDeploymentParameterNames.ReasoningEffort] = "High",
+    },
+    UtilityValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        [AIDeploymentParameterNames.ReasoningEffort] = "Low",
+    },
+});
+```
+
+The context builder handlers copy these onto `AICompletionContext.UtilityModelParameters`. A caller
+marks a request as a background utility completion by setting
+`AICompletionContext.IsUtilityCompletion`, which makes the completion client resolve the utility
+deployment (falling back to the chat deployment) and apply `UtilityModelParameters` instead of
+`ModelParameters`.
+
+The editors for AI profiles, AI profile templates, and chat interactions render a second parameter
+editor bound to the selected utility deployment, so an operator can pick a reasoning effort for the
+utility model independently of the chat model. Each editor shows only the parameters its own
+deployment declares.
+
 ### Markdown profile templates
 
-Markdown-authored profile templates can set values through the `ModelParameters` front-matter key.
-Pairs are `name=value`, separated by `;` or by a new line:
+Markdown-authored profile templates can set values through the `ModelParameters` and
+`UtilityModelParameters` front-matter keys. Pairs are `name=value`, separated by `;` or by a new line:
 
 ```markdown
 ---
 Name: Deep research
 ModelParameters: reasoningEffort=High
+UtilityModelParameters: reasoningEffort=Low
 ---
 
 You are a meticulous research assistant.
@@ -255,8 +291,8 @@ You are a meticulous research assistant.
 
 ## Runtime binding
 
-`ModelParametersAICompletionServiceHandler` runs as an `IAICompletionServiceHandler` and is the single
-enforcement point:
+`ModelParametersAICompletionServiceHandler` runs as an `IAICompletionServiceHandler` and delegates to
+`IAIDeploymentParameterApplier`, which is the single enforcement point:
 
 1. It iterates only the parameters the **deployment** exposes. A value stored for an unsupported
    parameter is ignored and never leaves the process.
@@ -268,6 +304,24 @@ enforcement point:
 
 `ReasoningEffortModelParameterBinder` implements step 3 for `reasoningEffort` by setting
 `ChatOptions.Reasoning.Effort`.
+
+The applier takes an `AIDeploymentParameterScope` that selects which stored values to read: `Chat`
+reads `AICompletionContext.ModelParameters`, `Utility` reads
+`AICompletionContext.UtilityModelParameters`. The handler picks the scope from
+`AICompletionContext.IsUtilityCompletion`.
+
+Background completions that resolve an `IChatClient` from `IAIClientFactory` and call it directly
+bypass the completion pipeline. Those call sites add the applier to the client pipeline with
+`ChatClientBuilder.UseModelParameters` (or `UseUtilityModelParameters`, which derives the context from
+an `AIProfile`), so a directly resolved client honors the same operator selections:
+
+```csharp
+var client = await clientFactory.CreateChatClientAsync(
+    utilityDeployment,
+    builder => builder
+        .UseDefaultResilience()
+        .UseUtilityModelParameters(parameterApplier, utilityDeployment, profile));
+```
 
 ### Feature enforcement
 
@@ -524,10 +578,12 @@ Both sample hosts render the metadata rather than hardcoding options.
   linked to a feature. Each parameter offers a *supported* toggle, an allowed-values selector, a default
   value, and numeric bounds where applicable.
 - **AI Profile, AI Profile Template, and Chat Interaction editors** — render only the parameters the
-  selected deployment supports, restricted to that deployment's allowed values, and show the selected
-  deployment's declared trained capabilities as read-only badges so operators can see what the model
-  supports. They also validate the chosen deployment against the slot's required capability at save time
-  (see [Guardrails](#guardrails-you-get-for-free)).
+  selected deployment supports, restricted to that deployment's allowed values. Nothing read-only is
+  rendered: the editor is inputs only, and the whole block — its heading included — is hidden when the
+  selected deployment declares no configurable parameter. Each screen renders two editors, one bound to
+  the chat deployment and one bound to the utility deployment, so the two models are configured
+  independently. They also validate the chosen deployment against the slot's required capability at save
+  time (see [Guardrails](#guardrails-you-get-for-free)).
 - **AI Chat and Chat Interaction chat views** — switch the input between a text box and an audio-only
   *Start speaking* control based on the effective deployment's `realtime` capability, as described in
   [Building a capability-aware chat UI](#building-a-capability-aware-chat-ui).

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
@@ -509,6 +509,10 @@ public class AIChatHubCore<TClient> : Hub<TClient>
             c.MaxTokens = 64;
             c.DataSourceId = null;
             c.DisableTools = true;
+
+            // Title generation runs on the utility deployment, so the values selected for that
+            // deployment are applied instead of the chat deployment's.
+            c.IsUtilityCompletion = true;
         });
         var deploymentManager = services.GetService<IAIDeploymentManager>();
         if (deploymentManager is null)

--- a/src/Primitives/CrestApps.Core.AI.Chat/Services/DataExtractionService.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Services/DataExtractionService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
@@ -20,6 +21,7 @@ public sealed class DataExtractionService
 {
     private readonly IAIClientFactory _clientFactory;
     private readonly IAIDeploymentManager _deploymentManager;
+    private readonly IAIDeploymentParameterApplier _parameterApplier;
     private readonly ITemplateService _aiTemplateService;
     private readonly ITemplateParser _markdownTemplateParser;
     private readonly TimeProvider _timeProvider;
@@ -34,16 +36,19 @@ public sealed class DataExtractionService
     /// <param name="timeProvider">The time provider.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="deploymentManager">The deployment manager.</param>
+    /// <param name="parameterApplier">The model parameter applier.</param>
     public DataExtractionService(
         IAIClientFactory clientFactory,
         ITemplateService aiTemplateService,
         IEnumerable<ITemplateParser> templateParsers,
         TimeProvider timeProvider,
         ILogger<DataExtractionService> logger,
-        IAIDeploymentManager deploymentManager = null)
+        IAIDeploymentManager deploymentManager = null,
+        IAIDeploymentParameterApplier parameterApplier = null)
     {
         _clientFactory = clientFactory;
         _deploymentManager = deploymentManager;
+        _parameterApplier = parameterApplier;
         _aiTemplateService = aiTemplateService;
         _markdownTemplateParser = ResolveMarkdownTemplateParser(templateParsers);
         _timeProvider = timeProvider;
@@ -454,7 +459,9 @@ public sealed class DataExtractionService
         {
             return await _clientFactory.CreateChatClientAsync(
                 deployment,
-                builder => builder.UseDefaultResilience());
+                builder => builder
+                    .UseDefaultResilience()
+                    .UseUtilityModelParameters(_parameterApplier, deployment, profile));
         }
 
         return null;

--- a/src/Primitives/CrestApps.Core.AI.Chat/Services/PostSessionProcessingService.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Services/PostSessionProcessingService.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text.Json;
+using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
@@ -29,6 +30,7 @@ public sealed class PostSessionProcessingService
 
     private readonly IAIClientFactory _clientFactory;
     private readonly IAIDeploymentManager _deploymentManager;
+    private readonly IAIDeploymentParameterApplier _parameterApplier;
     private readonly IToolRegistry _toolRegistry;
     private readonly ITemplateService _aiTemplateService;
     private readonly ITemplateParser _markdownTemplateParser;
@@ -51,6 +53,7 @@ public sealed class PostSessionProcessingService
     /// <param name="timeProvider">The time provider.</param>
     /// <param name="loggerFactory">The logger factory.</param>
     /// <param name="deploymentManager">The deployment manager.</param>
+    /// <param name="parameterApplier">The model parameter applier.</param>
     public PostSessionProcessingService(
         IAIClientFactory clientFactory,
         IToolRegistry toolRegistry,
@@ -60,10 +63,12 @@ public sealed class PostSessionProcessingService
         IServiceProvider serviceProvider,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory,
-        IAIDeploymentManager deploymentManager = null)
+        IAIDeploymentManager deploymentManager = null,
+        IAIDeploymentParameterApplier parameterApplier = null)
     {
         _clientFactory = clientFactory;
         _deploymentManager = deploymentManager;
+        _parameterApplier = parameterApplier;
         _toolRegistry = toolRegistry;
         _aiTemplateService = aiTemplateService;
         _markdownTemplateParser = ResolveMarkdownTemplateParser(templateParsers);
@@ -1412,7 +1417,9 @@ public sealed class PostSessionProcessingService
         {
             return await _clientFactory.CreateChatClientAsync(
                 deployment,
-                builder => builder.UseDefaultResilience());
+                builder => builder
+                    .UseDefaultResilience()
+                    .UseUtilityModelParameters(_parameterApplier, deployment, profile));
         }
 
         return null;

--- a/src/Primitives/CrestApps.Core.AI/Capabilities/AIDeploymentParameterChatClientBuilderExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/Capabilities/AIDeploymentParameterChatClientBuilderExtensions.cs
@@ -1,0 +1,75 @@
+using CrestApps.Core.AI.Completions;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using Microsoft.Extensions.AI;
+
+namespace CrestApps.Core.AI.Capabilities;
+
+/// <summary>
+/// Extension methods that add model parameter handling to a <see cref="ChatClientBuilder"/> pipeline.
+/// </summary>
+public static class AIDeploymentParameterChatClientBuilderExtensions
+{
+    /// <summary>
+    /// Applies the model parameter values selected in the given scope to every request issued through
+    /// the built client.
+    /// </summary>
+    /// <param name="builder">The chat client builder.</param>
+    /// <param name="applier">The parameter applier. When <see langword="null"/>, the builder is returned unchanged.</param>
+    /// <param name="deployment">The deployment resolved for the request.</param>
+    /// <param name="completionContext">The completion context holding the selected values.</param>
+    /// <param name="scope">The set of selected values to apply.</param>
+    public static ChatClientBuilder UseModelParameters(
+        this ChatClientBuilder builder,
+        IAIDeploymentParameterApplier applier,
+        AIDeployment deployment,
+        AICompletionContext completionContext,
+        AIDeploymentParameterScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (applier is null || completionContext is null)
+        {
+            return builder;
+        }
+
+        return builder.Use(innerClient => new DeploymentParameterApplyingChatClient(innerClient, applier, deployment, completionContext, scope));
+    }
+
+    /// <summary>
+    /// Applies the utility model parameter values selected on the given profile to every request issued
+    /// through the built client. Background completions such as planning, data extraction, and
+    /// post-session processing run against the profile's utility deployment.
+    /// </summary>
+    /// <param name="builder">The chat client builder.</param>
+    /// <param name="applier">The parameter applier. When <see langword="null"/>, the builder is returned unchanged.</param>
+    /// <param name="deployment">The utility deployment resolved for the request.</param>
+    /// <param name="profile">The profile holding the selected values.</param>
+    public static ChatClientBuilder UseUtilityModelParameters(
+        this ChatClientBuilder builder,
+        IAIDeploymentParameterApplier applier,
+        AIDeployment deployment,
+        AIProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (applier is null || profile is null)
+        {
+            return builder;
+        }
+
+        var completionContext = new AICompletionContext
+        {
+            ChatDeploymentName = profile.ChatDeploymentName,
+            UtilityDeploymentName = profile.UtilityDeploymentName,
+            IsUtilityCompletion = true,
+        };
+
+        if (profile.TryGet<AIDeploymentParametersMetadata>(out var metadata))
+        {
+            completionContext.ApplyModelParameters(metadata);
+        }
+
+        return builder.UseModelParameters(applier, deployment, completionContext, AIDeploymentParameterScope.Utility);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Handlers/ModelParametersAICompletionServiceHandler.cs
+++ b/src/Primitives/CrestApps.Core.AI/Handlers/ModelParametersAICompletionServiceHandler.cs
@@ -1,37 +1,27 @@
-using System.Globalization;
 using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Completions;
 using CrestApps.Core.AI.Models;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 
 namespace CrestApps.Core.AI.Handlers;
 
 /// <summary>
 /// Applies the model parameters selected for the current request to the outgoing
 /// <see cref="ChatOptions"/>. Only the parameters exposed by the resolved deployment are applied,
-/// which guarantees that unsupported parameters are never sent to a provider.
+/// which guarantees that unsupported parameters are never sent to a provider. Background utility
+/// completions apply the values selected for the utility deployment instead of the chat deployment.
 /// </summary>
 public sealed class ModelParametersAICompletionServiceHandler : IAICompletionServiceHandler
 {
-    private readonly IAIDeploymentCapabilityService _capabilityService;
-    private readonly IEnumerable<IAIDeploymentParameterBinder> _binders;
-    private readonly ILogger _logger;
+    private readonly IAIDeploymentParameterApplier _applier;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ModelParametersAICompletionServiceHandler"/> class.
     /// </summary>
-    /// <param name="capabilityService">The capability service used to resolve deployment metadata.</param>
-    /// <param name="binders">The registered parameter binders.</param>
-    /// <param name="logger">The logger.</param>
-    public ModelParametersAICompletionServiceHandler(
-        IAIDeploymentCapabilityService capabilityService,
-        IEnumerable<IAIDeploymentParameterBinder> binders,
-        ILogger<ModelParametersAICompletionServiceHandler> logger)
+    /// <param name="applier">The applier that binds the selected values onto the chat options.</param>
+    public ModelParametersAICompletionServiceHandler(IAIDeploymentParameterApplier applier)
     {
-        _capabilityService = capabilityService;
-        _binders = binders;
-        _logger = logger;
+        _applier = applier;
     }
 
     /// <inheritdoc/>
@@ -39,118 +29,10 @@ public sealed class ModelParametersAICompletionServiceHandler : IAICompletionSer
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var capabilities = context.Deployment is not null
-            ? _capabilityService.GetCapabilities(context.Deployment)
-            : await _capabilityService.GetCapabilitiesAsync(context.CompletionContext.ChatDeploymentName, cancellationToken);
+        var scope = context.CompletionContext.IsUtilityCompletion
+            ? AIDeploymentParameterScope.Utility
+            : AIDeploymentParameterScope.Chat;
 
-        if (capabilities.Parameters.Count == 0)
-        {
-            return;
-        }
-
-        foreach (var descriptor in capabilities.Parameters)
-        {
-            var value = GetValue(context.CompletionContext, descriptor);
-
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                continue;
-            }
-
-            var bindingContext = new AIDeploymentParameterBindingContext(descriptor, value, context.ChatOptions, context.CompletionContext)
-            {
-                Deployment = context.Deployment,
-            };
-
-            var binder = _binders.FirstOrDefault(candidate => string.Equals(candidate.ParameterName, descriptor.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (binder is null)
-            {
-                if (TryConvertValue(descriptor, value, out var converted))
-                {
-                    context.ChatOptions.AdditionalProperties ??= [];
-                    context.ChatOptions.AdditionalProperties[descriptor.Name] = converted;
-                }
-                else
-                {
-                    _logger.LogWarning("The value '{Value}' could not be converted for the model parameter '{Parameter}'. The parameter was skipped.", value, descriptor.Name);
-                }
-
-                continue;
-            }
-
-            await binder.BindAsync(bindingContext, cancellationToken);
-        }
-    }
-
-    private static bool TryConvertValue(AIDeploymentParameterDescriptor descriptor, string value, out object converted)
-    {
-        // The value has already been validated against the descriptor, so conversion is expected to
-        // succeed. Converting to the underlying primitive avoids sending numeric and Boolean values as
-        // quoted strings, which some providers reject. When conversion cannot produce the typed value,
-        // the parameter is skipped rather than sent as a mismatched string.
-        switch (descriptor.Kind)
-        {
-            case AIDeploymentParameterKind.Integer:
-                // Parse through decimal so the Int64 bounds are checked exactly. Using double would
-                // round long.MaxValue up to 2^63, allowing an out-of-range value to overflow the cast.
-                if (decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var integral) &&
-                    integral == Math.Truncate(integral) &&
-                    integral >= long.MinValue &&
-                    integral <= long.MaxValue)
-                {
-                    converted = (long)integral;
-
-                    return true;
-                }
-
-                break;
-
-            case AIDeploymentParameterKind.Number:
-                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) && double.IsFinite(number))
-                {
-                    converted = number;
-
-                    return true;
-                }
-
-                break;
-
-            case AIDeploymentParameterKind.Boolean:
-                if (bool.TryParse(value, out var boolean))
-                {
-                    converted = boolean;
-
-                    return true;
-                }
-
-                break;
-
-            default:
-                converted = value;
-
-                return true;
-        }
-
-        converted = null;
-
-        return false;
-    }
-
-    private string GetValue(AICompletionContext completionContext, AIDeploymentParameterDescriptor descriptor)
-    {
-        if (!completionContext.ModelParameters.TryGetValue(descriptor.Name, out var value) || string.IsNullOrWhiteSpace(value))
-        {
-            return descriptor.DefaultValue;
-        }
-
-        if (!descriptor.IsValidValue(value))
-        {
-            _logger.LogWarning("The value '{Value}' is not valid for the model parameter '{Parameter}'. The deployment default is used instead.", value, descriptor.Name);
-
-            return descriptor.DefaultValue;
-        }
-
-        return value;
+        await _applier.ApplyAsync(context.ChatOptions, context.Deployment, context.CompletionContext, scope, cancellationToken);
     }
 }

--- a/src/Primitives/CrestApps.Core.AI/Orchestration/DefaultOrchestrator.cs
+++ b/src/Primitives/CrestApps.Core.AI/Orchestration/DefaultOrchestrator.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Completions;
 using CrestApps.Core.AI.Deployments;
@@ -35,6 +36,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
     private readonly IAIClientFactory _aiClientFactory;
     private readonly ITemplateService _aiTemplateService;
     private readonly IAIDeploymentManager _deploymentManager;
+    private readonly IAIDeploymentParameterApplier _parameterApplier;
     private readonly IToolRegistry _toolRegistry;
     private readonly ITextTokenizer _tokenizer;
     private readonly DefaultOrchestratorOptions _options;
@@ -51,6 +53,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
     /// <param name="tokenizer">The tokenizer.</param>
     /// <param name="options">The options.</param>
     /// <param name="logger">The logger.</param>
+    /// <param name="parameterApplier">The model parameter applier.</param>
     public DefaultOrchestrator(
         IAICompletionService completionService,
         IAIClientFactory aiClientFactory,
@@ -59,12 +62,14 @@ public sealed class DefaultOrchestrator : IOrchestrator
         IToolRegistry toolRegistry,
         ITextTokenizer tokenizer,
         IOptions<DefaultOrchestratorOptions> options,
-        ILogger<DefaultOrchestrator> logger)
+        ILogger<DefaultOrchestrator> logger,
+        IAIDeploymentParameterApplier parameterApplier = null)
     {
         _completionService = completionService;
         _aiClientFactory = aiClientFactory;
         _aiTemplateService = aiTemplateService;
         _deploymentManager = deploymentManager;
+        _parameterApplier = parameterApplier;
         _toolRegistry = toolRegistry;
         _tokenizer = tokenizer;
         _options = options.Value;
@@ -502,6 +507,7 @@ public sealed class DefaultOrchestrator : IOrchestrator
     /// <summary>
     /// Attempts to create a chat client using the utility deployment,
     /// falling back to the chat deployment if no utility deployment is configured.
+    /// The client applies the model parameters selected for the utility deployment.
     /// Returns <c>null</c> if no deployment can be resolved.
     /// </summary>
     private async Task<IChatClient> GetUtilityChatClientAsync(OrchestrationContext context)
@@ -517,7 +523,9 @@ public sealed class DefaultOrchestrator : IOrchestrator
 
         var chatClient = await _aiClientFactory.CreateChatClientAsync(
             deployment,
-            builder => builder.UseDefaultResilience());
+            builder => builder
+                .UseDefaultResilience()
+                .UseModelParameters(_parameterApplier, deployment, context.CompletionContext, AIDeploymentParameterScope.Utility));
 
         if (chatClient == null)
         {

--- a/src/Primitives/CrestApps.Core.AI/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/ServiceCollectionExtensions.cs
@@ -209,6 +209,7 @@ public static class ServiceCollectionExtensions
 
         services.AddOptions<AIDeploymentCapabilityOptions>();
         services.TryAddScoped<IAIDeploymentCapabilityService, DefaultAIDeploymentCapabilityService>();
+        services.TryAddScoped<IAIDeploymentParameterApplier, DefaultAIDeploymentParameterApplier>();
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IAICompletionServiceHandler, ModelParametersAICompletionServiceHandler>());
         services.TryAddEnumerable(ServiceDescriptor.Scoped<IAIDeploymentParameterBinder, ReasoningEffortModelParameterBinder>());
 

--- a/src/Primitives/CrestApps.Core.AI/Services/AICompletionServiceBase.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/AICompletionServiceBase.cs
@@ -62,6 +62,32 @@ public abstract class AICompletionServiceBase
     }
 
     /// <summary>
+    /// Resolves the deployment that serves the given completion request. A request marked as a
+    /// background utility completion resolves the utility deployment first and falls back to the chat
+    /// deployment when no utility deployment is configured.
+    /// </summary>
+    /// <param name="context">The completion context of the current request.</param>
+    /// <param name="providerName">The provider name.</param>
+    protected virtual async ValueTask<AIDeployment> ResolveRequestDeploymentAsync(
+        AICompletionContext context,
+        string providerName)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.IsUtilityCompletion)
+        {
+            var utilityDeployment = await ResolveDeploymentAsync(AIDeploymentPurpose.Utility, providerName, context.UtilityDeploymentName);
+
+            if (utilityDeployment != null)
+            {
+                return utilityDeployment;
+            }
+        }
+
+        return await ResolveDeploymentAsync(AIDeploymentPurpose.Chat, providerName, context.ChatDeploymentName);
+    }
+
+    /// <summary>
     /// Gets total messages to skip.
     /// </summary>
     /// <param name="totalMessages">The total messages.</param>

--- a/src/Primitives/CrestApps.Core.AI/Services/AIProfileTemplateParser.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/AIProfileTemplateParser.cs
@@ -189,7 +189,7 @@ public static class AIProfileTemplateParser
 
         var modelParameters = ParseModelParameters(props);
 
-        if (modelParameters.Values.Count > 0)
+        if (modelParameters.Values.Count > 0 || modelParameters.UtilityValues.Count > 0)
         {
             template.Put(modelParameters);
         }
@@ -203,9 +203,22 @@ public static class AIProfileTemplateParser
     {
         var metadata = new AIDeploymentParametersMetadata();
 
-        if (props is null || !props.TryGetValue("ModelParameters", out var raw) || string.IsNullOrWhiteSpace(raw))
+        if (props is null)
         {
             return metadata;
+        }
+
+        ParseModelParameterValues(props, "ModelParameters", metadata.Values);
+        ParseModelParameterValues(props, "UtilityModelParameters", metadata.UtilityValues);
+
+        return metadata;
+    }
+
+    private static void ParseModelParameterValues(Dictionary<string, string> props, string propertyName, Dictionary<string, string> values)
+    {
+        if (!props.TryGetValue(propertyName, out var raw) || string.IsNullOrWhiteSpace(raw))
+        {
+            return;
         }
 
         foreach (var pair in raw.Split([';', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -225,10 +238,8 @@ public static class AIProfileTemplateParser
                 continue;
             }
 
-            metadata.Values[name] = value;
+            values[name] = value;
         }
-
-        return metadata;
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDeploymentParameterApplier.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIDeploymentParameterApplier.cs
@@ -1,0 +1,176 @@
+using System.Globalization;
+using CrestApps.Core.AI.Capabilities;
+using CrestApps.Core.AI.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.Services;
+
+/// <summary>
+/// Represents the default <see cref="IAIDeploymentParameterApplier"/>, which resolves the effective
+/// capabilities of a deployment and binds every selected value the deployment actually exposes.
+/// </summary>
+public sealed class DefaultAIDeploymentParameterApplier : IAIDeploymentParameterApplier
+{
+    private readonly IAIDeploymentCapabilityService _capabilityService;
+    private readonly IEnumerable<IAIDeploymentParameterBinder> _binders;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultAIDeploymentParameterApplier"/> class.
+    /// </summary>
+    /// <param name="capabilityService">The capability service used to resolve deployment metadata.</param>
+    /// <param name="binders">The registered parameter binders.</param>
+    /// <param name="logger">The logger.</param>
+    public DefaultAIDeploymentParameterApplier(
+        IAIDeploymentCapabilityService capabilityService,
+        IEnumerable<IAIDeploymentParameterBinder> binders,
+        ILogger<DefaultAIDeploymentParameterApplier> logger)
+    {
+        _capabilityService = capabilityService;
+        _binders = binders;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task ApplyAsync(
+        ChatOptions options,
+        AIDeployment deployment,
+        AICompletionContext completionContext,
+        AIDeploymentParameterScope scope,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(completionContext);
+
+        var capabilities = deployment is not null
+            ? _capabilityService.GetCapabilities(deployment)
+            : await _capabilityService.GetCapabilitiesAsync(GetDeploymentName(completionContext, scope), cancellationToken);
+
+        if (capabilities.Parameters.Count == 0)
+        {
+            return;
+        }
+
+        var values = scope == AIDeploymentParameterScope.Utility
+            ? completionContext.UtilityModelParameters
+            : completionContext.ModelParameters;
+
+        foreach (var descriptor in capabilities.Parameters)
+        {
+            var value = GetValue(values, descriptor);
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var bindingContext = new AIDeploymentParameterBindingContext(descriptor, value, options, completionContext)
+            {
+                Deployment = deployment,
+            };
+
+            var binder = _binders.FirstOrDefault(candidate => string.Equals(candidate.ParameterName, descriptor.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (binder is null)
+            {
+                if (TryConvertValue(descriptor, value, out var converted))
+                {
+                    options.AdditionalProperties ??= [];
+                    options.AdditionalProperties[descriptor.Name] = converted;
+                }
+                else
+                {
+                    _logger.LogWarning("The value '{Value}' could not be converted for the model parameter '{Parameter}'. The parameter was skipped.", value, descriptor.Name);
+                }
+
+                continue;
+            }
+
+            await binder.BindAsync(bindingContext, cancellationToken);
+        }
+    }
+
+    private static string GetDeploymentName(AICompletionContext completionContext, AIDeploymentParameterScope scope)
+    {
+        if (scope != AIDeploymentParameterScope.Utility)
+        {
+            return completionContext.ChatDeploymentName;
+        }
+
+        return string.IsNullOrWhiteSpace(completionContext.UtilityDeploymentName)
+            ? completionContext.ChatDeploymentName
+            : completionContext.UtilityDeploymentName;
+    }
+
+    private static bool TryConvertValue(AIDeploymentParameterDescriptor descriptor, string value, out object converted)
+    {
+        // The value has already been validated against the descriptor, so conversion is expected to
+        // succeed. Converting to the underlying primitive avoids sending numeric and Boolean values as
+        // quoted strings, which some providers reject. When conversion cannot produce the typed value,
+        // the parameter is skipped rather than sent as a mismatched string.
+        switch (descriptor.Kind)
+        {
+            case AIDeploymentParameterKind.Integer:
+                // Parse through decimal so the Int64 bounds are checked exactly. Using double would
+                // round long.MaxValue up to 2^63, allowing an out-of-range value to overflow the cast.
+                if (decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var integral) &&
+                    integral == Math.Truncate(integral) &&
+                    integral >= long.MinValue &&
+                    integral <= long.MaxValue)
+                {
+                    converted = (long)integral;
+
+                    return true;
+                }
+
+                break;
+
+            case AIDeploymentParameterKind.Number:
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number) && double.IsFinite(number))
+                {
+                    converted = number;
+
+                    return true;
+                }
+
+                break;
+
+            case AIDeploymentParameterKind.Boolean:
+                if (bool.TryParse(value, out var boolean))
+                {
+                    converted = boolean;
+
+                    return true;
+                }
+
+                break;
+
+            default:
+                converted = value;
+
+                return true;
+        }
+
+        converted = null;
+
+        return false;
+    }
+
+    private string GetValue(Dictionary<string, string> values, AIDeploymentParameterDescriptor descriptor)
+    {
+        if (values is null || !values.TryGetValue(descriptor.Name, out var value) || string.IsNullOrWhiteSpace(value))
+        {
+            return descriptor.DefaultValue;
+        }
+
+        if (!descriptor.IsValidValue(value))
+        {
+            _logger.LogWarning("The value '{Value}' is not valid for the model parameter '{Parameter}'. The deployment default is used instead.", value, descriptor.Name);
+
+            return descriptor.DefaultValue;
+        }
+
+        return value;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/DeploymentParameterApplyingChatClient.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DeploymentParameterApplyingChatClient.cs
@@ -1,0 +1,82 @@
+using System.Runtime.CompilerServices;
+using CrestApps.Core.AI.Capabilities;
+using CrestApps.Core.AI.Models;
+using Microsoft.Extensions.AI;
+
+namespace CrestApps.Core.AI.Services;
+
+/// <summary>
+/// A <see cref="DelegatingChatClient"/> that applies the model parameter values an operator selected
+/// for a deployment to every request issued through it. Callers that resolve a chat client directly
+/// from <see cref="Clients.IAIClientFactory"/> — such as the background utility completions used for
+/// planning, data extraction, and post-session processing — bypass the completion pipeline, so this
+/// client gives them the same parameter handling the pipeline provides.
+/// </summary>
+internal sealed class DeploymentParameterApplyingChatClient : DelegatingChatClient
+{
+    private readonly IAIDeploymentParameterApplier _applier;
+    private readonly AIDeployment _deployment;
+    private readonly AICompletionContext _completionContext;
+    private readonly AIDeploymentParameterScope _scope;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeploymentParameterApplyingChatClient"/> class.
+    /// </summary>
+    /// <param name="innerClient">The inner chat client that performs the provider request.</param>
+    /// <param name="applier">The applier that binds the selected values onto the chat options.</param>
+    /// <param name="deployment">The deployment resolved for the request.</param>
+    /// <param name="completionContext">The completion context holding the selected values.</param>
+    /// <param name="scope">The set of selected values to apply.</param>
+    public DeploymentParameterApplyingChatClient(
+        IChatClient innerClient,
+        IAIDeploymentParameterApplier applier,
+        AIDeployment deployment,
+        AICompletionContext completionContext,
+        AIDeploymentParameterScope scope)
+        : base(innerClient)
+    {
+        _applier = applier;
+        _deployment = deployment;
+        _completionContext = completionContext;
+        _scope = scope;
+    }
+
+    /// <inheritdoc/>
+    public override async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions options = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await base.GetResponseAsync(messages, await ApplyAsync(options, cancellationToken), cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var applied = await ApplyAsync(options, cancellationToken);
+
+        await foreach (var update in base.GetStreamingResponseAsync(messages, applied, cancellationToken))
+        {
+            yield return update;
+        }
+    }
+
+    private async Task<ChatOptions> ApplyAsync(ChatOptions options, CancellationToken cancellationToken)
+    {
+        if (_applier is null || _completionContext is null)
+        {
+            return options;
+        }
+
+        // Clone before mutating so a caller that reuses the same options instance across requests is
+        // never affected by the values applied for this deployment.
+        var applied = options?.Clone() ?? new ChatOptions();
+
+        await _applier.ApplyAsync(applied, _deployment, _completionContext, _scope, cancellationToken);
+
+        return applied;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/NamedAICompletionClient.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/NamedAICompletionClient.cs
@@ -143,11 +143,9 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
         ArgumentNullException.ThrowIfNull(messages);
         ArgumentNullException.ThrowIfNull(context);
 
-        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
-        var deployment = await ResolveDeploymentAsync(
-            AIDeploymentPurpose.Chat,
-            ClientName,
-            deploymentName: context.ChatDeploymentName);
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution. A utility
+        // completion resolves the utility deployment and falls back to the chat deployment.
+        var deployment = await ResolveRequestDeploymentAsync(context, ClientName);
 
         if (deployment == null)
         {
@@ -196,11 +194,9 @@ public abstract class NamedAICompletionClient : AICompletionServiceBase, IAIComp
         ArgumentNullException.ThrowIfNull(messages);
         ArgumentNullException.ThrowIfNull(context);
 
-        // Use the deployment resolver with fallback to legacy dictionary-based resolution.
-        var deployment = await ResolveDeploymentAsync(
-            AIDeploymentPurpose.Chat,
-            ClientName,
-            deploymentName: context.ChatDeploymentName);
+        // Use the deployment resolver with fallback to legacy dictionary-based resolution. A utility
+        // completion resolves the utility deployment and falls back to the chat deployment.
+        var deployment = await ResolveRequestDeploymentAsync(context, ClientName);
 
         if (deployment == null)
         {

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Forms/ModelParametersEditor.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Forms/ModelParametersEditor.razor
@@ -3,26 +3,20 @@
 @using CrestApps.Core.AI.Models
 @inject IAIDeploymentCapabilityService CapabilityService
 
-@if (_capabilities.Features.Count > 0)
-{
-    <div class="mb-3">
-        <label class="form-label d-block mb-1">Model capabilities</label>
-        <div class="d-flex flex-wrap gap-1">
-            @foreach (var feature in _capabilities.Features)
-            {
-                <span class="badge rounded-pill text-bg-info">@(feature.DisplayName?.Value ?? feature.Name)</span>
-            }
-        </div>
-        <div class="form-text">Trained capabilities the selected deployment declares support for.</div>
-    </div>
-}
-
 @if (_capabilities.Parameters.Count > 0)
 {
+    @if (!string.IsNullOrWhiteSpace(Title))
+    {
+        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> @Title</h6>
+    }
+    @if (!string.IsNullOrWhiteSpace(Description))
+    {
+        <p class="text-muted small">@Description</p>
+    }
     @foreach (var parameter in _capabilities.Parameters)
     {
         var parameterName = parameter.Name;
-        var elementId = $"modelParameter_{parameterName.Replace('.', '_')}";
+        var elementId = $"{ElementIdPrefix}_{parameterName.Replace('.', '_')}";
         <div class="mb-3">
             <label class="form-label" for="@elementId">@(parameter.DisplayName?.Value ?? parameter.Name)</label>
             @if (parameter.Kind == AIDeploymentParameterKind.Choice)
@@ -76,12 +70,6 @@
         </div>
     }
 }
-else if (ShowEmptyNotice)
-{
-    <div class="alert alert-secondary py-2 mb-3" role="status">
-        The selected deployment does not expose any configurable model parameters.
-    </div>
-}
 
 @code {
     private AIDeploymentCapabilities _capabilities = AIDeploymentCapabilities.Empty;
@@ -100,10 +88,24 @@ else if (ShowEmptyNotice)
     public Dictionary<string, string> Values { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Gets or sets a value indicating whether a notice is rendered when the deployment exposes no parameters.
+    /// Gets or sets the heading rendered above the editor. The heading is rendered only when the
+    /// selected deployment exposes at least one configurable parameter.
     /// </summary>
     [Parameter]
-    public bool ShowEmptyNotice { get; set; } = true;
+    public string Title { get; set; } = "Model parameters";
+
+    /// <summary>
+    /// Gets or sets the descriptive text rendered under the heading.
+    /// </summary>
+    [Parameter]
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the prefix applied to generated element identifiers so a page can render more than
+    /// one editor without colliding.
+    /// </summary>
+    [Parameter]
+    public string ElementIdPrefix { get; set; } = "modelParameter";
 
     /// <inheritdoc />
     protected override async Task OnParametersSetAsync()

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/AIProfiles/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/AIProfiles/Create.razor
@@ -620,9 +620,15 @@
                         <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                     </div>
 
-                    <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                    <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                    <ModelParametersEditor DeploymentName="_model.ChatDeploymentName" Values="_model.ModelParameters" />
+                    <ModelParametersEditor DeploymentName="@_model.ChatDeploymentName"
+                                           Values="_model.ModelParameters"
+                                           Description="Only the parameters declared by the selected chat deployment are shown." />
+
+                    <ModelParametersEditor DeploymentName="@_model.UtilityDeploymentName"
+                                           Values="_model.UtilityModelParameters"
+                                           ElementIdPrefix="utilityModelParameter"
+                                           Title="Utility model parameters"
+                                           Description="Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown." />
                 </div>
 
                 <!-- Capabilities Tab -->
@@ -1804,13 +1810,19 @@
 
     private static void ApplyTemplateToProfile(AIProfile profile, AIProfileTemplate template)
     {
-        if (template.TryGet<AIDeploymentParametersMetadata>(out var templateModelParameters) && templateModelParameters.Values is { Count: > 0 })
+        if (template.TryGet<AIDeploymentParametersMetadata>(out var templateModelParameters) &&
+            (templateModelParameters.Values is { Count: > 0 } || templateModelParameters.UtilityValues is { Count: > 0 }))
         {
             profile.Alter<AIDeploymentParametersMetadata>(m =>
             {
-                foreach (var entry in templateModelParameters.Values)
+                foreach (var entry in templateModelParameters.Values ?? [])
                 {
                     m.Values[entry.Key] = entry.Value;
+                }
+
+                foreach (var entry in templateModelParameters.UtilityValues ?? [])
+                {
+                    m.UtilityValues[entry.Key] = entry.Value;
                 }
             });
         }

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/AIProfiles/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/AIProfiles/Edit.razor
@@ -574,9 +574,15 @@ else if (_model != null)
                             <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                         </div>
 
-                        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                        <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                        <ModelParametersEditor DeploymentName="_model.ChatDeploymentName" Values="_model.ModelParameters" />
+                        <ModelParametersEditor DeploymentName="@_model.ChatDeploymentName"
+                                               Values="_model.ModelParameters"
+                                               Description="Only the parameters declared by the selected chat deployment are shown." />
+
+                        <ModelParametersEditor DeploymentName="@_model.UtilityDeploymentName"
+                                               Values="_model.UtilityModelParameters"
+                                               ElementIdPrefix="utilityModelParameter"
+                                               Title="Utility model parameters"
+                                               Description="Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown." />
                     </div>
 
                     <!-- Capabilities Tab -->

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/Templates/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/Templates/Create.razor
@@ -437,9 +437,15 @@
                         </div>
                         <div class="mb-3"><div class="form-check form-switch"><InputCheckbox class="form-check-input" @bind-Value="_model.UseCaching" /><label class="form-check-label">Enable response caching</label></div></div>
 
-                    <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                    <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                    <ModelParametersEditor DeploymentName="_model.ChatDeploymentName" Values="_model.ModelParameters" />
+                    <ModelParametersEditor DeploymentName="@_model.ChatDeploymentName"
+                                           Values="_model.ModelParameters"
+                                           Description="Only the parameters declared by the selected chat deployment are shown." />
+
+                    <ModelParametersEditor DeploymentName="@_model.UtilityDeploymentName"
+                                           Values="_model.UtilityModelParameters"
+                                           ElementIdPrefix="utilityModelParameter"
+                                           Title="Utility model parameters"
+                                           Description="Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown." />
                     </div>
 
                     <!-- Capabilities -->

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/Templates/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/AI/Templates/Edit.razor
@@ -454,9 +454,15 @@
                         </div>
                         <div class="mb-3"><div class="form-check form-switch"><InputCheckbox class="form-check-input" @bind-Value="_model.UseCaching" /><label class="form-check-label">Enable response caching</label></div><div class="form-text">Cache responses to improve performance for repeated queries.</div></div>
 
-                    <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                    <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                    <ModelParametersEditor DeploymentName="_model.ChatDeploymentName" Values="_model.ModelParameters" />
+                    <ModelParametersEditor DeploymentName="@_model.ChatDeploymentName"
+                                           Values="_model.ModelParameters"
+                                           Description="Only the parameters declared by the selected chat deployment are shown." />
+
+                    <ModelParametersEditor DeploymentName="@_model.UtilityDeploymentName"
+                                           Values="_model.UtilityModelParameters"
+                                           ElementIdPrefix="utilityModelParameter"
+                                           Title="Utility model parameters"
+                                           Description="Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown." />
                     </div>
 
                     <!-- Capabilities -->

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/ChatInteractions/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/ChatInteractions/Create.razor
@@ -85,6 +85,18 @@
                     </div>
 
                     <div class="mb-3">
+                        <label for="utilityDeployment" class="form-label">Utility deployment</label>
+                        <InputSelect id="utilityDeployment" class="form-select" @bind-Value="_model.UtilityDeploymentName">
+                            <option value="">Use the default utility deployment</option>
+                            @foreach (var d in _model.UtilityDeployments)
+                            {
+                                <option value="@d.Value">@d.Text</option>
+                            }
+                        </InputSelect>
+                        <div class="form-text">The deployment used for background completions such as title generation. Leave blank to use the site default.</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label for="orchestrator" class="form-label">Orchestrator</label>
                         <InputSelect id="orchestrator" class="form-select" @bind-Value="_model.OrchestratorName">
                             <option value="">Use default orchestrator</option>
@@ -246,9 +258,15 @@
                         </div>
                     </div>
 
-                    <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                    <p class="text-muted small">Only the parameters declared by the selected deployment are shown.</p>
-                    <ModelParametersEditor DeploymentName="_model.ChatDeploymentName" Values="_model.ModelParameters" />
+                    <ModelParametersEditor DeploymentName="@_model.ChatDeploymentName"
+                                           Values="_model.ModelParameters"
+                                           Description="Only the parameters declared by the selected deployment are shown." />
+
+                    <ModelParametersEditor DeploymentName="@_model.UtilityDeploymentName"
+                                           Values="_model.UtilityModelParameters"
+                                           ElementIdPrefix="utilityModelParameter"
+                                           Title="Utility model parameters"
+                                           Description="Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown." />
                 }
                 else if (_activeTab == "capabilities")
                 {
@@ -508,6 +526,12 @@
                 string.Equals(d.Name, d.ModelName, StringComparison.OrdinalIgnoreCase) ? d.Name : $"{d.Name} ({d.ModelName})",
                 d.Name))
             .ToList();
+        _model.UtilityDeployments = deployments
+            .Where(d => d.Purpose.Supports(AIDeploymentPurpose.Utility) || d.Purpose.Supports(AIDeploymentPurpose.Chat))
+            .Select(d => new SelectOption(
+                string.Equals(d.Name, d.ModelName, StringComparison.OrdinalIgnoreCase) ? d.Name : $"{d.Name} ({d.ModelName})",
+                d.Name))
+            .ToList();
         var interactionDocSettings = SiteSettingsStore.Get<InteractionDocumentSettings>();
         var visionDeployment = await DeploymentManager.ResolveOrDefaultAsync(AIDeploymentPurpose.Vision);
         _model.AllowImageUploads = interactionDocSettings.AllowImageUploads && visionDeployment != null;
@@ -670,6 +694,7 @@
         interaction.OwnerId = userName;
         interaction.Author = userName;
         interaction.ChatDeploymentName = _model.ChatDeploymentName;
+        interaction.UtilityDeploymentName = _model.UtilityDeploymentName;
         interaction.OrchestratorName = _model.OrchestratorName;
         interaction.SystemMessage = _model.SystemMessage;
         interaction.Temperature = _model.Temperature;
@@ -695,11 +720,8 @@
 
         interaction.Alter<AIDeploymentParametersMetadata>(metadata =>
         {
-            metadata.Values = _model.ModelParameters is null
-                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(
-                    _model.ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
-                    StringComparer.OrdinalIgnoreCase);
+            metadata.Values = SelectedModelParameters(_model.ModelParameters);
+            metadata.UtilityValues = SelectedModelParameters(_model.UtilityModelParameters);
         });
 
         if (!string.IsNullOrWhiteSpace(_model.DataSourceId))
@@ -776,5 +798,17 @@
         {
             return null;
         }
+    }
+
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIProfileViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIProfileViewModel.cs
@@ -223,6 +223,12 @@ public sealed class AIProfileViewModel
     /// </summary>
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this profile,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     public static AIProfileViewModel FromProfile(AIProfile profile)
     {
         var settings = profile.GetOrCreateSettings<AIProfileSettings>();
@@ -284,9 +290,17 @@ public sealed class AIProfileViewModel
             EnableUserMemory = memoryMetadata.EnableUserMemory ?? false,
         };
 
-        if (profile.TryGet<AIDeploymentParametersMetadata>(out var modelParameters) && modelParameters.Values is { Count: > 0 })
+        if (profile.TryGet<AIDeploymentParametersMetadata>(out var modelParameters))
         {
-            vm.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+            if (modelParameters.Values is { Count: > 0 })
+            {
+                vm.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (modelParameters.UtilityValues is { Count: > 0 })
+            {
+                vm.UtilityModelParameters = new Dictionary<string, string>(modelParameters.UtilityValues, StringComparer.OrdinalIgnoreCase);
+            }
         }
 
         if (profile.TryGet<AIProfileMetadata>(out var metadata))
@@ -450,11 +464,8 @@ public sealed class AIProfileViewModel
 
         profile.Alter<AIDeploymentParametersMetadata>(m =>
         {
-            m.Values = ModelParameters is null
-                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(
-                    ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
-                    StringComparer.OrdinalIgnoreCase);
+            m.Values = SelectedModelParameters(ModelParameters);
+            m.UtilityValues = SelectedModelParameters(UtilityModelParameters);
         });
 
         profile.AlterSettings<AIProfileSettings>(s =>
@@ -671,6 +682,18 @@ public sealed class AIProfileViewModel
                 ? TimeSpan.FromSeconds(SecurityAnonymousSessionRateLimitWindowSeconds.Value)
                 : null,
         });
+    }
+
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
     }
 }
 

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AITemplateViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AITemplateViewModel.cs
@@ -206,6 +206,12 @@ public sealed class AITemplateViewModel
     /// </summary>
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this template,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     public static AITemplateViewModel FromTemplate(AIProfileTemplate template)
     {
         var model = new AITemplateViewModel
@@ -228,9 +234,17 @@ public sealed class AITemplateViewModel
         }
         else if (template.Source == AITemplateSources.Profile)
         {
-            if (template.TryGet<AIDeploymentParametersMetadata>(out var modelParameters) && modelParameters.Values is { Count: > 0 })
+            if (template.TryGet<AIDeploymentParametersMetadata>(out var modelParameters))
             {
-                model.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+                if (modelParameters.Values is { Count: > 0 })
+                {
+                    model.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+                }
+
+                if (modelParameters.UtilityValues is { Count: > 0 })
+                {
+                    model.UtilityModelParameters = new Dictionary<string, string>(modelParameters.UtilityValues, StringComparer.OrdinalIgnoreCase);
+                }
             }
 
             if (template.TryGet<ProfileTemplateMetadata>(out var metadata))
@@ -414,13 +428,10 @@ public sealed class AITemplateViewModel
         {
             var toolNames = SelectedToolNames?.Where(n => !string.IsNullOrWhiteSpace(n)).ToArray();
             var agentNames = SelectedAgentNames?.Where(n => !string.IsNullOrWhiteSpace(n)).ToArray();
-            var selectedModelParameters = ModelParameters is null
-                ? []
-                : ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value));
-
             template.Put(new AIDeploymentParametersMetadata
             {
-                Values = new Dictionary<string, string>(selectedModelParameters, StringComparer.OrdinalIgnoreCase),
+                Values = SelectedModelParameters(ModelParameters),
+                UtilityValues = SelectedModelParameters(UtilityModelParameters),
             });
 
             template.Put(new ProfileTemplateMetadata
@@ -654,5 +665,17 @@ public sealed class AITemplateViewModel
         {
             template.Remove<PromptSecurityProfileSettings>();
         }
+    }
+
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/ChatInteractionViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/ChatInteractionViewModel.cs
@@ -9,6 +9,8 @@ public sealed class ChatInteractionViewModel
 
     public string ChatDeploymentName { get; set; }
 
+    public string UtilityDeploymentName { get; set; }
+
     public string OrchestratorName { get; set; }
 
     public string SystemMessage { get; set; }
@@ -88,6 +90,7 @@ public sealed class ChatInteractionViewModel
 
     public List<SelectOption> DataSources { get; set; } = [];
     public List<SelectOption> Deployments { get; set; } = [];
+    public List<SelectOption> UtilityDeployments { get; set; } = [];
     public List<SelectOption> Orchestrators { get; set; } = [];
     public List<SelectOption> CopilotAvailableModels { get; set; } = [];
     public List<SelectOption> AnthropicAvailableModels { get; set; } = [];
@@ -99,6 +102,12 @@ public sealed class ChatInteractionViewModel
     /// parameter technical name.
     /// </summary>
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this interaction,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }
 
 public sealed class SelectOption

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Controllers/AIProfileController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Controllers/AIProfileController.cs
@@ -313,7 +313,16 @@ public sealed class AIProfileController : Controller
 
     private async Task PopulateDropdownsAsync(AIProfileViewModel model)
     {
-        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(model.ModelParameters);
+        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.ModelParameters,
+            description: "Only the parameters declared by the selected chat deployment are shown.");
+        model.UtilityModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.UtilityModelParameters,
+            deploymentFieldName: nameof(AIProfileViewModel.UtilityDeploymentName),
+            fieldPrefix: nameof(AIProfileViewModel.UtilityModelParameters),
+            elementPrefix: "utilityModelParameters",
+            title: "Utility model parameters",
+            description: "Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown.");
 
         var allDeployments = await _deploymentCatalog.GetAllAsync();
         model.ChatDeployments = allDeployments.Where(d => d.Purpose.Supports(AIDeploymentPurpose.Chat)).Select(d => new SelectListItem(BuildDeploymentLabel(d), d.Name)).ToList();
@@ -483,13 +492,19 @@ public sealed class AIProfileController : Controller
 
     private static void ApplyTemplateToProfile(AIProfile profile, AIProfileTemplate template)
     {
-        if (template.TryGet<AIDeploymentParametersMetadata>(out var templateModelParameters) && templateModelParameters.Values is { Count: > 0 })
+        if (template.TryGet<AIDeploymentParametersMetadata>(out var templateModelParameters) &&
+            (templateModelParameters.Values is { Count: > 0 } || templateModelParameters.UtilityValues is { Count: > 0 }))
         {
             profile.Alter<AIDeploymentParametersMetadata>(m =>
             {
-                foreach (var entry in templateModelParameters.Values)
+                foreach (var entry in templateModelParameters.Values ?? [])
                 {
                     m.Values[entry.Key] = entry.Value;
+                }
+
+                foreach (var entry in templateModelParameters.UtilityValues ?? [])
+                {
+                    m.UtilityValues[entry.Key] = entry.Value;
                 }
             });
         }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Controllers/AITemplateController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Controllers/AITemplateController.cs
@@ -238,7 +238,16 @@ public sealed class AITemplateController : Controller
 
     private async Task PopulateDropdownsAsync(AITemplateViewModel model)
     {
-        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(model.ModelParameters);
+        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.ModelParameters,
+            description: "Only the parameters declared by the selected chat deployment are shown.");
+        model.UtilityModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.UtilityModelParameters,
+            deploymentFieldName: nameof(AITemplateViewModel.UtilityDeploymentName),
+            fieldPrefix: nameof(AITemplateViewModel.UtilityModelParameters),
+            elementPrefix: "utilityModelParameters",
+            title: "Utility model parameters",
+            description: "Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown.");
 
         var allDeployments = await _deploymentCatalog.GetAllAsync();
         model.ChatDeployments = allDeployments.Where(d => d.Purpose.Supports(AIDeploymentPurpose.Chat)).Select(d => new SelectListItem(BuildDeploymentLabel(d), d.Name)).ToList();

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/ViewModels/AIProfileViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/ViewModels/AIProfileViewModel.cs
@@ -217,10 +217,22 @@ public sealed class AIProfileViewModel
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this profile,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets or sets the metadata-driven model parameter editor.
     /// </summary>
     [BindNever]
     public ModelParameterEditorViewModel ModelParameterEditor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata-driven model parameter editor for the utility deployment.
+    /// </summary>
+    [BindNever]
+    public ModelParameterEditorViewModel UtilityModelParameterEditor { get; set; }
 
     public static AIProfileViewModel FromProfile(AIProfile profile)
     {
@@ -278,9 +290,17 @@ public sealed class AIProfileViewModel
             EnableUserMemory = memoryMetadata.EnableUserMemory ?? false,
         };
 
-        if (profile.TryGet<AIDeploymentParametersMetadata>(out var modelParameters) && modelParameters.Values is { Count: > 0 })
+        if (profile.TryGet<AIDeploymentParametersMetadata>(out var modelParameters))
         {
-            vm.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+            if (modelParameters.Values is { Count: > 0 })
+            {
+                vm.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+            }
+
+            if (modelParameters.UtilityValues is { Count: > 0 })
+            {
+                vm.UtilityModelParameters = new Dictionary<string, string>(modelParameters.UtilityValues, StringComparer.OrdinalIgnoreCase);
+            }
         }
 
         if (profile.TryGet<AIProfileMetadata>(out var metadata))
@@ -446,11 +466,8 @@ public sealed class AIProfileViewModel
 
         profile.Alter<AIDeploymentParametersMetadata>(m =>
         {
-            m.Values = ModelParameters is null
-                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(
-                    ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
-                    StringComparer.OrdinalIgnoreCase);
+            m.Values = SelectedModelParameters(ModelParameters);
+            m.UtilityValues = SelectedModelParameters(UtilityModelParameters);
         });
 
         profile.AlterSettings<AIProfileSettings>(s =>
@@ -668,6 +685,18 @@ public sealed class AIProfileViewModel
                 ? TimeSpan.FromSeconds(SecurityAnonymousSessionRateLimitWindowSeconds.Value)
                 : null,
         });
+    }
+
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
     }
 }
 

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/ViewModels/AITemplateViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/ViewModels/AITemplateViewModel.cs
@@ -193,10 +193,22 @@ public sealed class AITemplateViewModel
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this template,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets or sets the metadata-driven model parameter editor.
     /// </summary>
     [BindNever]
     public ModelParameterEditorViewModel ModelParameterEditor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata-driven model parameter editor for the utility deployment.
+    /// </summary>
+    [BindNever]
+    public ModelParameterEditorViewModel UtilityModelParameterEditor { get; set; }
 
     public static AITemplateViewModel FromTemplate(AIProfileTemplate template)
     {
@@ -220,9 +232,17 @@ public sealed class AITemplateViewModel
         }
         else if (template.Source == AITemplateSources.Profile)
         {
-            if (template.TryGet<AIDeploymentParametersMetadata>(out var modelParameters) && modelParameters.Values is { Count: > 0 })
+            if (template.TryGet<AIDeploymentParametersMetadata>(out var modelParameters))
             {
-                model.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+                if (modelParameters.Values is { Count: > 0 })
+                {
+                    model.ModelParameters = new Dictionary<string, string>(modelParameters.Values, StringComparer.OrdinalIgnoreCase);
+                }
+
+                if (modelParameters.UtilityValues is { Count: > 0 })
+                {
+                    model.UtilityModelParameters = new Dictionary<string, string>(modelParameters.UtilityValues, StringComparer.OrdinalIgnoreCase);
+                }
             }
 
             if (template.TryGet<ProfileTemplateMetadata>(out var metadata))
@@ -435,13 +455,10 @@ public sealed class AITemplateViewModel
                     .ToArray() ?? [],
             });
 
-            var selectedModelParameters = ModelParameters is null
-                ? []
-                : ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value));
-
             template.Put(new AIDeploymentParametersMetadata
             {
-                Values = new Dictionary<string, string>(selectedModelParameters, StringComparer.OrdinalIgnoreCase),
+                Values = SelectedModelParameters(ModelParameters),
+                UtilityValues = SelectedModelParameters(UtilityModelParameters),
             });
 
             template.Put(new AIProfileMcpMetadata
@@ -635,5 +652,17 @@ public sealed class AITemplateViewModel
             template.Remove<ClaudeSessionMetadata>();
             template.Remove<CopilotSessionMetadata>();
         }
+    }
+
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AIProfile/Create.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AIProfile/Create.cshtml
@@ -384,12 +384,8 @@
                         </div>
                         <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                     </div>
-                    @if (Model.ModelParameterEditor is not null && Model.ModelParameterEditor.HasParameters)
-                    {
-                        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                        <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                        <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
-                    }
+                    <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
+                    <partial name="_ModelParameters" model="Model.UtilityModelParameterEditor" />
                 </div>
 
                 <!-- Capabilities Tab (A2A, MCP, Tools) -->

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AIProfile/Edit.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AIProfile/Edit.cshtml
@@ -449,12 +449,8 @@
                         </div>
                         <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                     </div>
-                    @if (Model.ModelParameterEditor is not null && Model.ModelParameterEditor.HasParameters)
-                    {
-                        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                        <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                        <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
-                    }
+                    <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
+                    <partial name="_ModelParameters" model="Model.UtilityModelParameterEditor" />
                 </div>
 
                 <!-- Capabilities Tab -->

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AITemplate/Create.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AITemplate/Create.cshtml
@@ -413,12 +413,8 @@
                             </div>
                             <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                         </div>
-                        @if (Model.ModelParameterEditor is not null && Model.ModelParameterEditor.HasParameters)
-                        {
-                            <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                            <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                            <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
-                        }
+                        <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
+                        <partial name="_ModelParameters" model="Model.UtilityModelParameterEditor" />
                     </div>
 
                     <!-- Capabilities Tab (Agents, A2A, MCP, Tools) -->

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AITemplate/Edit.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/AI/Views/AITemplate/Edit.cshtml
@@ -404,12 +404,8 @@
                             </div>
                             <div class="form-text">Cache responses to improve performance for repeated queries.</div>
                         </div>
-                        @if (Model.ModelParameterEditor is not null && Model.ModelParameterEditor.HasParameters)
-                        {
-                            <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                            <p class="text-muted small">Only the parameters declared by the selected chat deployment are shown.</p>
-                            <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
-                        }
+                        <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
+                        <partial name="_ModelParameters" model="Model.UtilityModelParameterEditor" />
                     </div>
 
                     <!-- Capabilities Tab (Agents, A2A, MCP, Tools) -->

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Controllers/ChatInteractionController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Controllers/ChatInteractionController.cs
@@ -166,6 +166,7 @@ public sealed class ChatInteractionController : Controller
         interaction.OwnerId = User.Identity?.Name ?? "anonymous";
         interaction.Author = User.Identity?.Name ?? "anonymous";
         interaction.ChatDeploymentName = model.ChatDeploymentName;
+        interaction.UtilityDeploymentName = model.UtilityDeploymentName;
         interaction.OrchestratorName = model.OrchestratorName;
         interaction.SystemMessage = model.SystemMessage;
         interaction.Temperature = model.Temperature;
@@ -327,11 +328,28 @@ public sealed class ChatInteractionController : Controller
 
     private async Task PopulateDropdownsAsync(ChatInteractionViewModel model)
     {
-        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(model.ModelParameters);
+        model.ModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.ModelParameters,
+            description: "Only the parameters declared by the selected deployment are shown.");
+        model.UtilityModelParameterEditor = await _modelParameterViewService.BuildAsync(
+            model.UtilityModelParameters,
+            deploymentFieldName: nameof(ChatInteractionViewModel.UtilityDeploymentName),
+            fieldPrefix: nameof(ChatInteractionViewModel.UtilityModelParameters),
+            elementPrefix: "utilityModelParameters",
+            title: "Utility model parameters",
+            description: "Applied to background completions such as title generation, data extraction, and post-session processing. Only the parameters declared by the selected utility deployment are shown.");
 
         var deployments = await _deploymentCatalog.GetAllAsync();
         model.Deployments = deployments
             .Where(d => d.Purpose.Supports(AIDeploymentPurpose.Chat))
+            .Select(d => new SelectListItem(
+                string.Equals(d.Name, d.ModelName, StringComparison.OrdinalIgnoreCase)
+        ? d.Name
+        : $"{d.Name} ({d.ModelName})",
+        d.Name))
+            .ToList();
+        model.UtilityDeployments = deployments
+            .Where(d => d.Purpose.Supports(AIDeploymentPurpose.Utility) || d.Purpose.Supports(AIDeploymentPurpose.Chat))
             .Select(d => new SelectListItem(
                 string.Equals(d.Name, d.ModelName, StringComparison.OrdinalIgnoreCase)
         ? d.Name
@@ -639,6 +657,18 @@ public sealed class ChatInteractionController : Controller
             .ToList();
     }
 
+    private static Dictionary<string, string> SelectedModelParameters(Dictionary<string, string> values)
+    {
+        if (values is null)
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return new Dictionary<string, string>(
+            values.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
     private async Task ApplyMetadataAsync(ChatInteraction interaction, ChatInteractionViewModel model)
     {
         var dataSourceId = await ResolveDataSourceIdAsync(model.DataSourceId);
@@ -674,11 +704,8 @@ public sealed class ChatInteractionController : Controller
 
         interaction.Alter<AIDeploymentParametersMetadata>(metadata =>
         {
-            metadata.Values = model.ModelParameters is null
-                ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                : new Dictionary<string, string>(
-                    model.ModelParameters.Where(static entry => !string.IsNullOrWhiteSpace(entry.Key) && !string.IsNullOrWhiteSpace(entry.Value)),
-                    StringComparer.OrdinalIgnoreCase);
+            metadata.Values = SelectedModelParameters(model.ModelParameters);
+            metadata.UtilityValues = SelectedModelParameters(model.UtilityModelParameters);
         });
 
         if (string.Equals(model.OrchestratorName, ClaudeOrchestrator.OrchestratorName, StringComparison.OrdinalIgnoreCase))

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/ViewModels/ChatInteractionViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/ViewModels/ChatInteractionViewModel.cs
@@ -16,6 +16,8 @@ public sealed class ChatInteractionViewModel
 
     public string ChatDeploymentName { get; set; }
 
+    public string UtilityDeploymentName { get; set; }
+
     public string OrchestratorName { get; set; }
 
     public string SystemMessage { get; set; }
@@ -108,6 +110,9 @@ public sealed class ChatInteractionViewModel
     public IEnumerable<SelectListItem> Deployments { get; set; } = [];
 
     [BindNever]
+    public IEnumerable<SelectListItem> UtilityDeployments { get; set; } = [];
+
+    [BindNever]
     public IEnumerable<SelectListItem> Orchestrators { get; set; } = [];
 
     [BindNever]
@@ -129,10 +134,22 @@ public sealed class ChatInteractionViewModel
     public Dictionary<string, string> ModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Gets or sets the model parameter values selected for the utility deployment of this interaction,
+    /// keyed by the registered parameter technical name.
+    /// </summary>
+    public Dictionary<string, string> UtilityModelParameters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Gets or sets the metadata-driven model parameter editor.
     /// </summary>
     [BindNever]
     public ModelParameterEditorViewModel ModelParameterEditor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the metadata-driven model parameter editor for the utility deployment.
+    /// </summary>
+    [BindNever]
+    public ModelParameterEditorViewModel UtilityModelParameterEditor { get; set; }
 }
 
 public sealed class AgentSelectionItem

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Views/ChatInteraction/Create.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/ChatInteractions/Views/ChatInteraction/Create.cshtml
@@ -81,6 +81,14 @@
                     </div>
 
                     <div class="mb-3">
+                        <label asp-for="UtilityDeploymentName" class="form-label">Utility deployment</label>
+                        <select asp-for="UtilityDeploymentName" class="form-select" asp-items="Model.UtilityDeployments">
+                            <option value="">Use the default utility deployment</option>
+                        </select>
+                        <div class="form-text">The deployment used for background completions such as title generation. Leave blank to use the site default.</div>
+                    </div>
+
+                    <div class="mb-3">
                         <label asp-for="OrchestratorName" class="form-label">Orchestrator</label>
                         <select asp-for="OrchestratorName" class="form-select" asp-items="Model.Orchestrators">
                             <option value="">Use default orchestrator</option>
@@ -283,12 +291,8 @@
                             <input asp-for="PastMessagesCount" type="number" class="form-control" min="0" placeholder="10" />
                         </div>
                     </div>
-                    @if (Model.ModelParameterEditor is not null && Model.ModelParameterEditor.HasParameters)
-                    {
-                        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> Model parameters</h6>
-                        <p class="text-muted small">Only the parameters declared by the selected deployment are shown.</p>
-                        <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
-                    }
+                    <partial name="_ModelParameters" model="Model.ModelParameterEditor" />
+                    <partial name="_ModelParameters" model="Model.UtilityModelParameterEditor" />
                 </div>
 
                 <!-- Capabilities Tab -->

--- a/src/Startup/CrestApps.Core.Mvc.Web/Models/ModelParameterEditorViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Models/ModelParameterEditorViewModel.cs
@@ -25,6 +25,17 @@ public sealed class ModelParameterEditorViewModel
     public string ElementPrefix { get; set; } = "modelParameters";
 
     /// <summary>
+    /// Gets or sets the heading rendered above the editor. The heading is hidden along with the rest
+    /// of the editor when the selected deployment exposes no configurable parameter.
+    /// </summary>
+    public string Title { get; set; } = "Model parameters";
+
+    /// <summary>
+    /// Gets or sets the descriptive text rendered under the heading.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
     /// Gets or sets every registered model parameter along with the value currently selected.
     /// </summary>
     public List<ModelParameterFieldViewModel> Parameters { get; set; } = [];
@@ -33,13 +44,6 @@ public sealed class ModelParameterEditorViewModel
     /// Gets or sets the per-deployment capability map serialized as JSON and consumed by the editor script.
     /// </summary>
     public string CapabilitiesJson { get; set; } = "{}";
-
-    /// <summary>
-    /// Gets or sets the per-deployment trained feature map serialized as JSON and consumed by the editor
-    /// script to render the read-only capability badges. Keyed by deployment name, each value is the list
-    /// of trained feature display names the deployment declares.
-    /// </summary>
-    public string FeaturesJson { get; set; } = "{}";
 
     /// <summary>
     /// Gets a value indicating whether at least one parameter is registered.

--- a/src/Startup/CrestApps.Core.Mvc.Web/Services/AIDeploymentParameterViewService.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Services/AIDeploymentParameterViewService.cs
@@ -35,17 +35,23 @@ public sealed class AIDeploymentParameterViewService
     /// <param name="deploymentFieldName">The name of the form field that holds the selected chat deployment.</param>
     /// <param name="fieldPrefix">The form field prefix used when posting the selected values.</param>
     /// <param name="elementPrefix">The prefix applied to generated element identifiers.</param>
+    /// <param name="title">The heading rendered above the editor.</param>
+    /// <param name="description">The descriptive text rendered under the heading.</param>
     public async Task<ModelParameterEditorViewModel> BuildAsync(
         IDictionary<string, string> values,
         string deploymentFieldName = "ChatDeploymentName",
         string fieldPrefix = "ModelParameters",
-        string elementPrefix = "modelParameters")
+        string elementPrefix = "modelParameters",
+        string title = "Model parameters",
+        string description = null)
     {
         var model = new ModelParameterEditorViewModel
         {
             DeploymentFieldName = deploymentFieldName,
             FieldPrefix = fieldPrefix,
             ElementPrefix = elementPrefix,
+            Title = title,
+            Description = description,
         };
 
         foreach (var descriptor in _capabilityService.GetRegisteredParameters())
@@ -66,34 +72,8 @@ public sealed class AIDeploymentParameterViewService
         }
 
         model.CapabilitiesJson = JsonSerializer.Serialize(await BuildCapabilityMapAsync(), ModelParameterCapabilityViewModel.SerializerOptions);
-        model.FeaturesJson = JsonSerializer.Serialize(await BuildFeatureMapAsync(), ModelParameterCapabilityViewModel.SerializerOptions);
 
         return model;
-    }
-
-    private async Task<Dictionary<string, string[]>> BuildFeatureMapAsync()
-    {
-        var map = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
-        var deployments = await _deploymentCatalog.GetAllAsync();
-
-        foreach (var deployment in deployments)
-        {
-            if (string.IsNullOrWhiteSpace(deployment.Name))
-            {
-                continue;
-            }
-
-            var capabilities = _capabilityService.GetCapabilities(deployment);
-
-            if (capabilities.Features.Count == 0)
-            {
-                continue;
-            }
-
-            map[deployment.Name] = [.. capabilities.Features.Select(feature => feature.DisplayName?.Value ?? feature.Name)];
-        }
-
-        return map;
     }
 
     private async Task<Dictionary<string, Dictionary<string, ModelParameterCapabilityViewModel>>> BuildCapabilityMapAsync()

--- a/src/Startup/CrestApps.Core.Mvc.Web/Views/Shared/_ModelParameters.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Views/Shared/_ModelParameters.cshtml
@@ -3,18 +3,17 @@
 
 @if (Model is not null && Model.HasParameters)
 {
-    <div class="model-parameters" id="@(Model.ElementPrefix)-container"
+    <div class="model-parameters d-none" id="@(Model.ElementPrefix)-container"
          data-deployment-field="@Model.DeploymentFieldName"
-         data-capabilities="@Model.CapabilitiesJson"
-         data-features="@Model.FeaturesJson">
-        <div class="mb-3 d-none" id="@(Model.ElementPrefix)-features" data-model-features>
-            <label class="form-label d-block mb-1">Model capabilities</label>
-            <div class="d-flex flex-wrap gap-1" data-model-features-list></div>
-            <div class="form-text">Trained capabilities the selected deployment declares support for.</div>
-        </div>
-        <div class="alert alert-secondary py-2 mb-3 d-none" id="@(Model.ElementPrefix)-empty" role="status">
-            The selected deployment does not expose any configurable model parameters.
-        </div>
+         data-capabilities="@Model.CapabilitiesJson">
+        @if (!string.IsNullOrWhiteSpace(Model.Title))
+        {
+            <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-sliders"></i> @Model.Title</h6>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.Description))
+        {
+            <p class="text-muted small">@Model.Description</p>
+        }
         @foreach (var parameter in Model.Parameters)
         {
             var fieldId = $"{Model.ElementPrefix}-{parameter.ElementId}";
@@ -75,60 +74,8 @@
                     capabilities = {};
                 }
 
-                var features = {};
-
-                try {
-                    features = JSON.parse(container.dataset.features || '{}');
-                } catch (e) {
-                    features = {};
-                }
-
                 var deploymentField = container.dataset.deploymentField;
                 var deploymentSelect = deploymentField ? document.querySelector('[name="' + deploymentField + '"]') : null;
-                var emptyNotice = container.querySelector('[id$="-empty"]');
-                var featuresContainer = container.querySelector('[data-model-features]');
-                var featuresList = container.querySelector('[data-model-features-list]');
-
-                function lookupFeatures(deploymentName) {
-                    if (!deploymentName) {
-                        return null;
-                    }
-
-                    var keys = Object.keys(features);
-
-                    for (var i = 0; i < keys.length; i++) {
-                        if (keys[i].toLowerCase() === deploymentName.toLowerCase()) {
-                            return features[keys[i]];
-                        }
-                    }
-
-                    return null;
-                }
-
-                function refreshFeatures(deploymentName) {
-                    if (!featuresContainer || !featuresList) {
-                        return;
-                    }
-
-                    var declared = lookupFeatures(deploymentName);
-
-                    featuresList.textContent = '';
-
-                    if (!declared || !declared.length) {
-                        featuresContainer.classList.add('d-none');
-
-                        return;
-                    }
-
-                    declared.forEach(function (name) {
-                        var badge = document.createElement('span');
-                        badge.className = 'badge rounded-pill text-bg-info';
-                        badge.textContent = name;
-                        featuresList.appendChild(badge);
-                    });
-
-                    featuresContainer.classList.remove('d-none');
-                }
 
                 function lookup(deploymentName) {
                     if (!deploymentName) {
@@ -205,8 +152,6 @@
                     var supported = lookup(deploymentName);
                     var visibleCount = 0;
 
-                    refreshFeatures(deploymentName);
-
                     Array.prototype.forEach.call(container.querySelectorAll('[data-model-parameter]'), function (wrapper) {
                         var name = wrapper.getAttribute('data-model-parameter');
                         var metadata = supported ? supported[name] : null;
@@ -242,9 +187,9 @@
                         }
                     });
 
-                    if (emptyNotice) {
-                        emptyNotice.classList.toggle('d-none', visibleCount > 0);
-                    }
+                    // The whole block, heading included, is hidden when the selected deployment exposes
+                    // no configurable parameter, so the editor only ever shows real inputs.
+                    container.classList.toggle('d-none', visibleCount === 0);
                 }
 
                 if (deploymentSelect) {

--- a/tests/CrestApps.Core.Tests/Framework/AI/AIDeploymentCapabilityTests.cs
+++ b/tests/CrestApps.Core.Tests/Framework/AI/AIDeploymentCapabilityTests.cs
@@ -292,7 +292,7 @@ public sealed class AIDeploymentCapabilityTests
     public async Task ConfigureAsync_WhenTheSelectedValueIsNotSupported_ShouldLogWarning()
     {
         // Arrange
-        var logger = new Mock<ILogger<ModelParametersAICompletionServiceHandler>>();
+        var logger = new Mock<ILogger<DefaultAIDeploymentParameterApplier>>();
         var handler = CreateHandler(logger: logger);
         var deployment = CreateDeployment(new AIDeploymentParameter
         {
@@ -514,7 +514,7 @@ public sealed class AIDeploymentCapabilityTests
             },
         });
 
-        var logger = new Mock<ILogger<ModelParametersAICompletionServiceHandler>>();
+        var logger = new Mock<ILogger<DefaultAIDeploymentParameterApplier>>();
         var handler = CreateHandler(options, logger);
 
         // A value larger than long.MaxValue passes the descriptor's numeric validation but cannot be
@@ -559,6 +559,72 @@ public sealed class AIDeploymentCapabilityTests
         // Assert
         Assert.Equal("High", context.ModelParameters["reasoningEffort"]);
         Assert.False(context.ModelParameters.ContainsKey("ignored"));
+    }
+
+    [Fact]
+    public void ApplyModelParameters_ShouldCopyTheStoredUtilityValuesIntoTheCompletionContext()
+    {
+        // Arrange
+        var context = new AICompletionContext();
+        var metadata = new AIDeploymentParametersMetadata
+        {
+            Values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["reasoningEffort"] = "High",
+            },
+            UtilityValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["reasoningEffort"] = "Low",
+                ["ignored"] = " ",
+            },
+        };
+
+        // Act
+        context.ApplyModelParameters(metadata);
+
+        // Assert
+        Assert.Equal("High", context.ModelParameters["reasoningEffort"]);
+        Assert.Equal("Low", context.UtilityModelParameters["reasoningEffort"]);
+        Assert.False(context.UtilityModelParameters.ContainsKey("ignored"));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WhenTheRequestIsAUtilityCompletion_ShouldApplyTheUtilityValue()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var deployment = CreateDeployment(new AIDeploymentParameter
+        {
+            AllowedValues = ["Low", "Medium", "High"],
+        });
+        var context = CreateConfigureContext(deployment, ("reasoningEffort", "High"));
+        context.CompletionContext.IsUtilityCompletion = true;
+        context.CompletionContext.UtilityModelParameters["reasoningEffort"] = "Low";
+
+        // Act
+        await handler.ConfigureAsync(context, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ReasoningEffort.Low, context.ChatOptions.Reasoning?.Effort);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_WhenTheRequestIsNotAUtilityCompletion_ShouldIgnoreTheUtilityValue()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var deployment = CreateDeployment(new AIDeploymentParameter
+        {
+            AllowedValues = ["Low", "Medium", "High"],
+        });
+        var context = CreateConfigureContext(deployment, ("reasoningEffort", "High"));
+        context.CompletionContext.UtilityModelParameters["reasoningEffort"] = "Low";
+
+        // Act
+        await handler.ConfigureAsync(context, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ReasoningEffort.High, context.ChatOptions.Reasoning?.Effort);
     }
 
     private static AIDeployment CreateDeployment(AIDeploymentParameter parameter)
@@ -644,13 +710,15 @@ public sealed class AIDeploymentCapabilityTests
 
     private static ModelParametersAICompletionServiceHandler CreateHandler(
         AIDeploymentCapabilityOptions options = null,
-        Mock<ILogger<ModelParametersAICompletionServiceHandler>> logger = null)
+        Mock<ILogger<DefaultAIDeploymentParameterApplier>> logger = null)
     {
         var service = new DefaultAIDeploymentCapabilityService(Options.Create(options ?? CreateOptions()), Mock.Of<IAIDeploymentStore>());
 
-        return new ModelParametersAICompletionServiceHandler(
+        var applier = new DefaultAIDeploymentParameterApplier(
             service,
             [new ReasoningEffortModelParameterBinder()],
-            logger?.Object ?? NullLogger<ModelParametersAICompletionServiceHandler>.Instance);
+            logger?.Object ?? NullLogger<DefaultAIDeploymentParameterApplier>.Instance);
+
+        return new ModelParametersAICompletionServiceHandler(applier);
     }
 }


### PR DESCRIPTION
## Problem

A profile, profile template, or chat interaction selects both a **chat** deployment and a **utility** deployment, but only the chat deployment's model parameters (such as `reasoningEffort`) could be configured. The utility deployment — which backs title generation, orchestration planning, data extraction, and post-session processing — silently ran with provider defaults even when its model declared the `reasoning` feature.

Both deployments are now configurable, and both are honored at runtime.

## Storage and runtime

- `AIDeploymentParametersMetadata.UtilityValues` stores the values selected for the utility deployment alongside the existing `Values`. Existing stored metadata keeps working; the new dictionary is simply empty.
- `AICompletionContext.UtilityModelParameters` and `AICompletionContext.IsUtilityCompletion` carry the selection and the intent. The profile and chat interaction context builder handlers copy both value sets onto the context.
- `NamedAICompletionClient` resolves the utility deployment (falling back to the chat deployment) when `IsUtilityCompletion` is set, so a utility completion runs on the deployment it was configured for. Chat title generation now sets that flag — previously it resolved the utility deployment and then dropped it.
- The parameter-binding loop moves out of `ModelParametersAICompletionServiceHandler` into the new `IAIDeploymentParameterApplier` / `DefaultAIDeploymentParameterApplier`, which takes an `AIDeploymentParameterScope` (`Chat` or `Utility`). The handler is now a thin wrapper that picks the scope from the completion context.
- `ChatClientBuilder.UseModelParameters` / `UseUtilityModelParameters` let the background completions that resolve an `IChatClient` directly from `IAIClientFactory` — orchestration planning, data extraction, post-session processing — apply the same operator selections as the pipeline.
- The markdown profile template parser accepts a `UtilityModelParameters` front-matter key.

## Editors

- A second **Utility model parameters** editor renders on the AI profile, AI profile template, and chat interaction screens in both `CrestApps.Core.Mvc.Web` and `CrestApps.Core.Blazor.Web`, bound to the selected utility deployment. Each editor shows only the parameters its own deployment declares, so a reasoning-capable utility model exposes its reasoning effort selector even when the chat model does not (and the reverse).
- The chat interaction editor gains a **Utility deployment** selector in both hosts; it previously offered only the chat deployment.
- The read-only capability badges and the "The selected deployment does not expose any configurable model parameters" notice are gone. Each editor now owns its own heading and hides itself completely — heading included — when the deployment it is bound to declares no configurable parameter.
- **Bug fix:** the Blazor pages passed the *literal string* `"_model.ChatDeploymentName"` to `ModelParametersEditor.DeploymentName`. Razor treats an unprefixed attribute value as a literal for a `string` parameter, so the component never resolved a deployment and rendered no parameters at all. The pages now pass `@_model.ChatDeploymentName`.

## Verification

Ran both sample hosts and exercised all six screens against a deployment declaring `reasoning` + `reasoningEffort` and one declaring neither:

| Screen | Host | Result |
| --- | --- | --- |
| AI Profile | MVC + Blazor | Chat and utility editors show/hide independently; `High` / `Low` round-trip through save and reload |
| AI Template (Profile source) | MVC + Blazor | Utility editor shows for the reasoning deployment while the chat block stays hidden; `ExtraHigh` round-trips |
| Chat Interaction | MVC + Blazor | Utility deployment selector and utility editor render; stored as `UtilityValues` on the interaction |

`dotnet test tests/CrestApps.Core.Tests -c Release`: **2946 passed, 0 failed** (3 new tests cover the utility scope and the metadata copy). Docs site builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
