### PR TITLE
Make the chat hub options actually apply

### DIFF
--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -50,7 +50,13 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.Configure<HubOptions<THub>>(options =>
+        // AddHubOptions, not services.Configure<HubOptions<THub>>. SignalR reads the typed options only when
+        // they were configured through this API, which sets an internal UserHasSetValues flag. Configured the
+        // other way the values are assigned and then ignored: HubConnectionHandler falls back to the global
+        // HubOptions, so everything below silently had no effect. Measured by resolving the handler and reading
+        // its private state -- with services.Configure<HubOptions<T>> it reports _maxParallelInvokes = 1 and
+        // _maximumMessageSize = 32768 no matter what is set here.
+        services.AddSignalR().AddHubOptions<THub>(options =>
         {
             // Allow long-running operations (e.g., multi-step MCP tool calls)
             // without the server dropping the connection prematurely.

--- a/src/Primitives/CrestApps.Core.SignalR/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.SignalR/ServiceCollectionExtensions.cs
@@ -23,7 +23,26 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton(new HubRouteManager(pathPrefix));
 
-        return services.AddSignalR()
+        return services.AddSignalR(options =>
+            {
+                // Defaults every hub in this host inherits, so a hub that never calls
+                // ConfigureCrestAppsChatHubOptions cannot silently run with settings that break realtime
+                // signaling. Only the two that are safe for unrelated hubs are set here; the chat hubs'
+                // longer timeouts and larger message size stay per hub type.
+
+                // One parallel invocation per client -- SignalR's default -- deadlocks the realtime WebRTC
+                // handshake. StartRealtimeWebRtc holds its invocation open while it waits for the peer to
+                // connect, so the trickled AddRealtimeIceCandidate calls it is waiting for queue up behind
+                // it and ICE can never complete. Loopback hides this completely, because the peer learns the
+                // browser's address as a peer-reflexive candidate from the inbound STUN checks; a remote
+                // host, whose own candidates are unroutable private addresses, has no such path.
+                options.MaximumParallelInvocationsPerClient = 8;
+
+                // The realtime WebSocket transport uploads audio as a client-to-server stream of small
+                // frames. The default buffer of ten fills while the provider session is still opening and
+                // blocks the connection's dispatch loop.
+                options.StreamBufferCapacity = 64;
+            })
             .AddJsonProtocol(options =>
             {
                 options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;


### PR DESCRIPTION
## The finding

`ConfigureCrestAppsChatHubOptions<THub>` configured every value with plain `services.Configure<HubOptions<THub>>` — and **SignalR ignored all of them.**

The typed options are honoured only when configured through `AddHubOptions<THub>`, which sets an internal `UserHasSetValues` flag. Configured any other way, the values are assigned to the options object and then never consulted: `HubConnectionHandler` falls back to the global `HubOptions`.

Measured on this SDK by resolving the handler and reading its private state:

| How the options were configured | `_maxParallelInvokes` | `_maximumMessageSize` |
|---|---|---|
| `services.Configure<HubOptions<T>>` | **1** | **32768** |
| `AddSignalR().AddHubOptions<T>` | 8 | 10485760 |
| `AddSignalR(global)` | 8 | 10485760 |

So none of it applied — not the eight parallel invocations, not the ten-minute client timeout, not the fifteen-second keep-alive, not the ten-megabyte message size, not the sixty-four frame stream buffer — **in any host, on any version, since the method was written.** Every caller ran on SignalR's defaults while looking configured.

That is how a realtime deployment came to fail: with one parallel invocation per client, `StartRealtimeWebRtc` holds its invocation open awaiting the ICE connection while the trickled `AddRealtimeIceCandidate` calls it is waiting for sit in a queue behind it. Observed on Azure — one candidate, sixteen seconds of silence, ICE failure, then all fourteen remaining candidates (including the `srflx` pair that could actually route) delivered in a single burst as the invocation gave up.

**Loopback hides it entirely**: the browser reaches the server's host candidate directly and the peer learns the browser's address as a *peer-reflexive* candidate from the inbound STUN checks, so the trickled candidates are never needed. No amount of local testing finds this.

## The two changes

**1. `ConfigureCrestAppsChatHubOptions` now uses `AddHubOptions<THub>`.** The internal flag cannot be set from outside SignalR, so this is the only supported route. It needs an `ISignalRServerBuilder`, hence the `AddSignalR()` call — additive and `TryAdd`-based, so safe where SignalR is already registered.

**2. `AddCoreSignalR` sets `MaximumParallelInvocationsPerClient` and `StreamBufferCapacity` as global defaults**, as a safety net for hubs that never call the per-hub method. Only those two: they are harmless to unrelated hubs, whereas a ten-megabyte ceiling on an arbitrary hub is a DoS surface and a ten-minute timeout leaves dead connections lingering.

## Scope

Change 1 fixes every consumer that calls the method — including the OrchardCore modules, which do call it correctly for both `AIChatHub` and `ChatInteractionHub`. **Nothing needs fixing in CrestApps.OrchardCore**; it was always calling a method that silently did nothing.

Change 2 only reaches hosts that build SignalR through `AddCoreSignalR`, which excludes OrchardCore.

Downstream hosts need a package carrying change 1; until then they can set the global `HubOptions` themselves (see rdicorp/CloudSolutions#735 for that shape).

## Still worth doing separately

The hub holding an invocation open across the ICE handshake is fragile even at eight parallel invocations. Returning immediately and driving connect/fail through `ReceiveRealtimeEvent`, which the client already handles, removes the dependency altogether. Left for its own PR.

## Verification

`CrestApps.Core.AI.Chat` and `CrestApps.Core.SignalR` build clean. The three-row table above comes from a harness that resolves `HubConnectionHandler<T>` and reflects `_maxParallelInvokes` / `_maximumMessageSize`. A full sample-host build could not run: Visual Studio and a running `CrestApps.Core.Mvc.Web` hold the output DLLs.

Related: #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
