### PR TITLE
Hold trickled ICE candidates until their peer exists

### DIFF
--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
@@ -1438,7 +1438,7 @@ public class AIChatHubCore<TClient> : Hub<TClient>
         return RunInScopeAsync(services =>
         {
             var registry = services.GetRequiredService<WebRtcRealtimePeerRegistry>();
-            registry.Get(connectionId)?.AddIceCandidate(new WebRtcIceCandidate
+            registry.AddIceCandidate(connectionId, new WebRtcIceCandidate
             {
                 Candidate = candidate,
                 SdpMid = sdpMid,

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
@@ -1068,7 +1068,7 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
         return RunInScopeAsync(services =>
         {
             var registry = services.GetRequiredService<WebRtcRealtimePeerRegistry>();
-            registry.Get(connectionId)?.AddIceCandidate(new WebRtcIceCandidate
+            registry.AddIceCandidate(connectionId, new WebRtcIceCandidate
             {
                 Candidate = candidate,
                 SdpMid = sdpMid,

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/WebRtcRealtimePeerRegistry.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/WebRtcRealtimePeerRegistry.cs
@@ -8,14 +8,28 @@ namespace CrestApps.Core.AI.Chat.Realtime;
 /// Tracks the active server-relay WebRTC peer per SignalR connection so trickled ICE candidates — which arrive on
 /// a separate hub invocation than the one that created the peer — can be routed to the right peer. A singleton.
 /// </summary>
+/// <remarks>
+/// Candidates that arrive before their peer exists are held rather than dropped. The browser trickles them the
+/// moment it has them, which is well before the peer finishes being built: creating the SIPSorcery peer binds a
+/// socket, resolves the ICE servers and completes a TURN allocation, then sets the remote description — measured
+/// at over five seconds on a cold App Service instance. Discarding that window leaves the peer with no remote
+/// candidates at all, so it forms no candidate pairs, sends no connectivity checks, and ICE times out with the
+/// browser still in "checking" while both sides hold a perfectly good relay candidate.
+/// </remarks>
 public sealed class WebRtcRealtimePeerRegistry
 {
+    // A browser sends on the order of a dozen candidates. The cap only exists so a client that keeps trickling at
+    // a connection with no peer cannot grow this without bound.
+    private const int MaxPendingCandidates = 64;
+
     private readonly ConcurrentDictionary<string, IWebRtcRealtimePeer> _peers = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Queue<WebRtcIceCandidate>> _pending = new(StringComparer.Ordinal);
 
     /// <summary>
-    /// Registers a connection's peer. A second session on the same connection replaces the first and returns the
-    /// one it displaced, so the caller can dispose it: silently overwriting leaked a live peer that kept holding
-    /// its sockets and pacing loop for the rest of the connection.
+    /// Registers a connection's peer and hands it any candidates that arrived while it was being built. A second
+    /// session on the same connection replaces the first and returns the one it displaced, so the caller can
+    /// dispose it: silently overwriting leaked a live peer that kept holding its sockets and pacing loop for the
+    /// rest of the connection.
     /// </summary>
     /// <param name="connectionId">The SignalR connection id.</param>
     /// <param name="peer">The peer to register.</param>
@@ -29,7 +43,45 @@ public sealed class WebRtcRealtimePeerRegistry
         _peers.TryGetValue(connectionId, out var displaced);
         _peers[connectionId] = peer;
 
+        FlushPending(connectionId);
+
         return ReferenceEquals(displaced, peer) ? null : displaced;
+    }
+
+    /// <summary>
+    /// Routes a trickled ICE candidate to the connection's peer, holding it until the peer exists when it does
+    /// not yet. Candidates are delivered in the order they arrived.
+    /// </summary>
+    /// <param name="connectionId">The SignalR connection id.</param>
+    /// <param name="candidate">The candidate to deliver.</param>
+    public void AddIceCandidate(string connectionId, WebRtcIceCandidate candidate)
+    {
+        if (string.IsNullOrEmpty(connectionId) || candidate is null)
+        {
+            return;
+        }
+
+        var queue = _pending.GetOrAdd(connectionId, static _ => new Queue<WebRtcIceCandidate>());
+
+        // Queueing and draining share the lock so a candidate cannot overtake one already waiting — the browser
+        // signals the end of gathering with an empty candidate, which must not arrive before the real ones.
+        lock (queue)
+        {
+            if (_peers.TryGetValue(connectionId, out var peer) && queue.Count == 0)
+            {
+                peer.AddIceCandidate(candidate);
+
+                return;
+            }
+
+            if (queue.Count < MaxPendingCandidates)
+            {
+                queue.Enqueue(candidate);
+            }
+        }
+
+        // The peer may have registered between the two, in which case nothing else is coming to drain the queue.
+        FlushPending(connectionId);
     }
 
     public IWebRtcRealtimePeer? Get(string connectionId)
@@ -40,6 +92,28 @@ public sealed class WebRtcRealtimePeerRegistry
         if (!string.IsNullOrEmpty(connectionId))
         {
             _peers.TryRemove(connectionId, out _);
+            _pending.TryRemove(connectionId, out _);
+        }
+    }
+
+    private void FlushPending(string connectionId)
+    {
+        if (!_pending.TryGetValue(connectionId, out var queue))
+        {
+            return;
+        }
+
+        lock (queue)
+        {
+            if (!_peers.TryGetValue(connectionId, out var peer))
+            {
+                return;
+            }
+
+            while (queue.Count > 0)
+            {
+                peer.AddIceCandidate(queue.Dequeue());
+            }
         }
     }
 }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/WebRtcRealtimePeerRegistryTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/WebRtcRealtimePeerRegistryTests.cs
@@ -1,0 +1,129 @@
+using CrestApps.Core.AI.Chat.Realtime;
+using CrestApps.Core.AI.Realtime;
+
+namespace CrestApps.Core.Tests.Core.Realtime;
+
+public class WebRtcRealtimePeerRegistryTests
+{
+    [Fact]
+    public void AddIceCandidate_DeliversCandidatesThatArrivedBeforeThePeerWasRegistered()
+    {
+        // The browser trickles its candidates the moment it has them, which is seconds before the peer finishes
+        // being built (socket bind, ICE server DNS, TURN allocation, setRemoteDescription). Dropping that window
+        // left the peer with no remote candidates, so it formed no pairs and ICE timed out on both sides.
+        var registry = new WebRtcRealtimePeerRegistry();
+        var peer = new FakeWebRtcRealtimePeer();
+
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "host" });
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "relay" });
+
+        Assert.Empty(peer.Candidates);
+
+        registry.Add("connection-1", peer);
+
+        Assert.Equal(["host", "relay"], peer.Candidates.Select(c => c.Candidate));
+    }
+
+    [Fact]
+    public void AddIceCandidate_DeliversStraightToAnAlreadyRegisteredPeer()
+    {
+        var registry = new WebRtcRealtimePeerRegistry();
+        var peer = new FakeWebRtcRealtimePeer();
+        registry.Add("connection-1", peer);
+
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "srflx" });
+
+        Assert.Equal(["srflx"], peer.Candidates.Select(c => c.Candidate));
+    }
+
+    [Fact]
+    public void AddIceCandidate_KeepsArrivalOrderAcrossTheRegistrationBoundary()
+    {
+        // The empty candidate is how the browser signals the end of gathering; it must not overtake a real one.
+        var registry = new WebRtcRealtimePeerRegistry();
+        var peer = new FakeWebRtcRealtimePeer();
+
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "host" });
+        registry.Add("connection-1", peer);
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = string.Empty });
+
+        Assert.Equal(["host", ""], peer.Candidates.Select(c => c.Candidate));
+    }
+
+    [Fact]
+    public void AddIceCandidate_DoesNotGrowWithoutBoundForAConnectionThatNeverGetsAPeer()
+    {
+        var registry = new WebRtcRealtimePeerRegistry();
+        var peer = new FakeWebRtcRealtimePeer();
+
+        for (var i = 0; i < 500; i++)
+        {
+            registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = $"host-{i}" });
+        }
+
+        registry.Add("connection-1", peer);
+
+        Assert.Equal(64, peer.Candidates.Count);
+    }
+
+    [Fact]
+    public void Remove_DiscardsCandidatesHeldForThatConnection()
+    {
+        var registry = new WebRtcRealtimePeerRegistry();
+        var peer = new FakeWebRtcRealtimePeer();
+
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "host" });
+        registry.Remove("connection-1");
+        registry.Add("connection-1", peer);
+
+        Assert.Empty(peer.Candidates);
+    }
+
+    [Fact]
+    public void AddIceCandidate_RoutesEachConnectionToItsOwnPeer()
+    {
+        var registry = new WebRtcRealtimePeerRegistry();
+        var first = new FakeWebRtcRealtimePeer();
+        var second = new FakeWebRtcRealtimePeer();
+
+        registry.AddIceCandidate("connection-1", new WebRtcIceCandidate { Candidate = "first" });
+        registry.AddIceCandidate("connection-2", new WebRtcIceCandidate { Candidate = "second" });
+        registry.Add("connection-1", first);
+        registry.Add("connection-2", second);
+
+        Assert.Equal(["first"], first.Candidates.Select(c => c.Candidate));
+        Assert.Equal(["second"], second.Candidates.Select(c => c.Candidate));
+    }
+
+    private sealed class FakeWebRtcRealtimePeer : IWebRtcRealtimePeer
+    {
+        public List<WebRtcIceCandidate> Candidates { get; } = [];
+
+        public string AnswerSdp => string.Empty;
+
+        public int QueuedPlaybackMs => 0;
+
+        public event Action<WebRtcIceCandidate> IceCandidateGenerated { add { } remove { } }
+
+        public event Action Connected { add { } remove { } }
+
+        public event Action Closed { add { } remove { } }
+
+        public void AddIceCandidate(WebRtcIceCandidate candidate)
+            => Candidates.Add(candidate);
+
+        public IAsyncEnumerable<ReadOnlyMemory<byte>> ReadAudioAsync(CancellationToken cancellationToken = default)
+            => AsyncEnumerable.Empty<ReadOnlyMemory<byte>>();
+
+        public void SendAudio(ReadOnlyMemory<byte> pcm24k)
+        {
+        }
+
+        public void FlushPlayback()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## The failure

Realtime WebRTC never connected on Azure App Service. The browser gathered a Cloudflare relay candidate, the server gathered one too, and ICE still timed out with the browser stuck in `checking`:

```
ICE RTP channel failed to connect as no checklist entries became available within 16.02s
```

**No checklist entries** means SIPSorcery formed no candidate pairs at all, so it never sent a single connectivity check. Not a TURN problem — a pairing problem.

## Why

The browser trickles its candidates the moment it has them. Building the peer is far slower: bind a socket, resolve the ICE servers, complete a TURN allocation, then set the remote description. On a staging App Service instance, 5.7 seconds:

| Time | Event |
|---|---|
| 17:12:14.894 | `StartRealtimeWebRtc` received |
| **17:12:15.09–15.18** | **all 14 `AddRealtimeIceCandidate` calls arrive** |
| 17:12:18.94 | RTP socket created |
| 17:12:19.78 | TURN allocate succeeds |
| **17:12:20.42** | `setRemoteDescription` |
| 17:12:20.57 | ICE channel remote credentials set |

Every candidate in that window reached

```csharp
registry.Get(connectionId)?.AddIceCandidate(...)
```

with no peer registered yet — the peer is only registered after `CreateAsync` returns — and the null-conditional dropped it. All fourteen were lost.

This is the other edge of the head-of-line fix in #168. Candidates used to arrive too *late*, blocked behind the invocation waiting for them; now they arrive too *early*.

## The change

Queue candidates per connection in `WebRtcRealtimePeerRegistry` and flush them on registration:

- **Arrival order preserved**, so the empty end-of-gathering candidate cannot overtake a real one.
- **Capped at 64**, so a client trickling at a connection that never gets a peer cannot grow it without bound.
- Both hubs route through the new `AddIceCandidate(connectionId, candidate)`, so the fix is not per-hub.

## Testing

Six tests covering delivery across the registration boundary, direct delivery to a registered peer, ordering, the cap, discard on `Remove`, and per-connection routing. Full suite: 3092 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)