### PR TITLE
Make the cascade's speaking leg work with any provider

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -54,6 +54,15 @@ text-to-speech deployment into a single `IRealtimeClient`, and may mix vendors a
   that is the deployment that actually speaks.
 - `DefaultRealtimeVoiceResolver` takes an additional `IAIDeploymentStore` constructor argument to reach that
   leg. Hosts that resolve it from the container are unaffected.
+- the text-to-speech leg must answer with raw PCM (`audio/L16` or `audio/pcm`) at the session's output rate.
+  Realtime audio is played as headerless samples, so an MP3 or WAV reply would have been played as noise with
+  nothing reporting a problem; the session now refuses it and names the format it was given.
+- the speech-to-text leg transcribes with its own deployment's model. Previously the model resolved for a
+  native realtime session was forwarded to it, which named a model of a different provider entirely.
+- `AzureSpeechServiceTextToSpeechClient` honors `TextToSpeechOptions.AudioFormat` instead of always
+  synthesizing 16 kHz MP3, and reports the matching media type. Raw PCM, RIFF/WAV, and MP3 are selectable by
+  name (`Pcm24000`, `Riff16000`, `Mp3`, and so on), as are the Speech SDK's own format names; MP3 remains the
+  default. This is what lets Azure Speech serve as the speaking leg of a cascaded realtime deployment.
 - the realtime orchestrator no longer substitutes its OpenAI fallback voice (`alloy`) when a cascaded
   deployment has no voice selected. That name is meaningless to another vendor's speech model and would be
   rejected, so the voice is left unset and the speaking provider applies its own configured default.

--- a/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
+++ b/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
@@ -55,11 +55,18 @@ deployment.Alter<AIDeploymentMetadata>(metadata =>
 What to expect from each leg:
 
 - **Speech-to-text** must expose a realtime client that supports a transcription session. It hears the user
-  continuously; a committed transcript is what ends the user's turn and starts the reply.
+  continuously; a committed transcript is what ends the user's turn and starts the reply. It transcribes with
+  its own deployment's model, not the one a native realtime session would name.
 - **Chat** produces the reply. Tools, data sources, and the profile's system message are applied here, so a
   cascaded session keeps every capability a text profile has. Function invocation is applied automatically.
 - **Text-to-speech** speaks the reply. The reply is spoken a sentence at a time so audio starts playing while
   the model is still writing, and the voice picker for the deployment lists this leg's voices.
+
+  It must answer with **raw PCM** at the session's output sample rate — `audio/L16` or `audio/pcm`. Realtime
+  audio is played as headerless samples, so a reply encoded as MP3 or wrapped in a WAV container would be
+  played as noise. The session refuses anything else rather than emitting it, naming the format it was given.
+  Providers are asked for `Pcm<rate>` (for example `Pcm24000`); a provider that cannot produce raw PCM cannot
+  serve this leg.
 
 Two differences from a native speech-to-speech model are worth planning for. Latency is higher, because a turn
 passes through three services instead of one. And interruption is driven by transcription: when the user

--- a/src/Primitives/CrestApps.Core.AI.OpenAI.Azure/Services/AzureSpeechServiceTextToSpeechClient.cs
+++ b/src/Primitives/CrestApps.Core.AI.OpenAI.Azure/Services/AzureSpeechServiceTextToSpeechClient.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Azure.Core;
 using Azure.Identity;
@@ -19,6 +19,30 @@ public sealed class AzureSpeechServiceTextToSpeechClient : ITextToSpeechClient
 {
     private const string CognitiveServicesScope = "https://cognitiveservices.azure.com/.default";
     private const string DefaultContentType = "audio/mp3";
+
+    // Raw PCM carries no container to describe itself, so callers that decode it — the realtime pipeline,
+    // for one — rely on this media type to know what the bytes are.
+    private const string PcmContentType = "audio/L16";
+
+    private static readonly SpeechSynthesisOutputFormat _defaultOutputFormat = SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3;
+
+    // The formats a caller can ask for by name. Raw PCM is what an audio pipeline wants; MP3 is what a
+    // browser plays directly, and stays the default.
+    private static readonly Dictionary<string, SpeechSynthesisOutputFormat> _outputFormats = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["pcm8000"] = SpeechSynthesisOutputFormat.Raw8Khz16BitMonoPcm,
+        ["pcm16000"] = SpeechSynthesisOutputFormat.Raw16Khz16BitMonoPcm,
+        ["pcm24000"] = SpeechSynthesisOutputFormat.Raw24Khz16BitMonoPcm,
+        ["pcm48000"] = SpeechSynthesisOutputFormat.Raw48Khz16BitMonoPcm,
+        ["riff8000"] = SpeechSynthesisOutputFormat.Riff8Khz16BitMonoPcm,
+        ["riff16000"] = SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm,
+        ["riff24000"] = SpeechSynthesisOutputFormat.Riff24Khz16BitMonoPcm,
+        ["riff48000"] = SpeechSynthesisOutputFormat.Riff48Khz16BitMonoPcm,
+        ["mp3"] = SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3,
+        ["mp3_16000"] = SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3,
+        ["mp3_24000"] = SpeechSynthesisOutputFormat.Audio24Khz48KBitRateMonoMp3,
+        ["mp3_48000"] = SpeechSynthesisOutputFormat.Audio48Khz96KBitRateMonoMp3,
+    };
 
     private static readonly string[] _regionSuffixes =
     [
@@ -102,7 +126,7 @@ public sealed class AzureSpeechServiceTextToSpeechClient : ITextToSpeechClient
 
             return new TextToSpeechResponse(new List<AIContent>
             {
-                new DataContent(result.AudioData, DefaultContentType),
+                new DataContent(result.AudioData, ResolveContentType(options?.AudioFormat)),
             });
         }
 
@@ -141,6 +165,7 @@ public sealed class AzureSpeechServiceTextToSpeechClient : ITextToSpeechClient
         }
 
         var speechConfig = await CreateSpeechConfigAsync(options, cancellationToken);
+        var contentType = ResolveContentType(options?.AudioFormat);
 
         // Use null audio config to get in-memory audio.
         using var synthesizer = new SpeechSynthesizer(speechConfig, null);
@@ -162,7 +187,7 @@ public sealed class AzureSpeechServiceTextToSpeechClient : ITextToSpeechClient
 
                 channel.Writer.TryWrite(new TextToSpeechResponseUpdate(new List<AIContent>
                 {
-                    new DataContent(e.Result.AudioData, DefaultContentType),
+                    new DataContent(e.Result.AudioData, contentType),
                 })
                 {
                     Kind = TextToSpeechResponseUpdateKind.AudioUpdating,
@@ -335,10 +360,101 @@ public sealed class AzureSpeechServiceTextToSpeechClient : ITextToSpeechClient
             config.SpeechSynthesisLanguage = options.Language;
         }
 
-        // Default to MP3 output for browser compatibility.
-        config.SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat.Audio16Khz32KBitRateMonoMp3);
+        // MP3 stays the default, for browser compatibility. A caller that needs raw PCM — an audio
+        // pipeline that mixes or resamples the result rather than handing it to an <audio> element — asks
+        // for it by name through the options.
+        config.SetSpeechSynthesisOutputFormat(ResolveOutputFormat(options?.AudioFormat));
 
         return config;
+    }
+
+    /// <summary>
+    /// Resolves the synthesis output format a caller asked for by name, falling back to the MP3 default
+    /// when the name is missing or is not one this client offers.
+    /// </summary>
+    /// <param name="audioFormat">The requested format name, such as <c>Pcm24000</c>.</param>
+    private static SpeechSynthesisOutputFormat ResolveOutputFormat(string audioFormat)
+    {
+        if (string.IsNullOrWhiteSpace(audioFormat))
+        {
+            return _defaultOutputFormat;
+        }
+
+        // Names arrive in whatever shape the caller uses - "Pcm24000", "pcm_24000", "PCM-24000" - so they
+        // are compared with the separators removed.
+        var normalized = Normalize(audioFormat);
+
+        if (_outputFormats.TryGetValue(normalized, out var outputFormat))
+        {
+            return outputFormat;
+        }
+
+        // The Speech SDK's own enum names are accepted too, so a caller that knows this is Azure can ask
+        // for a format this client does not list.
+        if (Enum.TryParse<SpeechSynthesisOutputFormat>(audioFormat, ignoreCase: true, out var parsed))
+        {
+            return parsed;
+        }
+
+        return _defaultOutputFormat;
+    }
+
+    /// <summary>
+    /// Gets the media type describing the audio the requested format produces.
+    /// </summary>
+    /// <param name="audioFormat">The requested format name, such as <c>Pcm24000</c>.</param>
+    private static string ResolveContentType(string audioFormat)
+    {
+        return ToContentType(ResolveOutputFormat(audioFormat));
+    }
+
+    /// <summary>
+    /// Gets the media type describing the audio a synthesis output format produces.
+    /// </summary>
+    /// <param name="outputFormat">The synthesis output format.</param>
+    private static string ToContentType(SpeechSynthesisOutputFormat outputFormat)
+    {
+        var name = outputFormat.ToString();
+
+        if (name.EndsWith("MonoPcm", StringComparison.Ordinal))
+        {
+            // A RIFF format is PCM wrapped in a WAV container, which callers have to be told apart from the
+            // raw stream because the header is not audio.
+            return name.StartsWith("Riff", StringComparison.Ordinal)
+                ? "audio/wav"
+                : PcmContentType;
+        }
+
+        if (name.Contains("Mp3", StringComparison.Ordinal))
+        {
+            return DefaultContentType;
+        }
+
+        if (name.Contains("Opus", StringComparison.Ordinal))
+        {
+            return "audio/opus";
+        }
+
+        if (name.Contains("Webm", StringComparison.Ordinal))
+        {
+            return "audio/webm";
+        }
+
+        if (name.Contains("MULaw", StringComparison.Ordinal))
+        {
+            return "audio/basic";
+        }
+
+        return DefaultContentType;
+    }
+
+    /// <summary>
+    /// Removes the separators a format name may be written with so names compare regardless of style.
+    /// </summary>
+    /// <param name="value">The format name.</param>
+    private static string Normalize(string value)
+    {
+        return new string([.. value.Where(char.IsLetterOrDigit)]);
     }
 
     private async Task<SpeechConfig> CreateRegionBasedConfigAsync(string region, CancellationToken cancellationToken)

--- a/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeClient.cs
+++ b/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeClient.cs
@@ -20,6 +20,7 @@ public sealed class CascadedRealtimeClient : IRealtimeClient
     private readonly IRealtimeClient _transcriptionClient;
     private readonly IChatClient _chatClient;
     private readonly ITextToSpeechClient _speechClient;
+    private readonly string? _transcriptionModelId;
     private readonly string? _speechModelId;
     private readonly ILogger<CascadedRealtimeClient> _logger;
 
@@ -29,18 +30,21 @@ public sealed class CascadedRealtimeClient : IRealtimeClient
     /// <param name="transcriptionClient">The realtime client that transcribes the user's speech.</param>
     /// <param name="chatClient">The chat client that generates the reply. Supply one that already has function invocation applied when the session should be able to call tools.</param>
     /// <param name="speechClient">The text-to-speech client that speaks the reply.</param>
+    /// <param name="transcriptionModelId">The model the speech-to-text deployment should use, or <see langword="null"/> for its default.</param>
     /// <param name="speechModelId">The model the text-to-speech deployment should use, or <see langword="null"/> for its default.</param>
     /// <param name="logger">The logger.</param>
     public CascadedRealtimeClient(
         IRealtimeClient transcriptionClient,
         IChatClient chatClient,
         ITextToSpeechClient speechClient,
+        string? transcriptionModelId,
         string? speechModelId,
         ILogger<CascadedRealtimeClient> logger)
     {
         _transcriptionClient = transcriptionClient;
         _chatClient = chatClient;
         _speechClient = speechClient;
+        _transcriptionModelId = transcriptionModelId;
         _speechModelId = speechModelId;
         _logger = logger;
     }
@@ -111,15 +115,41 @@ public sealed class CascadedRealtimeClient : IRealtimeClient
     /// over: the reply is produced by the chat leg, not by the transcriber.
     /// </summary>
     /// <param name="options">The session options the caller requested.</param>
-    private static RealtimeSessionOptions BuildTranscriptionOptions(RealtimeSessionOptions? options)
+    private RealtimeSessionOptions BuildTranscriptionOptions(RealtimeSessionOptions? options)
     {
         return new RealtimeSessionOptions
         {
             SessionKind = RealtimeSessionKind.Transcription,
             InputAudioFormat = options?.InputAudioFormat,
-            TranscriptionOptions = options?.TranscriptionOptions,
+            TranscriptionOptions = BuildTranscriptionModelOptions(options),
             VoiceActivityDetection = options?.VoiceActivityDetection,
             RawRepresentationFactory = options?.RawRepresentationFactory,
+        };
+    }
+
+    /// <summary>
+    /// Builds the transcription options for the speech-to-text leg, naming that leg's own model.
+    /// </summary>
+    /// <param name="options">The session options the caller requested.</param>
+    /// <remarks>
+    /// The caller's transcription model names a model of whichever provider serves a native realtime
+    /// session, which is rarely the provider transcribing here. Forwarding it would ask this provider for a
+    /// model it has never heard of, so the speech-to-text deployment's own model wins.
+    /// </remarks>
+    private TranscriptionOptions? BuildTranscriptionModelOptions(RealtimeSessionOptions? options)
+    {
+        if (string.IsNullOrWhiteSpace(_transcriptionModelId) && options?.TranscriptionOptions is null)
+        {
+            return null;
+        }
+
+        return new TranscriptionOptions
+        {
+            ModelId = string.IsNullOrWhiteSpace(_transcriptionModelId)
+                ? options?.TranscriptionOptions?.ModelId
+                : _transcriptionModelId,
+            SpeechLanguage = options?.TranscriptionOptions?.SpeechLanguage,
+            Prompt = options?.TranscriptionOptions?.Prompt,
         };
     }
 

--- a/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeSession.cs
+++ b/src/Primitives/CrestApps.Core.AI/Realtime/CascadedRealtimeSession.cs
@@ -33,6 +33,11 @@ internal sealed class CascadedRealtimeSession : IRealtimeClientSession
     // words to a speech model produces clipped, oddly-cadenced audio.
     private const int MinimumSpeakableLength = 24;
 
+    // Assistant audio is emitted straight onto the realtime timeline, where it is played as raw PCM
+    // frames. A speech model that answers with a container instead — MP3, WAV — would be played as noise,
+    // so the format is checked rather than trusted.
+    private const string PcmMediaType = "audio/L16";
+
     private readonly IRealtimeClientSession _transcription;
     private readonly IChatClient _chatClient;
     private readonly ITextToSpeechClient _speechClient;
@@ -366,6 +371,11 @@ internal sealed class CascadedRealtimeSession : IRealtimeClientSession
                     continue;
                 }
 
+                if (!IsRawPcm(audio.MediaType))
+                {
+                    throw new NotSupportedException($"The text-to-speech deployment answered with '{audio.MediaType}' audio, but a realtime session plays raw PCM ('{PcmMediaType}'). Configure that deployment to produce raw PCM at the session's output sample rate, or choose one that can.");
+                }
+
                 await WriteAsync(new OutputTextAudioRealtimeServerMessage(RealtimeServerMessageType.OutputAudioDelta)
                 {
                     Audio = Convert.ToBase64String(audio.Data.Span),
@@ -373,6 +383,20 @@ internal sealed class CascadedRealtimeSession : IRealtimeClientSession
                 });
             }
         }
+    }
+
+    /// <summary>
+    /// Determines whether a media type describes raw, headerless PCM samples.
+    /// </summary>
+    /// <param name="mediaType">The media type reported by the speech model.</param>
+    /// <remarks>
+    /// <c>audio/L16</c> is the registered type for linear PCM; <c>audio/pcm</c> is the informal spelling the
+    /// realtime APIs use for the same bytes. Both are accepted, and everything else is refused.
+    /// </remarks>
+    internal static bool IsRawPcm(string? mediaType)
+    {
+        return string.Equals(mediaType, PcmMediaType, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(mediaType, "audio/pcm", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Services/DefaultAIClientFactory.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DefaultAIClientFactory.cs
@@ -1,4 +1,4 @@
-using CrestApps.Core.AI.Capabilities;
+﻿using CrestApps.Core.AI.Capabilities;
 using CrestApps.Core.AI.Clients;
 using CrestApps.Core.AI.Connections;
 using CrestApps.Core.AI.Deployments;
@@ -273,6 +273,7 @@ public sealed class DefaultAIClientFactory : IAIClientFactory
                 transcriptionClient,
                 chatClient,
                 speechClient,
+                speechToText.ModelName,
                 textToSpeech.ModelName,
                 _serviceProvider.GetRequiredService<ILogger<CascadedRealtimeClient>>());
         }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CascadedRealtimeSessionTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CascadedRealtimeSessionTests.cs
@@ -149,6 +149,47 @@ public sealed class CascadedRealtimeSessionTests
         Assert.Equal(RealtimeResponseStatus.Cancelled, done.Status);
     }
 
+    // A speech model that answers with a container instead of raw samples would be played as noise, with
+    // nothing anywhere reporting a problem, so the format is checked rather than trusted.
+    [Fact]
+    public async Task Session_RefusesAudioThatIsNotRawPcm()
+    {
+        var transcription = new FakeTranscriptionSession();
+
+        await using var session = new CascadedRealtimeSession(
+            transcription,
+            new FakeChatClient(["All good."]),
+            new FakeSpeechClient(_audioChunk, mediaType: "audio/mp3"),
+            new RealtimeSessionOptions(),
+            chatOptions: null,
+            speechOptions: new TextToSpeechOptions(),
+            NullLogger.Instance);
+
+        session.Start();
+
+        transcription.Emit(Completed("hello"));
+        transcription.Complete();
+
+        var messages = await ReadAllAsync(session);
+
+        var error = Assert.Single(messages.OfType<ErrorRealtimeServerMessage>());
+        Assert.Contains("audio/mp3", error.Error?.Message);
+
+        Assert.DoesNotContain(messages, message => message.Type == RealtimeServerMessageType.OutputAudioDelta);
+    }
+
+    [Theory]
+    [InlineData("audio/L16", true)]
+    [InlineData("audio/l16", true)]
+    [InlineData("audio/pcm", true)]
+    [InlineData("audio/mp3", false)]
+    [InlineData("audio/wav", false)]
+    [InlineData(null, false)]
+    public void IsRawPcm_AcceptsOnlyHeaderlessSamples(string? mediaType, bool expected)
+    {
+        Assert.Equal(expected, CascadedRealtimeSession.IsRawPcm(mediaType));
+    }
+
     [Fact]
     public async Task SendAsync_ForwardsToTheTranscriptionLeg()
     {
@@ -331,10 +372,12 @@ public sealed class CascadedRealtimeSessionTests
     private sealed class FakeSpeechClient : ITextToSpeechClient
     {
         private readonly byte[] _audio;
+        private readonly string _mediaType;
 
-        public FakeSpeechClient(byte[] audio)
+        public FakeSpeechClient(byte[] audio, string mediaType = "audio/pcm")
         {
             _audio = audio;
+            _mediaType = mediaType;
         }
 
         public async IAsyncEnumerable<TextToSpeechResponseUpdate> GetStreamingAudioAsync(
@@ -344,7 +387,7 @@ public sealed class CascadedRealtimeSessionTests
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            yield return new TextToSpeechResponseUpdate([new DataContent(_audio, "audio/pcm")]);
+            yield return new TextToSpeechResponseUpdate([new DataContent(_audio, _mediaType)]);
 
             await Task.CompletedTask;
         }


### PR DESCRIPTION
Follow-up to #163. Testing revealed that a cascaded realtime deployment could only ever have worked with one specific provider. This is everything needed to make it work generally — deliberately scoped so no further package is required to get a cascade running end to end.

## The bug

The session took whatever bytes the text-to-speech leg returned, base64'd them, and emitted them as `OutputAudioDelta` — which is played as **raw PCM16 frames**. That only works if the speech client happens to answer in raw PCM.

`AzureSpeechServiceTextToSpeechClient` — the only text-to-speech client in this repo — hardcoded `SetSpeechSynthesisOutputFormat(Audio16Khz32KBitRateMonoMp3)` and ignored `TextToSpeechOptions.AudioFormat` entirely. So a cascade built on Azure Speech played **noise**, with nothing anywhere reporting a problem. It happened to work with ElevenLabs downstream only because that client honors the requested format.

## Three fixes

**1. Azure Speech honors `AudioFormat`.** Raw PCM, RIFF/WAV, and MP3 are selectable by name (`Pcm24000`, `Riff16000`, `Mp3`, …), as are the Speech SDK's own enum names. MP3 stays the default for browser playback. The `DataContent` media type now reports what was actually produced instead of always claiming `audio/mp3`. This is what lets Azure Speech serve as a cascade's speaking leg at all.

**2. The session refuses audio it cannot play.** Anything that is not headerless PCM (`audio/L16` / `audio/pcm`) is rejected with a message naming the format returned, rather than emitted as noise. This is the same rule applied elsewhere in this work — fail loudly rather than produce garbage — which I had not applied to the cascade's own output.

**3. Each leg uses its own deployment's model.** The transcription model resolved for a *native* realtime session was being forwarded to the transcribing leg. That model name belongs to whichever provider serves native realtime — with OpenAI's default being `whisper-1` — so a cascade whose transcriber was a different vendor was handed a model that vendor has never heard of. The speech-to-text deployment's own model now wins.

## Why these three together

With #163 alone a cascade is unusable outside one provider. (1) makes Azure Speech viable, (3) makes a mixed-vendor chain viable, and (2) means that if a future provider still gets it wrong you get an error naming the cause instead of a mystery.

I also checked the seams that would otherwise have forced another release: `OpenAIRealtimeClient` does honor `RealtimeSessionKind.Transcription` (so OpenAI can serve the transcribing leg), it ignores a foreign `RawRepresentationFactory` safely, Azure Speech implements `GetSpeechVoicesAsync` (so the cascade's voice picker populates), and `Raw24Khz16BitMonoPcm` matches the pipeline's 24 kHz. Those all work as-is.

## Verification

- `dotnet build CrestApps.Core.slnx -c Release -warnaserror /p:TreatWarningsAsErrors=true /p:RunAnalyzers=true` — clean, 0 warnings.
- `CrestApps.Core.Tests` — 2962/2962 pass, including new tests for the PCM guard and media-type rule.
- Docs site builds; Realtime Voice and the `2.0.0` changelog updated.

**Not covered:** still no live session. This is what should make the first one possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
