### PR TITLE
Say which ICE candidate was refused instead of only that none paired

### DIFF
--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeIceTransportPolicy.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeIceTransportPolicy.cs
@@ -1,0 +1,26 @@
+namespace CrestApps.Core.AI.Realtime;
+
+/// <summary>
+/// Which ICE candidates the server offers when negotiating a realtime WebRTC session. Mirrors the
+/// <c>RTCIceTransportPolicy</c> of the WebRTC specification.
+/// </summary>
+public enum RealtimeIceTransportPolicy
+{
+    /// <summary>
+    /// Offer every candidate the server gathers: host, server-reflexive and relay. The default, and the fastest
+    /// and cheapest route whenever the two peers can reach each other directly.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Offer only relay candidates, so all media travels through the configured TURN server.
+    /// </summary>
+    /// <remarks>
+    /// Two reasons to choose this. It keeps the server's host and server-reflexive addresses out of the candidate
+    /// list every browser receives, which would otherwise disclose internal addressing to anyone who starts a
+    /// voice session. And it makes the relay path the only path, so a developer machine behaves like a deployment
+    /// whose inbound UDP is blocked, where a direct pair is impossible — without it, a local peer can connect
+    /// directly and a broken relay path looks healthy. It costs a TURN allocation for every session.
+    /// </remarks>
+    Relay,
+}

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeTransportOptions.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeTransportOptions.cs
@@ -1,4 +1,4 @@
-namespace CrestApps.Core.AI.Realtime;
+﻿namespace CrestApps.Core.AI.Realtime;
 
 /// <summary>
 /// Configuration for the realtime WebRTC transport's ICE (NAT traversal) servers. Bound from configuration
@@ -120,4 +120,19 @@ public sealed class RealtimeTransportOptions
     /// Gets or sets a static TURN credential (password). Used only when <see cref="TurnSecret"/> is not set.
     /// </summary>
     public string TurnCredential { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the server offers only TURN relay candidates. Defaults to
+    /// <see langword="false"/>. Intended for diagnosing relay problems, not for production.
+    /// </summary>
+    /// <remarks>
+    /// A server that also offers host and server-reflexive candidates can pair directly with a browser on the
+    /// same machine or LAN, and a direct pair additionally lets ICE paper over remote candidates that never
+    /// arrived, by promoting the source of an inbound connectivity check to a peer-reflexive candidate. Locally
+    /// that turns a broken relay path into a working call, which is why a failure that reproduces every time in a
+    /// deployment where inbound UDP is blocked can be impossible to reproduce on a developer machine. Enabling
+    /// this removes both shortcuts so the relay path is the only path, and the deployed behaviour is what runs
+    /// locally. It costs a TURN allocation for every session, so leave it off outside diagnosis.
+    /// </remarks>
+    public bool ForceRelayOnly { get; set; }
 }

--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeTransportOptions.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/RealtimeTransportOptions.cs
@@ -122,17 +122,8 @@ public sealed class RealtimeTransportOptions
     public string TurnCredential { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the server offers only TURN relay candidates. Defaults to
-    /// <see langword="false"/>. Intended for diagnosing relay problems, not for production.
+    /// Gets or sets which ICE candidates the server offers. Defaults to
+    /// <see cref="RealtimeIceTransportPolicy.All"/>.
     /// </summary>
-    /// <remarks>
-    /// A server that also offers host and server-reflexive candidates can pair directly with a browser on the
-    /// same machine or LAN, and a direct pair additionally lets ICE paper over remote candidates that never
-    /// arrived, by promoting the source of an inbound connectivity check to a peer-reflexive candidate. Locally
-    /// that turns a broken relay path into a working call, which is why a failure that reproduces every time in a
-    /// deployment where inbound UDP is blocked can be impossible to reproduce on a developer machine. Enabling
-    /// this removes both shortcuts so the relay path is the only path, and the deployed behaviour is what runs
-    /// locally. It costs a TURN allocation for every session, so leave it off outside diagnosis.
-    /// </remarks>
-    public bool ForceRelayOnly { get; set; }
+    public RealtimeIceTransportPolicy IceTransportPolicy { get; set; } = RealtimeIceTransportPolicy.All;
 }

--- a/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
+++ b/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
@@ -180,7 +180,7 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
     public event Action Connected;
     public event Action Closed;
 
-    public SipSorceryWebRtcRealtimePeer(IReadOnlyList<WebRtcIceServer> iceServers, ILogger logger, bool relayOnly = false)
+    public SipSorceryWebRtcRealtimePeer(IReadOnlyList<WebRtcIceServer> iceServers, ILogger logger, RealtimeIceTransportPolicy iceTransportPolicy = RealtimeIceTransportPolicy.All)
     {
         _logger = logger;
         _incoming = Channel.CreateBounded<ReadOnlyMemory<byte>>(new BoundedChannelOptions(MaxBufferedInboundFrames)
@@ -227,16 +227,11 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
             iceServers = [.. iceServers.Select(ToRtcIceServer)],
         };
 
-        if (relayOnly)
+        if (iceTransportPolicy == RealtimeIceTransportPolicy.Relay)
         {
-            // A diagnostics aid, off by default. Host and server-reflexive candidates let two peers on the same
-            // machine or LAN pair directly, and a direct pair also lets ICE recover from remote candidates that
-            // never arrived by promoting the source of an inbound binding request to a peer-reflexive candidate.
-            // Both mask relay-path faults on a developer machine, which is why a server-relay failure that is
-            // obvious in a real deployment can be invisible locally. Relay only forces every packet through TURN.
             config.iceTransportPolicy = RTCIceTransportPolicy.relay;
 
-            _logger.LogWarning("WebRTC realtime: ICE transport policy forced to relay only. This is a diagnostics setting and should not be enabled in production.");
+            _logger.LogInformation("WebRTC realtime: offering relay candidates only. All media will travel through the configured TURN server.");
         }
 
         _pc = new RTCPeerConnection(config);

--- a/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
+++ b/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
@@ -127,6 +127,8 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
     private ushort? _lastInboundSequence;
     private short _recentPeak;
     private int _queuedFrames;
+    private const string CandidateAttributePrefix = "candidate:";
+
     private readonly object _localCandidateGate = new();
     private readonly List<WebRtcIceCandidate> _pendingLocalCandidates = [];
     private Action<WebRtcIceCandidate> _iceCandidateGenerated;
@@ -832,9 +834,22 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
             _logger.LogDebug("WebRTC realtime: local ICE candidate {Candidate}.", candidate.candidate);
         }
 
+        // SIPSorcery renders a candidate as the bare attribute value, without the "candidate:" prefix that the
+        // SDP a=candidate line carries. RTCIceCandidateInit.candidate is defined as the candidate-attribute
+        // itself, prefix included, and Chromium enforces that: it rejects the unprefixed form outright with
+        // "Error processing ICE candidate", so a browser silently ends up with no remote candidates at all and
+        // sits in "checking" until it times out. Measured directly — the identical candidate is refused without
+        // the prefix and accepted with it, after which ICE connects in about 250 ms.
+        var candidateText = candidate.candidate;
+
+        if (!string.IsNullOrEmpty(candidateText) && !candidateText.StartsWith(CandidateAttributePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            candidateText = CandidateAttributePrefix + candidateText;
+        }
+
         var generated = new WebRtcIceCandidate
         {
-            Candidate = candidate.candidate,
+            Candidate = candidateText,
             SdpMid = candidate.sdpMid,
             SdpMLineIndex = candidate.sdpMLineIndex,
         };

--- a/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
+++ b/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeer.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Threading.Channels;
@@ -127,17 +127,58 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
     private ushort? _lastInboundSequence;
     private short _recentPeak;
     private int _queuedFrames;
+    private readonly object _localCandidateGate = new();
+    private readonly List<WebRtcIceCandidate> _pendingLocalCandidates = [];
+    private Action<WebRtcIceCandidate> _iceCandidateGenerated;
 
     public string AnswerSdp { get; private set; }
 
     /// <inheritdoc />
     public int QueuedPlaybackMs => Volatile.Read(ref _queuedFrames) * FrameDurationMs;
 
-    public event Action<WebRtcIceCandidate> IceCandidateGenerated;
+    /// <summary>Raised for each ICE candidate this peer gathers.</summary>
+    /// <remarks>
+    /// Candidates gathered before a handler subscribes are replayed to it on subscription. Gathering starts
+    /// inside <c>setLocalDescription</c>, which runs while the peer is still being constructed, so the host
+    /// candidate is raised before the caller has had any opportunity to subscribe. Dropping it left the browser
+    /// with an incomplete view of the server's candidates.
+    /// </remarks>
+    public event Action<WebRtcIceCandidate> IceCandidateGenerated
+    {
+        add
+        {
+            if (value is null)
+            {
+                return;
+            }
+
+            List<WebRtcIceCandidate> replay;
+
+            lock (_localCandidateGate)
+            {
+                _iceCandidateGenerated += value;
+                replay = [.. _pendingLocalCandidates];
+                _pendingLocalCandidates.Clear();
+            }
+
+            foreach (var pending in replay)
+            {
+                value(pending);
+            }
+        }
+        remove
+        {
+            lock (_localCandidateGate)
+            {
+                _iceCandidateGenerated -= value;
+            }
+        }
+    }
+
     public event Action Connected;
     public event Action Closed;
 
-    public SipSorceryWebRtcRealtimePeer(IReadOnlyList<WebRtcIceServer> iceServers, ILogger logger)
+    public SipSorceryWebRtcRealtimePeer(IReadOnlyList<WebRtcIceServer> iceServers, ILogger logger, bool relayOnly = false)
     {
         _logger = logger;
         _incoming = Channel.CreateBounded<ReadOnlyMemory<byte>>(new BoundedChannelOptions(MaxBufferedInboundFrames)
@@ -183,6 +224,18 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
         {
             iceServers = [.. iceServers.Select(ToRtcIceServer)],
         };
+
+        if (relayOnly)
+        {
+            // A diagnostics aid, off by default. Host and server-reflexive candidates let two peers on the same
+            // machine or LAN pair directly, and a direct pair also lets ICE recover from remote candidates that
+            // never arrived by promoting the source of an inbound binding request to a peer-reflexive candidate.
+            // Both mask relay-path faults on a developer machine, which is why a server-relay failure that is
+            // obvious in a real deployment can be invisible locally. Relay only forces every packet through TURN.
+            config.iceTransportPolicy = RTCIceTransportPolicy.relay;
+
+            _logger.LogWarning("WebRTC realtime: ICE transport policy forced to relay only. This is a diagnostics setting and should not be enabled in production.");
+        }
 
         _pc = new RTCPeerConnection(config);
 
@@ -239,12 +292,35 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
             return;
         }
 
-        _pc.addIceCandidate(new RTCIceCandidateInit
+        var init = new RTCIceCandidateInit
         {
             candidate = candidate.Candidate,
             sdpMid = candidate.SdpMid,
             sdpMLineIndex = (ushort)Math.Max(0, candidate.SdpMLineIndex),
-        });
+        };
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            // SIPSorcery discards a remote candidate it cannot use without logging anything: a component it has
+            // no session for, a transport it does not support, or an address it cannot resolve. The session then
+            // fails sixteen seconds later with "no checklist entries became available", which says nothing about
+            // which candidate was refused or why. Parse it here the same way SIPSorcery does and record what the
+            // fields came out as, so a candidate lost on the way in is visible at the boundary.
+            try
+            {
+                var parsed = new RTCIceCandidate(init);
+
+                _logger.LogDebug(
+                    "WebRTC realtime: remote ICE candidate handed to the peer. Foundation: {Foundation}. Component: {Component}. Protocol: {Protocol}. Address: {Address}. Port: {Port}. Type: {Type}. SdpMid: {SdpMid}. SdpMLineIndex: {SdpMLineIndex}.",
+                    parsed.foundation, parsed.component, parsed.protocol, parsed.address, parsed.port, parsed.type, init.sdpMid, init.sdpMLineIndex);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "WebRTC realtime: remote ICE candidate could not be parsed: {Candidate}.", candidate.Candidate);
+            }
+        }
+
+        _pc.addIceCandidate(init);
     }
 
     public IAsyncEnumerable<ReadOnlyMemory<byte>> ReadAudioAsync(CancellationToken cancellationToken = default)
@@ -756,12 +832,28 @@ internal sealed class SipSorceryWebRtcRealtimePeer : IWebRtcRealtimePeer
             _logger.LogDebug("WebRTC realtime: local ICE candidate {Candidate}.", candidate.candidate);
         }
 
-        IceCandidateGenerated?.Invoke(new WebRtcIceCandidate
+        var generated = new WebRtcIceCandidate
         {
             Candidate = candidate.candidate,
             SdpMid = candidate.sdpMid,
             SdpMLineIndex = candidate.sdpMLineIndex,
-        });
+        };
+
+        Action<WebRtcIceCandidate> handler;
+
+        lock (_localCandidateGate)
+        {
+            handler = _iceCandidateGenerated;
+
+            if (handler is null)
+            {
+                _pendingLocalCandidates.Add(generated);
+
+                return;
+            }
+        }
+
+        handler(generated);
     }
 
     private void OnConnectionStateChanged(RTCPeerConnectionState state)

--- a/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeerFactory.cs
+++ b/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeerFactory.cs
@@ -1,4 +1,6 @@
+﻿using CrestApps.Core.AI.Realtime;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace CrestApps.Core.AI.Realtime.WebRtc;
 
@@ -8,10 +10,15 @@ namespace CrestApps.Core.AI.Realtime.WebRtc;
 internal sealed class SipSorceryWebRtcRealtimePeerFactory : IWebRtcRealtimePeerFactory
 {
     private readonly ILogger<SipSorceryWebRtcRealtimePeer> _logger;
+    private readonly IOptionsMonitor<RealtimeTransportOptions> _options;
 
-    public SipSorceryWebRtcRealtimePeerFactory(ILogger<SipSorceryWebRtcRealtimePeer> logger, ILoggerFactory loggerFactory)
+    public SipSorceryWebRtcRealtimePeerFactory(
+        ILogger<SipSorceryWebRtcRealtimePeer> logger,
+        ILoggerFactory loggerFactory,
+        IOptionsMonitor<RealtimeTransportOptions> options)
     {
         _logger = logger;
+        _options = options;
 
         // SIPSorcery logs to its own static factory, which defaults to a null logger. Without this, everything it
         // knows about ICE stays invisible: the TURN Allocate exchange, the CreatePermission it installs for each
@@ -25,7 +32,7 @@ internal sealed class SipSorceryWebRtcRealtimePeerFactory : IWebRtcRealtimePeerF
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(offerSdp);
 
-        var peer = new SipSorceryWebRtcRealtimePeer(iceServers ?? [], _logger);
+        var peer = new SipSorceryWebRtcRealtimePeer(iceServers ?? [], _logger, _options.CurrentValue.ForceRelayOnly);
 
         try
         {

--- a/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeerFactory.cs
+++ b/src/Primitives/CrestApps.Core.AI.Realtime.WebRtc/SipSorceryWebRtcRealtimePeerFactory.cs
@@ -32,7 +32,7 @@ internal sealed class SipSorceryWebRtcRealtimePeerFactory : IWebRtcRealtimePeerF
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(offerSdp);
 
-        var peer = new SipSorceryWebRtcRealtimePeer(iceServers ?? [], _logger, _options.CurrentValue.ForceRelayOnly);
+        var peer = new SipSorceryWebRtcRealtimePeer(iceServers ?? [], _logger, _options.CurrentValue.IceTransportPolicy);
 
         try
         {


### PR DESCRIPTION
Server-relay WebRTC on App Service fails every time with:

```
SIPSorcery.Net.RtpIceChannel|WARN|ICE RTP channel failed to connect as no checklist entries became available within 16.0088425s.
```

The candidates reach the hub and are handed to the peer — verified from both ends: the hub logs three `AddRealtimeIceCandidate` invocations, and the browser receives the server's reflexive and relay candidates, which proves the subscription (and therefore `registry.Add`, and therefore the #171 flush) had already run. SIPSorcery then formed zero candidate pairs and logged nothing at all for sixteen seconds.

It discards a remote candidate it cannot use silently — an unsupported component or transport, or an address it cannot resolve — so that timeout is the only evidence, and it names neither the candidate nor the reason. This PR makes the boundary observable and fixes one defect found on the way.

## Changes

**Log what each remote candidate parsed as.** `AddIceCandidate` now builds the `RTCIceCandidateInit`, constructs an `RTCIceCandidate` from it exactly as `RTCPeerConnection.addIceCandidate` does internally, and logs foundation, component, protocol, address, port and type at Debug before handing it over. A candidate refused for its component or transport, or one whose address came out empty, is now visible where it is lost.

**Buffer outbound candidates until a handler subscribes.** `IceCandidateGenerated` was a plain field-backed event raised with `?.Invoke`. Gathering begins inside `setLocalDescription`, which runs during `InitializeAsync` — while the peer is still being constructed and before `CreateAsync` has returned — so the host candidate was raised against an empty invocation list and discarded. Confirmed in a browser: the server's `srflx` and `relay` candidates arrived, its `169.254.254.5` host candidate never did. The event now holds candidates gathered before subscription and replays them on subscribe. This is the outbound mirror of the inbound queue from #171.

The lost candidate was link-local, so this is not what breaks the call — but the same race would drop the relay candidate on a slower or differently ordered gather, and that would.

**`RealtimeTransportOptions.ForceRelayOnly`**, default off. Locally, host and server-reflexive candidates let the browser and server pair directly, and a direct pair also lets ICE recover from remote candidates that never arrived by promoting the source of an inbound binding request to a peer-reflexive candidate. Both shortcuts turn a broken relay path into a working call, which is why this failure reproduces on every deployed session and never on a developer machine. Setting it makes the relay path the only path:

```
CrestApps__AI__RealtimeTransport__ForceRelayOnly=true
```

It costs a TURN allocation per session, so it stays off outside diagnosis.

## Testing

3092 tests pass, 0 failures.

No unit test covers the outbound replay: it needs a live `RTCPeerConnection` and real ICE gathering to raise `onicecandidate`, which would make the test bind sockets and depend on network timing. The mirrored inbound path is covered by the `WebRtcRealtimePeerRegistry` tests from #171.

## Follow-up

`ForceRelayOnly` should be documented in `docs/core/realtime-voice.md`. That file has uncommitted changes on another branch right now, so I left it alone rather than create a conflict.
