### PR TITLE
Add cascaded realtime deployments

### DIFF
--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/CascadedRealtimeMetadata.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/CascadedRealtimeMetadata.cs
@@ -1,0 +1,44 @@
+using CrestApps.Core.AI.Models;
+
+namespace CrestApps.Core.AI.Realtime;
+
+/// <summary>
+/// Metadata stored on an <see cref="AIDeployment"/> that turns it into a cascaded realtime deployment:
+/// one that answers speech with speech by chaining a realtime speech-to-text deployment, a chat
+/// deployment, and a text-to-speech deployment together.
+/// </summary>
+/// <remarks>
+/// Most providers do not ship a speech-to-speech model. A cascaded deployment lets those providers serve
+/// the realtime experience anyway, and lets a host mix vendors — transcribing with one, reasoning with
+/// another, and speaking with a third. The deployment carrying this metadata still has to declare the
+/// <see cref="AIDeploymentFeatureNames.Realtime"/> feature so the realtime orchestrator resolves it.
+/// </remarks>
+public sealed class CascadedRealtimeMetadata
+{
+    /// <summary>
+    /// Gets or sets the technical name of the deployment that transcribes the user's speech. The deployment
+    /// must expose a realtime client capable of a transcription session.
+    /// </summary>
+    public string SpeechToTextDeploymentName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technical name of the chat deployment that generates the reply. Tools, data sources,
+    /// and instructions resolved by the orchestrator are applied to this deployment.
+    /// </summary>
+    public string ChatDeploymentName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the technical name of the deployment that speaks the reply.
+    /// </summary>
+    public string TextToSpeechDeploymentName { get; set; }
+
+    /// <summary>
+    /// Determines whether every deployment the cascade needs has been named.
+    /// </summary>
+    public bool IsComplete()
+    {
+        return !string.IsNullOrWhiteSpace(SpeechToTextDeploymentName)
+            && !string.IsNullOrWhiteSpace(ChatDeploymentName)
+            && !string.IsNullOrWhiteSpace(TextToSpeechDeploymentName);
+    }
+}

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -35,6 +35,29 @@ and preview builds are published from `main` under the `2.0.0` version prefix.
     **not** obsolete). Hosts that enforce per-user tool permissions should keep their custom
     evaluator; it now governs Chat Interaction sends rather than every session completion.
 
+## Cascaded realtime deployments
+
+Realtime voice no longer requires a provider that ships a speech-to-speech model. A deployment carrying
+`CascadedRealtimeMetadata` chains a realtime speech-to-text deployment, a chat deployment, and a
+text-to-speech deployment into a single `IRealtimeClient`, and may mix vendors across the three. See
+[Realtime Voice](../core/realtime-voice.md) for the guide.
+
+- adds `CascadedRealtimeMetadata`, stored on an `AIDeployment` to name the three deployments to chain.
+- adds `CascadedRealtimeClient`, composed by `IAIClientFactory.CreateRealtimeClientAsync` when a deployment
+  carries that metadata. A client provider only ever sees one connection, so the cascade is assembled by the
+  factory rather than by a provider.
+- the chat leg is built with function invocation applied, so tools, data sources, and the profile's system
+  message keep working exactly as they do for a text profile.
+- the reply is spoken a sentence at a time so audio begins playing before the model finishes writing, and a
+  partial transcript arriving mid-reply cancels the turn and signals the client to flush buffered audio.
+- `DefaultRealtimeVoiceResolver` now lists the text-to-speech leg's voices for a cascaded deployment, since
+  that is the deployment that actually speaks.
+- `DefaultRealtimeVoiceResolver` takes an additional `IAIDeploymentStore` constructor argument to reach that
+  leg. Hosts that resolve it from the container are unaffected.
+- the realtime orchestrator no longer substitutes its OpenAI fallback voice (`alloy`) when a cascaded
+  deployment has no voice selected. That name is meaningless to another vendor's speech model and would be
+  rejected, so the voice is left unset and the speaking provider applies its own configured default.
+
 ## Metadata-driven model features and parameters
 
 AI deployments can now describe what their model supports instead of relying on hardcoded,

--- a/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
+++ b/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
@@ -20,6 +20,52 @@ Two transports carry that audio. The application selects between them automatica
 | **WebRTC** (server-relay) | Primary — whenever the server advertises it and the browser supports `RTCPeerConnection`, and the peer connects | The browser's acoustic echo canceller (AEC) keeps the mic open (full-duplex) |
 | **WebSocket** (PCM over SignalR) | Fallback — when WebRTC can't connect (blocked UDP, no TURN, unsupported browser) | Browser AEC still applies to the played-back audio; barge-in off additionally mutes the mic while the assistant speaks |
 
+## Providers without a speech-to-speech model
+
+Most providers do not ship a speech-to-speech model. A **cascaded realtime deployment** serves the same
+experience by chaining three deployments you already have — one that transcribes, one that reasons, and one
+that speaks:
+
+```
+mic ──▶ realtime speech-to-text ──▶ chat (tools, data sources) ──▶ text-to-speech ──▶ speaker
+```
+
+Everything above the client is unchanged: a cascaded deployment produces the same realtime messages a native
+provider does, so the orchestrator, the chat UI, transcripts, and turn persistence all behave identically.
+The legs may come from different vendors — transcribe with one, reason with another, speak with a third.
+
+Configure it by storing `CascadedRealtimeMetadata` on a deployment that also declares the `realtime` feature:
+
+```csharp
+var deployment = await deploymentManager.NewAsync("cascaded-voice", clientName);
+
+deployment.Alter<CascadedRealtimeMetadata>(cascade =>
+{
+    cascade.SpeechToTextDeploymentName = "elevenlabs-scribe";
+    cascade.ChatDeploymentName = "gpt-4o";
+    cascade.TextToSpeechDeploymentName = "elevenlabs-tts";
+});
+
+deployment.Alter<AIDeploymentMetadata>(metadata =>
+{
+    metadata.Features = [AIDeploymentFeatureNames.Realtime];
+});
+```
+
+What to expect from each leg:
+
+- **Speech-to-text** must expose a realtime client that supports a transcription session. It hears the user
+  continuously; a committed transcript is what ends the user's turn and starts the reply.
+- **Chat** produces the reply. Tools, data sources, and the profile's system message are applied here, so a
+  cascaded session keeps every capability a text profile has. Function invocation is applied automatically.
+- **Text-to-speech** speaks the reply. The reply is spoken a sentence at a time so audio starts playing while
+  the model is still writing, and the voice picker for the deployment lists this leg's voices.
+
+Two differences from a native speech-to-speech model are worth planning for. Latency is higher, because a turn
+passes through three services instead of one. And interruption is driven by transcription: when the user
+speaks over the assistant, the first partial transcript cancels the in-flight reply and tells the client to
+drop the audio it has buffered, so barge-in responds as fast as the transcriber reports speech.
+
 ## Architecture: server-relay WebRTC
 
 The realtime orchestrator, tool loop, system-prompt injection, and persistence are **transport-agnostic**. WebRTC swaps only the two audio boundaries; the server still drives the provider session.

--- a/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeClient.cs
+++ b/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeClient.cs
@@ -1,0 +1,177 @@
+#pragma warning disable MEAI001 // The realtime types from Microsoft.Extensions.AI are for evaluation purposes only.
+#nullable enable
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.Realtime;
+
+/// <summary>
+/// An <see cref="IRealtimeClient"/> that answers speech with speech without a speech-to-speech model, by
+/// chaining a realtime transcription client, a chat client, and a text-to-speech client.
+/// </summary>
+/// <remarks>
+/// This is what lets a provider that only transcribes — or a host that wants to reason with one vendor and
+/// speak with another — serve the realtime experience. It is composed by <c>IAIClientFactory</c> from a
+/// deployment carrying <see cref="CascadedRealtimeMetadata"/>, because a single
+/// <c>IAIClientProvider</c> only ever sees one connection and so could never reach three deployments.
+/// </remarks>
+public sealed class CascadedRealtimeClient : IRealtimeClient
+{
+    private readonly IRealtimeClient _transcriptionClient;
+    private readonly IChatClient _chatClient;
+    private readonly ITextToSpeechClient _speechClient;
+    private readonly string? _speechModelId;
+    private readonly ILogger<CascadedRealtimeClient> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CascadedRealtimeClient"/> class.
+    /// </summary>
+    /// <param name="transcriptionClient">The realtime client that transcribes the user's speech.</param>
+    /// <param name="chatClient">The chat client that generates the reply. Supply one that already has function invocation applied when the session should be able to call tools.</param>
+    /// <param name="speechClient">The text-to-speech client that speaks the reply.</param>
+    /// <param name="speechModelId">The model the text-to-speech deployment should use, or <see langword="null"/> for its default.</param>
+    /// <param name="logger">The logger.</param>
+    public CascadedRealtimeClient(
+        IRealtimeClient transcriptionClient,
+        IChatClient chatClient,
+        ITextToSpeechClient speechClient,
+        string? speechModelId,
+        ILogger<CascadedRealtimeClient> logger)
+    {
+        _transcriptionClient = transcriptionClient;
+        _chatClient = chatClient;
+        _speechClient = speechClient;
+        _speechModelId = speechModelId;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IRealtimeClientSession> CreateSessionAsync(RealtimeSessionOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        var transcription = await _transcriptionClient.CreateSessionAsync(BuildTranscriptionOptions(options), cancellationToken);
+
+        try
+        {
+            var session = new CascadedRealtimeSession(
+                transcription,
+                _chatClient,
+                _speechClient,
+                options,
+                BuildChatOptions(options),
+                BuildSpeechOptions(options),
+                _logger);
+
+            session.Start();
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("Started a cascaded realtime session speaking with voice '{Voice}'.", options?.Voice);
+            }
+
+            return session;
+        }
+        catch
+        {
+            await transcription.DisposeAsync();
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        if (serviceKey is not null)
+        {
+            return null;
+        }
+
+        if (serviceType.IsInstanceOfType(this))
+        {
+            return this;
+        }
+
+        return _transcriptionClient.GetService(serviceType)
+            ?? _chatClient.GetService(serviceType)
+            ?? _speechClient.GetService(serviceType);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // The legs are handed to each session, which disposes them when it ends. Disposing them here would
+        // tear down a session that is still running.
+        _transcriptionClient.Dispose();
+    }
+
+    /// <summary>
+    /// Builds the options for the transcription leg. Only the input audio and transcription settings carry
+    /// over: the reply is produced by the chat leg, not by the transcriber.
+    /// </summary>
+    /// <param name="options">The session options the caller requested.</param>
+    private static RealtimeSessionOptions BuildTranscriptionOptions(RealtimeSessionOptions? options)
+    {
+        return new RealtimeSessionOptions
+        {
+            SessionKind = RealtimeSessionKind.Transcription,
+            InputAudioFormat = options?.InputAudioFormat,
+            TranscriptionOptions = options?.TranscriptionOptions,
+            VoiceActivityDetection = options?.VoiceActivityDetection,
+            RawRepresentationFactory = options?.RawRepresentationFactory,
+        };
+    }
+
+    /// <summary>
+    /// Builds the options applied to every chat turn, carrying across the tools and limits the orchestrator
+    /// resolved for the conversation.
+    /// </summary>
+    /// <param name="options">The session options the caller requested.</param>
+    private static ChatOptions? BuildChatOptions(RealtimeSessionOptions? options)
+    {
+        if (options is null)
+        {
+            return null;
+        }
+
+        return new ChatOptions
+        {
+            MaxOutputTokens = options.MaxOutputTokens,
+            Tools = options.Tools?.ToList(),
+            ToolMode = options.ToolMode,
+        };
+    }
+
+    /// <summary>
+    /// Builds the options applied to every spoken fragment, pinning the audio format to the one the caller
+    /// asked the session to produce.
+    /// </summary>
+    /// <param name="options">The session options the caller requested.</param>
+    private TextToSpeechOptions BuildSpeechOptions(RealtimeSessionOptions? options)
+    {
+        return new TextToSpeechOptions
+        {
+            ModelId = _speechModelId,
+            VoiceId = options?.Voice,
+            Language = options?.TranscriptionOptions?.SpeechLanguage,
+            AudioFormat = FormatAudioFormat(options?.OutputAudioFormat),
+        };
+    }
+
+    /// <summary>
+    /// Names the speech client's output format so it emits the raw PCM the realtime pipeline plays, at the
+    /// rate the session negotiated. Providers parse this name themselves, so an unknown rate falls through
+    /// to the provider's own default rather than failing the session.
+    /// </summary>
+    /// <param name="format">The output audio format the caller requested.</param>
+    private static string? FormatAudioFormat(RealtimeAudioFormat? format)
+    {
+        if (format is null || format.SampleRate <= 0)
+        {
+            return null;
+        }
+
+        return $"Pcm{format.SampleRate}";
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeSession.cs
+++ b/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeSession.cs
@@ -1,0 +1,466 @@
+#pragma warning disable MEAI001 // The realtime types from Microsoft.Extensions.AI are for evaluation purposes only.
+#nullable enable
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.Realtime;
+
+/// <summary>
+/// A realtime session that answers speech with speech by chaining three ordinary clients: a realtime
+/// transcription session for the user's audio, an <see cref="IChatClient"/> for the reply, and an
+/// <see cref="ITextToSpeechClient"/> to speak it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The session presents itself to callers exactly like a native speech-to-speech provider: it emits the
+/// same <see cref="RealtimeServerMessage"/> types, so <c>DefaultRealtimeConversation</c> and everything
+/// above it work unchanged.
+/// </para>
+/// <para>
+/// Messages are produced by two writers — the transcription pump and the current assistant turn — and
+/// read by a single caller, so they meet in an unbounded channel rather than being yielded directly.
+/// That also means messages produced before the caller starts enumerating are kept rather than lost.
+/// </para>
+/// </remarks>
+internal sealed class CascadedRealtimeSession : IRealtimeClientSession
+{
+    // A reply is spoken a sentence at a time so the first audio starts playing while the model is still
+    // writing. Below this length a fragment is held back and joined to the next one: sending two or three
+    // words to a speech model produces clipped, oddly-cadenced audio.
+    private const int MinimumSpeakableLength = 24;
+
+    private readonly IRealtimeClientSession _transcription;
+    private readonly IChatClient _chatClient;
+    private readonly ITextToSpeechClient _speechClient;
+    private readonly ChatOptions? _chatOptions;
+    private readonly TextToSpeechOptions _speechOptions;
+    private readonly List<ChatMessage> _history = [];
+    private readonly Channel<RealtimeServerMessage> _messages = Channel.CreateUnbounded<RealtimeServerMessage>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false,
+    });
+
+    private readonly CancellationTokenSource _sessionCancellation = new();
+    private readonly ILogger _logger;
+
+    private Task? _pump;
+    private Task _turn = Task.CompletedTask;
+    private CancellationTokenSource? _turnCancellation;
+    private bool _speaking;
+    private int _disposed;
+
+    /// <inheritdoc />
+    public RealtimeSessionOptions? Options { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CascadedRealtimeSession"/> class.
+    /// </summary>
+    /// <param name="transcription">The realtime transcription session that hears the user.</param>
+    /// <param name="chatClient">The chat client that writes the reply.</param>
+    /// <param name="speechClient">The text-to-speech client that speaks the reply.</param>
+    /// <param name="options">The session options the caller requested.</param>
+    /// <param name="chatOptions">The chat options to apply to every turn, or <see langword="null"/> for none.</param>
+    /// <param name="speechOptions">The speech options to apply to every spoken fragment.</param>
+    /// <param name="logger">The logger.</param>
+    public CascadedRealtimeSession(
+        IRealtimeClientSession transcription,
+        IChatClient chatClient,
+        ITextToSpeechClient speechClient,
+        RealtimeSessionOptions? options,
+        ChatOptions? chatOptions,
+        TextToSpeechOptions speechOptions,
+        ILogger logger)
+    {
+        _transcription = transcription;
+        _chatClient = chatClient;
+        _speechClient = speechClient;
+        Options = options;
+        _chatOptions = chatOptions;
+        _speechOptions = speechOptions;
+        _logger = logger;
+
+        if (!string.IsNullOrWhiteSpace(options?.Instructions))
+        {
+            _history.Add(new ChatMessage(ChatRole.System, options!.Instructions));
+        }
+    }
+
+    /// <summary>
+    /// Starts relaying the transcription session. Called once, by the client that created this session.
+    /// </summary>
+    public void Start()
+    {
+        _pump ??= Task.Run(() => PumpTranscriptionAsync(_sessionCancellation.Token));
+    }
+
+    /// <inheritdoc />
+    public Task SendAsync(RealtimeClientMessage message, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        // Everything the caller sends is about the user's audio, which only the transcription leg can act
+        // on. It decides for itself what it cannot honor.
+        return _transcription.SendAsync(message, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<RealtimeServerMessage> GetStreamingResponseAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await foreach (var message in _messages.Reader.ReadAllAsync(cancellationToken))
+        {
+            yield return message;
+        }
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(serviceType);
+
+        if (serviceKey is not null)
+        {
+            return null;
+        }
+
+        if (serviceType.IsInstanceOfType(this))
+        {
+            return this;
+        }
+
+        return _transcription.GetService(serviceType)
+            ?? _chatClient.GetService(serviceType)
+            ?? _speechClient.GetService(serviceType);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        await _sessionCancellation.CancelAsync();
+
+        CancelTurn();
+
+        // The pump and the turn own the inner clients while they run, so let them unwind before disposing.
+        await SafeAwaitAsync(_pump);
+        await SafeAwaitAsync(_turn);
+
+        await _transcription.DisposeAsync();
+
+        _chatClient.Dispose();
+        _speechClient.Dispose();
+        _sessionCancellation.Dispose();
+        _turnCancellation?.Dispose();
+    }
+
+    /// <summary>
+    /// Relays the transcription session, starting an assistant turn each time the user finishes speaking.
+    /// </summary>
+    /// <param name="cancellationToken">A token that ends the session.</param>
+    private async Task PumpTranscriptionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var message in _transcription.GetStreamingResponseAsync(cancellationToken))
+            {
+                if (message.Type == RealtimeServerMessageType.InputAudioTranscriptionDelta)
+                {
+                    // The transcription leg reports no speech-start event of its own, but a partial
+                    // transcript only exists because the user is talking. Treating the first one as the
+                    // start of a turn is what lets a caller cut off audio that is still playing.
+                    await BargeInAsync(message);
+                }
+
+                await _messages.Writer.WriteAsync(message, cancellationToken);
+
+                if (message.Type == RealtimeServerMessageType.InputAudioTranscriptionCompleted &&
+                    message is InputAudioTranscriptionRealtimeServerMessage transcription &&
+                    !string.IsNullOrWhiteSpace(transcription.Transcription))
+                {
+                    await StartTurnAsync(transcription.Transcription!, cancellationToken);
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The session was disposed.
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "The cascaded realtime transcription relay failed.");
+
+            await WriteErrorAsync(exception);
+        }
+        finally
+        {
+            // The reply to the last thing the user said is still being written and spoken on its own task.
+            // Completing the channel here would cut it off mid-sentence.
+            await SafeAwaitAsync(_turn);
+
+            _messages.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
+    /// Stops a reply that is still being spoken because the user started talking over it.
+    /// </summary>
+    /// <param name="message">The partial transcript that revealed the user is speaking.</param>
+    private async Task BargeInAsync(RealtimeServerMessage message)
+    {
+        if (!_speaking)
+        {
+            return;
+        }
+
+        _speaking = false;
+
+        CancelTurn();
+
+        // Mirrors what a native provider emits when it detects speech over its own audio, which is what a
+        // caller listens for to drop whatever it has already buffered for playback.
+        await _messages.Writer.WriteAsync(new RealtimeServerMessage
+        {
+            Type = RealtimeServerMessageType.RawContentOnly,
+            RawRepresentation = JsonDocument.Parse($$"""{"type":"input_audio_buffer.speech_started","item_id":{{JsonSerializer.Serialize(message.MessageId)}}}""").RootElement.Clone(),
+        });
+    }
+
+    /// <summary>
+    /// Queues an assistant turn for the utterance the user just finished.
+    /// </summary>
+    /// <param name="userText">The transcript of the user's utterance.</param>
+    /// <param name="cancellationToken">A token that ends the session.</param>
+    private async Task StartTurnAsync(string userText, CancellationToken cancellationToken)
+    {
+        // Turns are strictly sequential: the history and the audio timeline are both ordered, so a new
+        // utterance waits for the previous reply to finish unwinding before it starts its own.
+        await SafeAwaitAsync(_turn);
+
+        _turnCancellation?.Dispose();
+        _turnCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var turnCancellation = _turnCancellation.Token;
+
+        // Marked here, on the pump, rather than inside the turn: an interruption arriving in the moment
+        // between queueing the reply and the reply starting would otherwise not be recognized as one.
+        _speaking = true;
+
+        _turn = Task.Run(() => RunTurnAsync(userText, turnCancellation), CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Generates and speaks one reply.
+    /// </summary>
+    /// <param name="userText">The transcript of the user's utterance.</param>
+    /// <param name="cancellationToken">A token that cancels this turn, including on barge-in.</param>
+    private async Task RunTurnAsync(string userText, CancellationToken cancellationToken)
+    {
+        var responseId = Guid.NewGuid().ToString("n");
+        var reply = new StringBuilder();
+        var pending = new StringBuilder();
+
+        try
+        {
+            _history.Add(new ChatMessage(ChatRole.User, userText));
+
+            await WriteAsync(new ResponseCreatedRealtimeServerMessage(RealtimeServerMessageType.ResponseCreated)
+            {
+                ResponseId = responseId,
+            });
+
+            await foreach (var update in _chatClient.GetStreamingResponseAsync(_history, _chatOptions, cancellationToken))
+            {
+                var text = update.Text;
+
+                if (string.IsNullOrEmpty(text))
+                {
+                    continue;
+                }
+
+                reply.Append(text);
+                pending.Append(text);
+
+                await WriteAsync(new OutputTextAudioRealtimeServerMessage(RealtimeServerMessageType.OutputAudioTranscriptionDelta)
+                {
+                    Text = text,
+                    ResponseId = responseId,
+                });
+
+                while (TryTakeSpeakableFragment(pending, out var fragment))
+                {
+                    await SpeakAsync(fragment, responseId, cancellationToken);
+                }
+            }
+
+            if (pending.Length > 0)
+            {
+                await SpeakAsync(pending.ToString(), responseId, cancellationToken);
+            }
+
+            await WriteAsync(new OutputTextAudioRealtimeServerMessage(RealtimeServerMessageType.OutputAudioTranscriptionDone)
+            {
+                Text = reply.ToString(),
+                ResponseId = responseId,
+            });
+
+            if (reply.Length > 0)
+            {
+                _history.Add(new ChatMessage(ChatRole.Assistant, reply.ToString()));
+            }
+
+            await WriteAsync(new ResponseCreatedRealtimeServerMessage(RealtimeServerMessageType.ResponseDone)
+            {
+                ResponseId = responseId,
+                Status = RealtimeResponseStatus.Completed,
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            // Interrupted by the user or by disposal. Whatever was said before the interruption stays in
+            // history, because the user heard it.
+            if (reply.Length > 0)
+            {
+                _history.Add(new ChatMessage(ChatRole.Assistant, reply.ToString()));
+            }
+
+            await WriteAsync(new ResponseCreatedRealtimeServerMessage(RealtimeServerMessageType.ResponseDone)
+            {
+                ResponseId = responseId,
+                Status = RealtimeResponseStatus.Cancelled,
+            });
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "The cascaded realtime turn failed.");
+
+            await WriteErrorAsync(exception);
+        }
+        finally
+        {
+            _speaking = false;
+        }
+    }
+
+    /// <summary>
+    /// Speaks one fragment of the reply, emitting its audio as it arrives.
+    /// </summary>
+    /// <param name="text">The fragment to speak.</param>
+    /// <param name="responseId">The identifier of the reply this fragment belongs to.</param>
+    /// <param name="cancellationToken">A token that cancels this turn.</param>
+    private async Task SpeakAsync(string text, string responseId, CancellationToken cancellationToken)
+    {
+        await foreach (var update in _speechClient.GetStreamingAudioAsync(text, _speechOptions, cancellationToken))
+        {
+            foreach (var content in update.Contents)
+            {
+                if (content is not DataContent audio || audio.Data.IsEmpty)
+                {
+                    continue;
+                }
+
+                await WriteAsync(new OutputTextAudioRealtimeServerMessage(RealtimeServerMessageType.OutputAudioDelta)
+                {
+                    Audio = Convert.ToBase64String(audio.Data.Span),
+                    ResponseId = responseId,
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Takes the next fragment of the reply that is long enough and complete enough to speak on its own.
+    /// </summary>
+    /// <param name="pending">The reply text that has not been spoken yet. The fragment is removed from it.</param>
+    /// <param name="fragment">The fragment to speak, when one is available.</param>
+    internal static bool TryTakeSpeakableFragment(StringBuilder pending, out string fragment)
+    {
+        ArgumentNullException.ThrowIfNull(pending);
+
+        for (var index = 0; index < pending.Length; index++)
+        {
+            if (pending[index] is not ('.' or '!' or '?' or '\n'))
+            {
+                continue;
+            }
+
+            // A terminator has to be followed by whitespace (or end the buffer) to end a sentence, which
+            // keeps "3.5" and "Dr. Chen" from being split down the middle.
+            if (index + 1 < pending.Length && !char.IsWhiteSpace(pending[index + 1]))
+            {
+                continue;
+            }
+
+            var length = index + 1;
+
+            if (length < MinimumSpeakableLength && length < pending.Length)
+            {
+                continue;
+            }
+
+            fragment = pending.ToString(0, length);
+
+            pending.Remove(0, length);
+
+            return true;
+        }
+
+        fragment = string.Empty;
+
+        return false;
+    }
+
+    private void CancelTurn()
+    {
+        try
+        {
+            _turnCancellation?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The turn already finished and its source was replaced.
+        }
+    }
+
+    private async Task WriteAsync(RealtimeServerMessage message)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        await _messages.Writer.WriteAsync(message);
+    }
+
+    private async Task WriteErrorAsync(Exception exception)
+    {
+        await WriteAsync(new ErrorRealtimeServerMessage
+        {
+            Error = new ErrorContent(exception.Message),
+        });
+    }
+
+    private static async Task SafeAwaitAsync(Task? task)
+    {
+        if (task is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await task;
+        }
+        catch (Exception)
+        {
+            // Faults are reported through the message channel; this only waits for the work to stop.
+        }
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Realtime/DefaultRealtimeOrchestrator.cs
+++ b/src/Primitives/CrestApps.Core.AI/Realtime/DefaultRealtimeOrchestrator.cs
@@ -1,4 +1,5 @@
 #pragma warning disable MEAI001 // The realtime API from Microsoft.Extensions.AI is for evaluation purposes only.
+using CrestApps.Core;
 using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Completions;
@@ -100,11 +101,16 @@ public sealed class DefaultRealtimeOrchestrator : IRealtimeOrchestrator
 
         var tools = await MaterializeToolsAsync(context, cancellationToken);
 
+        // The fallback voice is an OpenAI voice name. A cascaded deployment speaks through whatever
+        // provider its text-to-speech leg uses, where that name means nothing and would be rejected, so
+        // leave the voice unset and let that provider fall back to its own configured default.
+        var isCascaded = deployment.TryGet<CascadedRealtimeMetadata>(out var cascade) && cascade.IsComplete();
+
         var options = _sessionConfigurator.Configure(new RealtimeSessionConfiguratorContext
         {
             Model = deployment.ModelName,
             Instructions = context.CompletionContext?.SystemMessage,
-            Voice = string.IsNullOrWhiteSpace(request.Voice) ? DefaultVoice : request.Voice,
+            Voice = string.IsNullOrWhiteSpace(request.Voice) && !isCascaded ? DefaultVoice : request.Voice,
             Tools = tools,
             MaxOutputTokens = context.CompletionContext?.MaxTokens,
             SpeechLanguage = request.SpeechLanguage,

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIClientFactory.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIClientFactory.cs
@@ -1,7 +1,9 @@
 using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Connections;
+using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Realtime;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -219,6 +221,14 @@ public sealed class DefaultAIClientFactory : IAIClientFactory
     public async ValueTask<IRealtimeClient> CreateRealtimeClientAsync(AIDeployment deployment)
     {
         ArgumentNullException.ThrowIfNull(deployment);
+
+        // A cascaded deployment names three other deployments instead of speaking to a provider itself, so
+        // it is composed here: a client provider only ever sees one connection and could never reach them.
+        if (deployment.TryGet<CascadedRealtimeMetadata>(out var cascade) && cascade.IsComplete())
+        {
+            return await CreateCascadedRealtimeClientAsync(deployment, cascade);
+        }
+
         ArgumentException.ThrowIfNullOrEmpty(deployment.ClientName);
 
         // Realtime eligibility (a chat deployment whose model declares the 'realtime' capability) is
@@ -228,6 +238,69 @@ public sealed class DefaultAIClientFactory : IAIClientFactory
 
         return await ResolveClientAsync(deployment, connection,
             (provider, conn, model) => provider.GetRealtimeClientAsync(conn, model));
+    }
+
+    /// <summary>
+    /// Composes the realtime client for a deployment that answers speech with speech by chaining a
+    /// transcription deployment, a chat deployment, and a text-to-speech deployment.
+    /// </summary>
+    /// <param name="deployment">The cascaded realtime deployment.</param>
+    /// <param name="cascade">The metadata naming the deployments to chain.</param>
+    private async ValueTask<IRealtimeClient> CreateCascadedRealtimeClientAsync(AIDeployment deployment, CascadedRealtimeMetadata cascade)
+    {
+        var deploymentStore = _serviceProvider.GetRequiredService<IAIDeploymentStore>();
+
+        var speechToText = await ResolveCascadeLegAsync(deploymentStore, deployment, cascade.SpeechToTextDeploymentName, "speech-to-text");
+        var chat = await ResolveCascadeLegAsync(deploymentStore, deployment, cascade.ChatDeploymentName, "chat");
+        var textToSpeech = await ResolveCascadeLegAsync(deploymentStore, deployment, cascade.TextToSpeechDeploymentName, "text-to-speech");
+
+        // A cascade whose transcription leg is itself a cascade would compose forever.
+        if (speechToText.TryGet<CascadedRealtimeMetadata>(out var nested) && nested.IsComplete())
+        {
+            throw new InvalidOperationException($"The cascaded realtime deployment '{deployment.Name}' names '{speechToText.Name}' for speech-to-text, but that deployment is itself cascaded. Name a deployment that transcribes directly.");
+        }
+
+        var transcriptionClient = await CreateRealtimeClientAsync(speechToText);
+
+        try
+        {
+            // Tools resolved for the conversation are invoked on the chat leg, which is the only leg that
+            // can call them. The realtime middleware above this client then sees no tool calls to handle.
+            var chatClient = await CreateChatClientAsync(chat, builder => builder.UseFunctionInvocation());
+            var speechClient = await CreateTextToSpeechClientAsync(textToSpeech);
+
+            return new CascadedRealtimeClient(
+                transcriptionClient,
+                chatClient,
+                speechClient,
+                textToSpeech.ModelName,
+                _serviceProvider.GetRequiredService<ILogger<CascadedRealtimeClient>>());
+        }
+        catch
+        {
+            transcriptionClient.Dispose();
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Loads one of the deployments a cascade chains together.
+    /// </summary>
+    /// <param name="deploymentStore">The deployment store.</param>
+    /// <param name="deployment">The cascaded deployment doing the naming, used for diagnostics.</param>
+    /// <param name="name">The technical name of the deployment to load.</param>
+    /// <param name="role">The role the named deployment plays in the cascade, used for diagnostics.</param>
+    private static async ValueTask<AIDeployment> ResolveCascadeLegAsync(
+        IAIDeploymentStore deploymentStore,
+        AIDeployment deployment,
+        string name,
+        string role)
+    {
+        var leg = await deploymentStore.FindByNameAsync(name);
+
+        return leg
+            ?? throw new InvalidOperationException($"The cascaded realtime deployment '{deployment.Name}' names '{name}' as its {role} deployment, but no deployment with that name exists.");
     }
 #pragma warning restore MEAI001 // The realtime API from Microsoft.Extensions.AI is for evaluation purposes only and requires explicit opt-in at each usage site.
 

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultRealtimeVoiceResolver.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultRealtimeVoiceResolver.cs
@@ -1,6 +1,8 @@
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Connections;
+using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Realtime;
 using CrestApps.Core.AI.Speech;
 using Microsoft.AspNetCore.DataProtection;
 
@@ -15,6 +17,7 @@ public sealed class DefaultRealtimeVoiceResolver : IRealtimeVoiceResolver
     private readonly IEnumerable<IAIClientProvider> _clientProviders;
     private readonly IEnumerable<IAIProviderConnectionHandler> _connectionHandlers;
     private readonly IAIProviderConnectionStore _connectionCatalog;
+    private readonly IAIDeploymentStore _deploymentStore;
     private readonly IDataProtectionProvider _dataProtectionProvider;
 
     /// <summary>
@@ -24,16 +27,19 @@ public sealed class DefaultRealtimeVoiceResolver : IRealtimeVoiceResolver
     /// <param name="connectionHandlers">The connection handlers.</param>
     /// <param name="dataProtectionProvider">The data protection provider.</param>
     /// <param name="connectionCatalog">The connection catalog.</param>
+    /// <param name="deploymentStore">The deployment store, used to reach the speaking deployment of a cascaded realtime deployment.</param>
     public DefaultRealtimeVoiceResolver(
         IEnumerable<IAIClientProvider> clientProviders,
         IEnumerable<IAIProviderConnectionHandler> connectionHandlers,
         IDataProtectionProvider dataProtectionProvider,
-        IAIProviderConnectionStore connectionCatalog)
+        IAIProviderConnectionStore connectionCatalog,
+        IAIDeploymentStore deploymentStore)
     {
         _clientProviders = clientProviders;
         _connectionHandlers = connectionHandlers;
         _dataProtectionProvider = dataProtectionProvider;
         _connectionCatalog = connectionCatalog;
+        _deploymentStore = deploymentStore;
     }
 
     /// <summary>
@@ -43,6 +49,35 @@ public sealed class DefaultRealtimeVoiceResolver : IRealtimeVoiceResolver
     public async Task<SpeechVoice[]> GetVoicesAsync(AIDeployment deployment)
     {
         ArgumentNullException.ThrowIfNull(deployment);
+
+        // A cascaded deployment does not speak: the deployment it names for text-to-speech does, so the
+        // voices to choose from are that deployment's speech voices.
+        if (deployment.TryGet<CascadedRealtimeMetadata>(out var cascade) && cascade.IsComplete())
+        {
+            var speakingDeployment = await _deploymentStore.FindByNameAsync(cascade.TextToSpeechDeploymentName);
+
+            if (speakingDeployment is null)
+            {
+                return [];
+            }
+
+            return await GetVoicesAsync(speakingDeployment, static (provider, connection, model) => provider.GetSpeechVoicesAsync(connection, model));
+        }
+
+        ArgumentException.ThrowIfNullOrEmpty(deployment.ClientName);
+
+        return await GetVoicesAsync(deployment, static (provider, connection, model) => provider.GetRealtimeVoicesAsync(connection, model));
+    }
+
+    /// <summary>
+    /// Reads the voices of a deployment from the first client provider that can handle it.
+    /// </summary>
+    /// <param name="deployment">The deployment whose voices are wanted.</param>
+    /// <param name="read">Reads the voices from the resolved provider.</param>
+    private async Task<SpeechVoice[]> GetVoicesAsync(
+        AIDeployment deployment,
+        Func<IAIClientProvider, AIProviderConnectionEntry, string, Task<SpeechVoice[]>> read)
+    {
         ArgumentException.ThrowIfNullOrEmpty(deployment.ClientName);
 
         var connectionEntry = await GetConnectionEntryAsync(deployment);
@@ -54,7 +89,7 @@ public sealed class DefaultRealtimeVoiceResolver : IRealtimeVoiceResolver
                 continue;
             }
 
-            return await clientProvider.GetRealtimeVoicesAsync(connectionEntry, deployment.ModelName);
+            return await read(clientProvider, connectionEntry, deployment.ModelName);
         }
 
         return [];

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CascadedRealtimeSessionTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CascadedRealtimeSessionTests.cs
@@ -1,0 +1,366 @@
+#pragma warning disable MEAI001 // The realtime API from Microsoft.Extensions.AI is for evaluation purposes only.
+#nullable enable
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using CrestApps.Core.AI.Realtime;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CrestApps.Core.Tests.Core.Realtime;
+
+/// <summary>
+/// Verifies that <see cref="CascadedRealtimeSession"/> turns three ordinary clients into something that
+/// behaves like a speech-to-speech provider: the user's transcript starts a turn, the reply is streamed as
+/// transcript and audio, and speaking over the assistant cuts the reply short.
+/// </summary>
+public sealed class CascadedRealtimeSessionTests
+{
+    private static readonly byte[] _audioChunk = [1, 2, 3, 4];
+
+    [Fact]
+    public async Task Session_TurnsACommittedTranscriptIntoASpokenReply()
+    {
+        var transcription = new FakeTranscriptionSession();
+        await using var session = CreateSession(transcription, out _, reply: "All good.");
+
+        transcription.Emit(Completed("turn the lights on"));
+        transcription.Complete();
+
+        var messages = await ReadAllAsync(session);
+
+        // The user's own transcript is passed through so the caller can show what was heard...
+        Assert.Contains(messages, message => message.Type == RealtimeServerMessageType.InputAudioTranscriptionCompleted);
+
+        // ...then the reply arrives as a response, with transcript and audio, and is closed off.
+        Assert.Contains(messages, message => message.Type == RealtimeServerMessageType.ResponseCreated);
+        Assert.Contains(messages, message => message.Type == RealtimeServerMessageType.OutputAudioTranscriptionDelta);
+        Assert.Contains(messages, message => message.Type == RealtimeServerMessageType.OutputAudioTranscriptionDone);
+        Assert.Contains(messages, message => message.Type == RealtimeServerMessageType.ResponseDone);
+
+        var audio = messages
+            .OfType<OutputTextAudioRealtimeServerMessage>()
+            .Where(message => message.Type == RealtimeServerMessageType.OutputAudioDelta)
+            .ToList();
+
+        Assert.NotEmpty(audio);
+        Assert.Equal(Convert.ToBase64String(_audioChunk), audio[0].Audio);
+    }
+
+    [Fact]
+    public async Task Session_SendsTheUserTranscriptToTheChatClient()
+    {
+        var transcription = new FakeTranscriptionSession();
+        await using var session = CreateSession(transcription, out var chatClient, reply: "Done.");
+
+        transcription.Emit(Completed("turn the lights on"));
+        transcription.Complete();
+
+        await ReadAllAsync(session);
+
+        var lastRequest = Assert.Single(chatClient.Requests);
+        Assert.Equal("turn the lights on", lastRequest.Last(message => message.Role == ChatRole.User).Text);
+    }
+
+    // The instructions the orchestrator resolved for the profile are what make the assistant answer in
+    // character, so they have to reach the chat leg as a system message.
+    [Fact]
+    public async Task Session_PutsTheSessionInstructionsAtTheHeadOfTheConversation()
+    {
+        var transcription = new FakeTranscriptionSession();
+        await using var session = CreateSession(transcription, out var chatClient, reply: "Done.", instructions: "You are terse.");
+
+        transcription.Emit(Completed("hello"));
+        transcription.Complete();
+
+        await ReadAllAsync(session);
+
+        var request = Assert.Single(chatClient.Requests);
+        Assert.Equal(ChatRole.System, request[0].Role);
+        Assert.Equal("You are terse.", request[0].Text);
+    }
+
+    [Fact]
+    public async Task Session_KeepsTheReplyInHistoryForTheNextTurn()
+    {
+        var transcription = new FakeTranscriptionSession();
+        await using var session = CreateSession(transcription, out var chatClient, reply: "The lights are on.");
+
+        transcription.Emit(Completed("turn the lights on"));
+        transcription.Emit(Completed("and the kettle"));
+        transcription.Complete();
+
+        await ReadAllAsync(session);
+
+        Assert.Equal(2, chatClient.Requests.Count);
+
+        var secondRequest = chatClient.Requests[1];
+        Assert.Contains(secondRequest, message => message.Role == ChatRole.Assistant && message.Text == "The lights are on.");
+    }
+
+    // Speaking over the assistant has to stop the reply, or the user is talked over for as long as the
+    // model keeps writing. The fake reply is held open indefinitely, so the only thing that can end this
+    // turn is the interruption cancelling it; the timeout turns a regression into a failure, not a hang.
+    [Fact(Timeout = 30000)]
+    public async Task Session_StopsSpeakingWhenTheUserTalksOverTheReply()
+    {
+        var transcription = new FakeTranscriptionSession();
+        var chatClient = new FakeChatClient(["Part one. ", "Part two. ", "Part three. "]);
+        var speechClient = new FakeSpeechClient(_audioChunk);
+
+        await using var session = new CascadedRealtimeSession(
+            transcription,
+            chatClient,
+            speechClient,
+            new RealtimeSessionOptions(),
+            chatOptions: null,
+            speechOptions: new TextToSpeechOptions(),
+            NullLogger.Instance);
+
+        session.Start();
+
+        transcription.Emit(Completed("tell me a story"));
+
+        // Wait until the reply is actually being spoken before interrupting it.
+        await chatClient.Streaming.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        transcription.Emit(new InputAudioTranscriptionRealtimeServerMessage(RealtimeServerMessageType.InputAudioTranscriptionDelta)
+        {
+            Transcription = "actually",
+        });
+
+        transcription.Complete();
+
+        var messages = await ReadAllAsync(session);
+
+        // The caller is told to drop audio it has already buffered...
+        var flush = messages.FirstOrDefault(message => message.Type == RealtimeServerMessageType.RawContentOnly);
+        Assert.NotNull(flush);
+
+        var element = Assert.IsType<JsonElement>(flush!.RawRepresentation);
+        Assert.Equal("input_audio_buffer.speech_started", element.GetProperty("type").GetString());
+
+        // ...and the reply is closed as cancelled rather than completed.
+        var done = messages
+            .OfType<ResponseCreatedRealtimeServerMessage>()
+            .Last(message => message.Type == RealtimeServerMessageType.ResponseDone);
+
+        Assert.Equal(RealtimeResponseStatus.Cancelled, done.Status);
+    }
+
+    [Fact]
+    public async Task SendAsync_ForwardsToTheTranscriptionLeg()
+    {
+        var transcription = new FakeTranscriptionSession();
+        await using var session = CreateSession(transcription, out _, reply: "Done.");
+
+        var message = new InputAudioBufferCommitRealtimeClientMessage();
+        await session.SendAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.Same(message, Assert.Single(transcription.Sent));
+    }
+
+    [Theory]
+    // A complete sentence past the minimum length is spoken on its own.
+    [InlineData("The lights are now on in the kitchen. And ", "The lights are now on in the kitchen.", " And ")]
+    // A decimal point is not the end of a sentence.
+    [InlineData("The reading was 3.5 degrees below the target. ", "The reading was 3.5 degrees below the target.", " ")]
+    // Too short to speak well on its own, so it waits for more text.
+    [InlineData("Sure. ", null, "Sure. ")]
+    public void TryTakeSpeakableFragment_SplitsOnSentencesWorthSpeaking(string pending, string? expected, string remaining)
+    {
+        var builder = new StringBuilder(pending);
+
+        var taken = CascadedRealtimeSession.TryTakeSpeakableFragment(builder, out var fragment);
+
+        Assert.Equal(expected is not null, taken);
+
+        if (expected is not null)
+        {
+            Assert.Equal(expected, fragment);
+        }
+
+        Assert.Equal(remaining, builder.ToString());
+    }
+
+    private static CascadedRealtimeSession CreateSession(
+        FakeTranscriptionSession transcription,
+        out FakeChatClient chatClient,
+        string reply,
+        string? instructions = null)
+    {
+        chatClient = new FakeChatClient([reply]);
+
+        var session = new CascadedRealtimeSession(
+            transcription,
+            chatClient,
+            new FakeSpeechClient(_audioChunk),
+            new RealtimeSessionOptions { Instructions = instructions },
+            chatOptions: null,
+            speechOptions: new TextToSpeechOptions(),
+            NullLogger.Instance);
+
+        session.Start();
+
+        return session;
+    }
+
+    private static InputAudioTranscriptionRealtimeServerMessage Completed(string text)
+    {
+        return new InputAudioTranscriptionRealtimeServerMessage(RealtimeServerMessageType.InputAudioTranscriptionCompleted)
+        {
+            Transcription = text,
+        };
+    }
+
+    private static async Task<List<RealtimeServerMessage>> ReadAllAsync(CascadedRealtimeSession session)
+    {
+        var messages = new List<RealtimeServerMessage>();
+
+        await foreach (var message in session.GetStreamingResponseAsync(TestContext.Current.CancellationToken))
+        {
+            messages.Add(message);
+        }
+
+        return messages;
+    }
+
+    private sealed class FakeTranscriptionSession : IRealtimeClientSession
+    {
+        private readonly Channel<RealtimeServerMessage> _messages = Channel.CreateUnbounded<RealtimeServerMessage>();
+
+        public RealtimeSessionOptions? Options => null;
+
+        public List<RealtimeClientMessage> Sent { get; } = [];
+
+        public void Emit(RealtimeServerMessage message)
+        {
+            _messages.Writer.TryWrite(message);
+        }
+
+        public void Complete()
+        {
+            _messages.Writer.TryComplete();
+        }
+
+        public Task SendAsync(RealtimeClientMessage message, CancellationToken cancellationToken = default)
+        {
+            Sent.Add(message);
+
+            return Task.CompletedTask;
+        }
+
+        public IAsyncEnumerable<RealtimeServerMessage> GetStreamingResponseAsync(CancellationToken cancellationToken = default)
+        {
+            return _messages.Reader.ReadAllAsync(cancellationToken);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            return null;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Complete();
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeChatClient : IChatClient
+    {
+        private readonly string[] _updates;
+        private readonly TaskCompletionSource _held = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public FakeChatClient(string[] updates)
+        {
+            _updates = updates;
+        }
+
+        /// <summary>
+        /// Completes once the client has produced its first update, so a test can interrupt a reply that
+        /// is genuinely in flight instead of racing the turn.
+        /// </summary>
+        public TaskCompletionSource Streaming { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<IReadOnlyList<ChatMessage>> Requests { get; } = [];
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Requests.Add([.. messages]);
+
+            for (var index = 0; index < _updates.Length; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                yield return new ChatResponseUpdate(ChatRole.Assistant, _updates[index]);
+
+                if (index == 0 && _updates.Length > 1)
+                {
+                    // Hold the reply open after the first update so an interruption lands mid-reply. Only
+                    // cancelling the turn releases it, which is exactly what the interruption should do.
+                    Streaming.TrySetResult();
+
+                    await _held.Task.WaitAsync(cancellationToken);
+                }
+            }
+
+            Streaming.TrySetResult();
+        }
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            return null;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class FakeSpeechClient : ITextToSpeechClient
+    {
+        private readonly byte[] _audio;
+
+        public FakeSpeechClient(byte[] audio)
+        {
+            _audio = audio;
+        }
+
+        public async IAsyncEnumerable<TextToSpeechResponseUpdate> GetStreamingAudioAsync(
+            string text,
+            TextToSpeechOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            yield return new TextToSpeechResponseUpdate([new DataContent(_audio, "audio/pcm")]);
+
+            await Task.CompletedTask;
+        }
+
+        public Task<TextToSpeechResponse> GetAudioAsync(string text, TextToSpeechOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+        {
+            return null;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
Realtime voice currently requires a provider that ships a speech-to-speech model. Most providers do not, so their deployments cannot serve the realtime experience at all.

This adds a **cascaded realtime deployment**: one that answers speech with speech by chaining three deployments you already have.

```
mic ──▶ realtime speech-to-text ──▶ chat (tools, data sources) ──▶ text-to-speech ──▶ speaker
```

The legs may come from different vendors — transcribe with one, reason with another, speak with a third.

## What's here

- **`CascadedRealtimeMetadata`** — stored on an `AIDeployment`, naming the three deployments to chain. The deployment still declares the `realtime` feature, so the orchestrator resolves it the usual way.
- **`CascadedRealtimeClient` / `CascadedRealtimeSession`** — the turn engine. A committed transcript starts a turn; the reply streams from the chat leg as transcript deltas and is spoken a sentence at a time so audio begins before the model finishes writing; the turn closes with `ResponseDone`.
- **`DefaultAIClientFactory.CreateRealtimeClientAsync`** composes it. This is deliberately *not* an `IAIClientProvider`: a provider only ever sees one connection, so it could never reach three deployments. Guards against a cascade naming another cascade as its transcriber.
- **`DefaultRealtimeVoiceResolver`** now lists the text-to-speech leg's voices for a cascaded deployment, since that is the leg that actually speaks.

The session emits the same `RealtimeServerMessage` types a native provider does, so `DefaultRealtimeConversation` and everything above it — orchestrator, hubs, chat UI, transcripts, turn persistence — work unchanged. The chat leg is built with `UseFunctionInvocation()`, so a voice profile keeps every capability a text profile has.

Interruption is transcription-driven: the first partial transcript arriving while a reply is in flight cancels the turn and emits `input_audio_buffer.speech_started`, which is what tells the client to drop buffered audio.

## Behavior changes worth calling out

- `DefaultRealtimeVoiceResolver` takes an additional `IAIDeploymentStore` constructor argument. Hosts that resolve it from the container are unaffected.
- The orchestrator no longer substitutes its OpenAI fallback voice (`alloy`) when a **cascaded** deployment has no voice selected. That name is meaningless to another vendor's speech model and would be rejected, so the voice is left unset and the speaking provider applies its own default. Non-cascaded deployments are unchanged.

## Verification

- `dotnet build CrestApps.Core.slnx -c Release` — clean, 0 warnings.
- `CrestApps.Core.Tests` — 2955/2955 pass, including 9 new tests covering the turn sequence, history carry-over, instructions reaching the chat leg, interruption, and sentence splitting.
- Docs site builds. New section in **Realtime Voice** plus a `2.0.0` changelog entry.

**Not covered:** no live audio. The turn engine, interruption, and history are tested against fakes, but nothing has run end to end against real services. Expect first-session tuning on latency (three services per turn) and on the sentence-splitting threshold, which only sounds right or wrong out loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
