### PR TITLE
Mint realtime TURN credentials from a provider instead of configuration

### DIFF
--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/IRealtimeIceServerProvider.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Realtime/IRealtimeIceServerProvider.cs
@@ -1,0 +1,31 @@
+namespace CrestApps.Core.AI.Realtime;
+
+/// <summary>
+/// Supplies the ICE (STUN/TURN) servers used to negotiate a realtime WebRTC connection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both halves of a realtime session resolve their servers here — the list handed to the browser and the one
+/// the server-relay peer connects with — so the two can never disagree about which relay to use or which
+/// credentials to present.
+/// </para>
+/// <para>
+/// The method is asynchronous because a TURN provider is entitled to fetch credentials over the network.
+/// Hosted TURN services (Cloudflare Realtime, Twilio) mint short-lived credentials through an HTTP API rather
+/// than exposing a shared secret an implementation could sign locally. An implementation that needs no I/O
+/// should return a completed <see cref="ValueTask{TResult}"/>, which costs no allocation.
+/// </para>
+/// </remarks>
+public interface IRealtimeIceServerProvider
+{
+    /// <summary>
+    /// Gets the ICE servers to negotiate the next realtime connection with.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// The ICE servers, most preferred first. Never <see langword="null"/>; an implementation that cannot
+    /// resolve a TURN server returns whatever STUN servers it has rather than failing, because a direct
+    /// connection still succeeds for most callers.
+    /// </returns>
+    ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default);
+}

--- a/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
+++ b/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
@@ -513,6 +513,76 @@ For simpler setups you can use a long-lived username and password instead of a s
 
 If `TurnUrls` is set but neither a secret nor static credentials are provided, no TURN entry is offered (there would be nothing to authenticate with).
 
+Static credentials are the wrong tool for a hosted TURN service. Cloudflare and Twilio issue credentials with a
+fixed lifetime — often 24 hours — so pasting a generated username and password here means realtime voice stops
+working the next day, and the failure is quiet: the relay is refused, ICE falls back, and callers behind a strict
+NAT simply get no audio. Use the section below instead.
+
+### TURN through Cloudflare Realtime
+
+Cloudflare does not expose a shared secret, so credentials cannot be signed locally the way coturn's
+`use-auth-secret` allows — they are issued by an API call. Register the provider and give it the TURN key:
+
+```csharp
+services.AddCloudflareRealtimeTurn();
+```
+
+```json
+{
+  "CrestApps": {
+    "AI": {
+      "RealtimeTransport": {
+        "Cloudflare": {
+          "KeyId": "<TURN Token ID>",
+          "ApiToken": "<API token>",
+          "TtlSeconds": 86400
+        }
+      }
+    }
+  }
+}
+```
+
+Nothing here expires. The key and token are long-lived, and every credential a browser sees is minted on demand,
+so there is no rotation step to forget. Credentials are reused until they are halfway through `TtlSeconds` and
+then replaced, which means roughly two API calls per lifetime rather than one per connection, and a credential
+handed to a browser is always valid for at least as long again — no call can outlive the credentials it started
+with.
+
+Cloudflare answers with its own STUN entry plus TURN URLs spanning UDP, TCP, and TLS on 443, and all of them are
+offered to the browser as returned. Do not narrow the list to a single `turn:` URL: the TLS entry on 443 is what
+gets a caller out of a network that allows nothing else. `StunUrls` and `TurnUrls` are ignored while Cloudflare is
+configured, because credentials issued for one relay do not authenticate against another.
+
+Two behaviours are worth knowing. While `KeyId` and `ApiToken` are unset the provider does nothing and whatever
+was configured above still applies, so registering it before the key exists is safe. And if Cloudflare cannot be
+reached, the credentials already issued keep being served — they are good for about half their lifetime — rather
+than dropping every caller to STUN only; the failure is logged and retried within 30 seconds.
+
+Changing `KeyId` or `ApiToken` at runtime, from an administration screen or a rotating secret store, takes effect
+on the next connection: the options are watched and the cached credentials dropped.
+
+### Sourcing ICE servers from somewhere else
+
+Both halves of a session — the list handed to the browser and the server-relay peer itself — resolve through
+`IRealtimeIceServerProvider`, so they can never disagree about which relay to use or which credentials to present.
+Implement it to reach any other TURN service:
+
+```csharp
+public sealed class TwilioIceServerProvider : IRealtimeIceServerProvider
+{
+    public async ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default)
+    {
+        // Mint credentials however the service requires, then return them.
+    }
+}
+
+services.AddSingleton<IRealtimeIceServerProvider, TwilioIceServerProvider>();
+```
+
+The method is asynchronous precisely so an implementation may fetch credentials over the network. One that needs
+no I/O should return a completed `ValueTask`, which allocates nothing.
+
 ### Options reference
 
 | Property | Purpose |
@@ -526,7 +596,9 @@ If `TurnUrls` is set but neither a secret nor static credentials are provided, n
 | `TurnUrls` | TURN server URLs (`turn:`/`turns:`). Empty means no relay. |
 | `TurnSecret` | coturn `use-auth-secret` shared secret; enables ephemeral credentials. |
 | `TurnCredentialTtlSeconds` | Lifetime of a minted ephemeral credential (default 3600). |
-| `TurnUsername` / `TurnCredential` | Static TURN credentials, used only when `TurnSecret` is unset. |
+| `TurnUsername` / `TurnCredential` | Static TURN credentials, used only when `TurnSecret` is unset. Not suitable for a hosted TURN service, whose credentials expire. |
+| `Cloudflare:KeyId` / `Cloudflare:ApiToken` | Cloudflare Realtime TURN key. When both are set, credentials are minted per lifetime and the STUN and TURN properties above are ignored. |
+| `Cloudflare:TtlSeconds` | Lifetime requested for each Cloudflare credential (default 86400). Refreshed at half this. |
 
 ## Verifying which transport a session used
 

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
@@ -1243,7 +1243,7 @@ public class AIChatHubCore<TClient> : Hub<TClient>
                 var registry = services.GetRequiredService<WebRtcRealtimePeerRegistry>();
                 var caller = Clients.Caller;
 
-                await using var peer = await peerFactory.CreateAsync(offerSdp, RealtimeWebRtcIceServers.Resolve(services), cancellationToken);
+                await using var peer = await peerFactory.CreateAsync(offerSdp, await RealtimeWebRtcIceServers.ResolveAsync(services, cancellationToken), cancellationToken);
                 // A second voice session on the same connection displaces the first; dispose it rather than
                 // leaving a live peer holding its sockets and pacing loop for the rest of the connection.
                 var displaced = registry.Add(connectionId, peer);
@@ -1384,11 +1384,9 @@ public class AIChatHubCore<TClient> : Hub<TClient>
     {
         IReadOnlyList<RealtimeIceServerModel> servers = [];
 
-        await RunInScopeAsync(services =>
+        await RunInScopeAsync(async services =>
         {
-            servers = [.. RealtimeWebRtcIceServers.Resolve(services).Select(RealtimeIceServerModel.From)];
-
-            return Task.CompletedTask;
+            servers = [.. (await RealtimeWebRtcIceServers.ResolveAsync(services)).Select(RealtimeIceServerModel.From)];
         });
 
         return servers;

--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/ChatInteractionHubBase.cs
@@ -910,7 +910,7 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
                 var registry = services.GetRequiredService<WebRtcRealtimePeerRegistry>();
                 var caller = Clients.Caller;
 
-                await using var peer = await peerFactory.CreateAsync(offerSdp, GetIceServers(services), cancellationToken);
+                await using var peer = await peerFactory.CreateAsync(offerSdp, await GetIceServersAsync(services, cancellationToken), cancellationToken);
                 // A second voice session on the same connection displaces the first; dispose it rather than
                 // leaving a live peer holding its sockets and pacing loop for the rest of the connection.
                 var displaced = registry.Add(connectionId, peer);
@@ -1012,11 +1012,9 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
     {
         IReadOnlyList<RealtimeIceServerModel> servers = [];
 
-        await RunInScopeAsync(services =>
+        await RunInScopeAsync(async services =>
         {
-            servers = [.. GetIceServers(services).Select(RealtimeIceServerModel.From)];
-
-            return Task.CompletedTask;
+            servers = [.. (await GetIceServersAsync(services)).Select(RealtimeIceServerModel.From)];
         });
 
         return servers;
@@ -1194,11 +1192,15 @@ public class ChatInteractionHubBase : Hub<IChatInteractionHubClient>
     }
 
     /// <summary>
-    /// Gets the ICE (STUN/TURN) servers offered to the browser for the server-relay WebRTC peer. Phase 1 uses a
-    /// public STUN server for local/same-network use; TURN for production behind NAT is configured later.
+    /// Gets the ICE (STUN/TURN) servers offered to the browser for the server-relay WebRTC peer, and used by
+    /// that peer itself so the two never disagree about which relay to use.
     /// </summary>
-    private static IReadOnlyList<WebRtcIceServer> GetIceServers(IServiceProvider services)
-        => RealtimeWebRtcIceServers.Resolve(services);
+    /// <remarks>
+    /// Asynchronous because a hosted TURN service mints its credentials over HTTP. A deployment that names its
+    /// servers in configuration resolves without any I/O.
+    /// </remarks>
+    private static ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        => RealtimeWebRtcIceServers.ResolveAsync(services, cancellationToken);
 
     /// <summary>
     /// Gets the message returned when the WebRTC transport is not available on the server.

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
@@ -1,0 +1,202 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using CrestApps.Core.AI.Realtime;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.AI.Chat.Realtime;
+
+/// <summary>
+/// Resolves the realtime ICE servers from Cloudflare Realtime TURN, which issues short-lived credentials
+/// through an API rather than exposing a shared secret.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Credentials are fetched once and reused until they are halfway through their lifetime, so a call is made
+/// roughly twice per <see cref="CloudflareTurnOptions.TtlSeconds"/> rather than per connection. Refreshing at
+/// the halfway point means a credential handed to a browser is always valid for at least as long again, so no
+/// session can outlive the credentials it started with.
+/// </para>
+/// <para>
+/// Nothing here expires on its own: the key and token used to mint credentials are long-lived, and every
+/// credential the browser sees is minted on demand. That is the whole point of preferring this over pasting a
+/// generated username and password into configuration, which stops working when they lapse.
+/// </para>
+/// </remarks>
+internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerProvider, IDisposable
+{
+    /// <summary>
+    /// The shortest interval between refresh attempts after a failure. Long enough not to hammer Cloudflare
+    /// while an outage lasts, short enough to recover well inside the lifetime of the credentials in hand.
+    /// </summary>
+    private static readonly TimeSpan _retryDelay = TimeSpan.FromSeconds(30);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptionsMonitor<CloudflareTurnOptions> _optionsMonitor;
+    private readonly IRealtimeIceServerProvider _fallback;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<CloudflareRealtimeIceServerProvider> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly IDisposable _optionsChangeRegistration;
+
+    private IReadOnlyList<WebRtcIceServer> _cached;
+    private DateTimeOffset _refreshAfter;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CloudflareRealtimeIceServerProvider"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">The HTTP client factory.</param>
+    /// <param name="optionsMonitor">The Cloudflare TURN options, watched so a change takes effect at once.</param>
+    /// <param name="fallback">The provider used while Cloudflare is not configured.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    /// <param name="logger">The logger.</param>
+    public CloudflareRealtimeIceServerProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<CloudflareTurnOptions> optionsMonitor,
+        IRealtimeIceServerProvider fallback,
+        TimeProvider timeProvider,
+        ILogger<CloudflareRealtimeIceServerProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _optionsMonitor = optionsMonitor;
+        _fallback = fallback;
+        _timeProvider = timeProvider;
+        _logger = logger;
+
+        // The key or token can be changed while the application is running -- from an administration screen,
+        // or by a secret store rotating them underneath. Credentials minted with the previous key stay
+        // accepted by Cloudflare for their remaining lifetime, so nothing breaks immediately, but continuing
+        // to serve them would leave the change looking as though it had been ignored.
+        _optionsChangeRegistration = _optionsMonitor.OnChange(_ => Invalidate());
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default)
+    {
+        var options = _optionsMonitor.CurrentValue;
+
+        if (!options.IsConfigured)
+        {
+            // Not a Cloudflare deployment. Behave exactly as though this provider were not registered, so the
+            // configured STUN and TURN servers, and a coturn shared secret, keep working untouched.
+            return await _fallback.GetIceServersAsync(cancellationToken);
+        }
+
+        if (TryGetCached(out var cached))
+        {
+            return cached;
+        }
+
+        await _gate.WaitAsync(cancellationToken);
+
+        try
+        {
+            // Another caller may have refreshed while this one waited for the gate.
+            if (TryGetCached(out cached))
+            {
+                return cached;
+            }
+
+            var servers = await FetchIceServersAsync(options, cancellationToken);
+
+            _cached = servers;
+            _refreshAfter = _timeProvider.GetUtcNow().AddSeconds(Math.Max(options.TtlSeconds / 2, 60));
+
+            return servers;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Credentials are refreshed at the halfway mark, so whatever is cached is still valid for about
+            // half its lifetime. Serving it through a Cloudflare outage is strictly better than dropping every
+            // caller behind a strict NAT to STUN only, which is what returning the fallback would do.
+            _refreshAfter = _timeProvider.GetUtcNow().Add(_retryDelay);
+
+            if (_cached is not null)
+            {
+                _logger.LogWarning(ex, "Could not refresh the Cloudflare TURN credentials. Reusing the credentials already issued, which remain valid for about half their lifetime.");
+
+                return _cached;
+            }
+
+            _logger.LogError(ex, "Could not obtain Cloudflare TURN credentials, and none have been issued yet. Realtime voice will fall back to the configured servers, which for most deployments means STUN only.");
+
+            return await _fallback.GetIceServersAsync(cancellationToken);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Drops the cached credentials so the next caller mints a new set.
+    /// </summary>
+    private void Invalidate()
+    {
+        _cached = null;
+        _refreshAfter = default;
+    }
+
+    private bool TryGetCached(out IReadOnlyList<WebRtcIceServer> servers)
+    {
+        servers = _cached;
+
+        return servers is not null && _timeProvider.GetUtcNow() < _refreshAfter;
+    }
+
+    private async Task<IReadOnlyList<WebRtcIceServer>> FetchIceServersAsync(CloudflareTurnOptions options, CancellationToken cancellationToken)
+    {
+        var client = _httpClientFactory.CreateClient(nameof(CloudflareRealtimeIceServerProvider));
+
+        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{options.KeyId}/credentials/generate-ice-servers";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(new CloudflareCredentialRequest(options.TtlSeconds)),
+        };
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiToken);
+
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<CloudflareIceServersResponse>(cancellationToken)
+            ?? throw new InvalidOperationException("Cloudflare returned an empty response when asked for ICE servers.");
+
+        if (payload.IceServers is not { Length: > 0 })
+        {
+            throw new InvalidOperationException("Cloudflare returned no ICE servers.");
+        }
+
+        // Returned verbatim. Cloudflare answers with its own STUN entry plus a TURN entry spanning UDP, TCP,
+        // and TLS on 443 -- the last of which is what gets a caller out of a network that allows nothing else.
+        // Narrowing the list, or mixing in separately configured servers, is how a deployment ends up relaying
+        // through a URL the credentials were never issued for.
+        return [.. payload.IceServers.Select(static server => new WebRtcIceServer
+        {
+            Urls = server.Urls ?? [],
+            Username = server.Username,
+            Credential = server.Credential,
+        })];
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _optionsChangeRegistration?.Dispose();
+        _gate.Dispose();
+    }
+
+    private sealed record CloudflareCredentialRequest(
+        [property: JsonPropertyName("ttl")] int Ttl);
+
+    private sealed record CloudflareIceServersResponse(
+        [property: JsonPropertyName("iceServers")] CloudflareIceServer[] IceServers);
+
+    private sealed record CloudflareIceServer(
+        [property: JsonPropertyName("urls")] string[] Urls,
+        [property: JsonPropertyName("username")] string Username,
+        [property: JsonPropertyName("credential")] string Credential);
+}

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
@@ -1,0 +1,47 @@
+namespace CrestApps.Core.AI.Chat.Realtime;
+
+/// <summary>
+/// Identifies the Cloudflare Realtime TURN key used to mint short-lived TURN credentials.
+/// </summary>
+/// <remarks>
+/// Cloudflare does not expose a shared secret, so credentials cannot be signed locally the way coturn's
+/// <c>use-auth-secret</c> allows. They are issued by an API call authenticated with the values below, which are
+/// long-lived and belong in a secret store rather than in configuration files.
+/// </remarks>
+public sealed class CloudflareTurnOptions
+{
+    /// <summary>
+    /// Gets or sets the TURN key identifier, shown as the TURN Token ID in the Cloudflare dashboard.
+    /// </summary>
+    public string KeyId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the API token issued alongside the TURN key.
+    /// </summary>
+    public string ApiToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lifetime, in seconds, requested for each set of credentials. Defaults to 24 hours.
+    /// </summary>
+    /// <remarks>
+    /// Credentials are replaced once they are halfway through this lifetime, so the value only needs to
+    /// comfortably exceed the longest call a caller might place. It is not a session limit — that is
+    /// <see cref="Core.AI.Realtime.RealtimeTransportOptions.MaxSessionDurationSeconds"/>.
+    /// </remarks>
+    public int TtlSeconds { get; set; } = 86400;
+
+    /// <summary>
+    /// Gets or sets the base address of the Cloudflare Realtime API.
+    /// </summary>
+    /// <remarks>
+    /// Overridable so a test can point at a stub, and so a future regional or proxied endpoint needs no code
+    /// change. Defaults to the public endpoint.
+    /// </remarks>
+    public string ApiBaseAddress { get; set; } = "https://rtc.live.cloudflare.com";
+
+    /// <summary>
+    /// Gets a value indicating whether both credentials needed to call the Cloudflare API are present.
+    /// </summary>
+    public bool IsConfigured
+        => !string.IsNullOrWhiteSpace(KeyId) && !string.IsNullOrWhiteSpace(ApiToken);
+}

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/OptionsRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/OptionsRealtimeIceServerProvider.cs
@@ -1,0 +1,30 @@
+using CrestApps.Core.AI.Realtime;
+
+namespace CrestApps.Core.AI.Chat.Realtime;
+
+/// <summary>
+/// Resolves the realtime ICE servers from <see cref="RealtimeTransportOptions"/>, which is what a deployment
+/// running its own STUN and TURN servers configures.
+/// </summary>
+/// <remarks>
+/// This is the default provider and needs no I/O: the servers are named in configuration, and a coturn shared
+/// secret is signed locally per call. A deployment on a hosted TURN service that mints credentials through an
+/// HTTP API replaces it — see <see cref="CloudflareRealtimeIceServerProvider"/>.
+/// </remarks>
+internal sealed class OptionsRealtimeIceServerProvider : IRealtimeIceServerProvider
+{
+    private readonly IServiceProvider _services;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OptionsRealtimeIceServerProvider"/> class.
+    /// </summary>
+    /// <param name="services">The service provider used to read the transport options.</param>
+    public OptionsRealtimeIceServerProvider(IServiceProvider services)
+    {
+        _services = services;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(RealtimeWebRtcIceServers.Resolve(_services));
+}

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/RealtimeWebRtcIceServers.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/RealtimeWebRtcIceServers.cs
@@ -18,6 +18,28 @@ internal static class RealtimeWebRtcIceServers
 {
     private const string DefaultStunUrl = "stun:stun.l.google.com:19302";
 
+    /// <summary>
+    /// Resolves the ICE servers through the registered <see cref="IRealtimeIceServerProvider"/>, which is what
+    /// lets a deployment source them from a TURN service that mints credentials over HTTP instead of naming
+    /// them in configuration.
+    /// </summary>
+    /// <param name="services">The service provider.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <remarks>
+    /// Falls back to <see cref="Resolve(IServiceProvider)"/> when no provider is registered. Resolving needed
+    /// no registration at all before the provider existed, so a host that composes these services by hand
+    /// rather than through <c>AddCoreAIChat</c> keeps working after upgrading instead of failing on a service
+    /// it never registered.
+    /// </remarks>
+    public static ValueTask<IReadOnlyList<WebRtcIceServer>> ResolveAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        var provider = services.GetService<IRealtimeIceServerProvider>();
+
+        return provider is not null
+            ? provider.GetIceServersAsync(cancellationToken)
+            : ValueTask.FromResult(Resolve(services));
+    }
+
     public static IReadOnlyList<WebRtcIceServer> Resolve(IServiceProvider services)
     {
         var options = services.GetService<IOptions<RealtimeTransportOptions>>()?.Value ?? new RealtimeTransportOptions();

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -1,11 +1,13 @@
 using CrestApps.Core.AI.Chat.Handlers;
 using CrestApps.Core.AI.Chat.Models;
+using CrestApps.Core.AI.Chat.Realtime;
 using CrestApps.Core.AI.Chat.Security;
 using CrestApps.Core.AI.Chat.Services;
 using CrestApps.Core.AI.Completions;
 using CrestApps.Core.AI.Handlers;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.AI.Realtime;
 using CrestApps.Core.AI.Security;
 using CrestApps.Core.AI.Services;
 using CrestApps.Core.Builders;
@@ -17,6 +19,8 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace CrestApps.Core.AI.Chat;
 
@@ -128,6 +132,11 @@ public static class ServiceCollectionExtensions
         services.AddDataProtection();
         services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
         services.TryAddSingleton(TimeProvider.System);
+
+        // The realtime ICE servers come from here for both the browser and the server-relay peer. The
+        // default reads them from configuration; AddCloudflareRealtimeTurn replaces it for a deployment
+        // whose TURN service issues credentials through an API instead.
+        services.TryAddSingleton<IRealtimeIceServerProvider, OptionsRealtimeIceServerProvider>();
         services.AddOptions<AIVisitorIdentityOptions>();
         services.AddOptions<AIChatEndpointRateLimitingOptions>();
         services.AddSingleton<IAIVisitorIdentityResolver, DefaultAIVisitorIdentityResolver>();
@@ -209,5 +218,76 @@ public static class ServiceCollectionExtensions
         builder.Services.Configure(configure);
 
         return builder;
+    }
+    /// <summary>
+    /// Sources the realtime TURN servers from Cloudflare Realtime, which issues short-lived credentials
+    /// through an API rather than exposing a shared secret that could be signed locally.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configures the Cloudflare TURN key. Usually bound from configuration instead.</param>
+    /// <remarks>
+    /// <para>
+    /// Registering this is safe before the key exists: while <see cref="CloudflareTurnOptions.KeyId"/> and
+    /// <see cref="CloudflareTurnOptions.ApiToken"/> are unset the previously registered provider answers,
+    /// so a deployment running its own coturn is unaffected until it opts in.
+    /// </para>
+    /// <para>
+    /// Prefer this over pasting a generated username and password into
+    /// <see cref="RealtimeTransportOptions"/>: those are issued with a fixed lifetime and stop working when
+    /// it lapses, whereas the key and token used here are long-lived and every credential the browser sees
+    /// is minted on demand.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddCloudflareRealtimeTurn(this IServiceCollection services, Action<CloudflareTurnOptions> configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpClient(nameof(CloudflareRealtimeIceServerProvider));
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddOptions<CloudflareTurnOptions>();
+
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
+
+        // Decorates rather than replaces: the provider already registered becomes the fallback used while
+        // Cloudflare is not configured, and whenever an outage leaves no credentials to serve.
+        services.TryAddSingleton<IRealtimeIceServerProvider, OptionsRealtimeIceServerProvider>();
+
+        var existing = services.Last(descriptor => descriptor.ServiceType == typeof(IRealtimeIceServerProvider));
+
+        services.Add(ServiceDescriptor.Singleton<IRealtimeIceServerProvider>(provider =>
+            new CloudflareRealtimeIceServerProvider(
+                provider.GetRequiredService<IHttpClientFactory>(),
+                provider.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>(),
+                CreateFallback(provider, existing),
+                provider.GetRequiredService<TimeProvider>(),
+                provider.GetRequiredService<ILogger<CloudflareRealtimeIceServerProvider>>())));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Materializes the provider that was registered before Cloudflare decorated it.
+    /// </summary>
+    /// <remarks>
+    /// Resolving <see cref="IRealtimeIceServerProvider"/> from the container here would return the
+    /// Cloudflare provider itself, since the last registration wins, and the decorator would call into
+    /// itself forever. The captured descriptor is built directly instead.
+    /// </remarks>
+    private static IRealtimeIceServerProvider CreateFallback(IServiceProvider provider, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is IRealtimeIceServerProvider instance)
+        {
+            return instance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return (IRealtimeIceServerProvider)descriptor.ImplementationFactory(provider);
+        }
+
+        return (IRealtimeIceServerProvider)ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
     }
 }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -1,0 +1,365 @@
+using System.Net;
+using System.Text;
+using CrestApps.Core.AI.Chat.Realtime;
+using CrestApps.Core.AI.Realtime;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+
+namespace CrestApps.Core.Tests.Core.Realtime;
+
+public sealed class CloudflareRealtimeIceServerProviderTests
+{
+    private const string ValidResponse = """
+    {
+        "iceServers": [
+            { "urls": ["stun:stun.cloudflare.com:3478"] },
+            {
+                "urls": [
+                    "turn:turn.cloudflare.com:3478?transport=udp",
+                    "turns:turn.cloudflare.com:443?transport=tcp"
+                ],
+                "username": "cf-user",
+                "credential": "cf-credential"
+            }
+        ]
+    }
+    """;
+
+    [Fact]
+    public async Task GetIceServersAsync_WhenTheKeyIsNotConfigured_UsesTheConfiguredServersAndCallsNothing()
+    {
+        // Arrange
+        // Registering the Cloudflare provider must be harmless until a key is supplied, so a deployment
+        // running its own coturn is not disturbed by the registration alone.
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, new CloudflareTurnOptions(), out _);
+
+        // Act
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(handler.Requests);
+        var server = Assert.Single(servers);
+        Assert.Equal(["stun:fallback.example.com:3478"], server.Urls);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WhenConfigured_ReturnsTheServersCloudflareIssued()
+    {
+        // Arrange
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(), out _);
+
+        // Act
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(HttpMethod.Post, request.Method);
+        Assert.Equal(
+            "https://cloudflare.test/v1/turn/keys/key-1/credentials/generate-ice-servers",
+            request.Url);
+        Assert.Equal("Bearer token-1", request.Authorization);
+        Assert.Contains("\"ttl\":600", request.Body);
+
+        // Returned verbatim: the TLS entry on 443 is what gets a caller out of a locked-down network, so
+        // narrowing the list would quietly remove the case TURN exists for.
+        Assert.Equal(2, servers.Count);
+        Assert.Equal(["stun:stun.cloudflare.com:3478"], servers[0].Urls);
+        Assert.Equal(
+            ["turn:turn.cloudflare.com:3478?transport=udp", "turns:turn.cloudflare.com:443?transport=tcp"],
+            servers[1].Urls);
+        Assert.Equal("cf-user", servers[1].Username);
+        Assert.Equal("cf-credential", servers[1].Credential);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WithinHalfTheLifetime_ReusesTheCredentialsAlreadyIssued()
+    {
+        // Arrange
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(ttlSeconds: 600), out var time);
+
+        // Act
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+        time.Advance(TimeSpan.FromSeconds(299));
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_PastHalfTheLifetime_MintsAFreshSet()
+    {
+        // Arrange
+        // Refreshing at the halfway mark is what guarantees a credential handed to a browser stays valid for
+        // at least as long again, so no call can outlive the credentials it started with.
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(ttlSeconds: 600), out var time);
+
+        // Act
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+        time.Advance(TimeSpan.FromSeconds(301));
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WhenCloudflareFails_KeepsServingTheCredentialsAlreadyIssued()
+    {
+        // Arrange
+        // The cached credentials are good for about half their lifetime, so an outage must not drop callers
+        // behind a strict NAT to STUN only.
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(ttlSeconds: 600), out var time);
+
+        var issued = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        handler.FailWith(HttpStatusCode.ServiceUnavailable);
+        time.Advance(TimeSpan.FromSeconds(301));
+
+        // Act
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(issued[1].Username, servers[1].Username);
+        Assert.Equal(issued[1].Credential, servers[1].Credential);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WhenCloudflareFailsBeforeAnythingWasIssued_FallsBackInsteadOfThrowing()
+    {
+        // Arrange
+        var handler = new RecordingHandler(ValidResponse);
+        handler.FailWith(HttpStatusCode.Unauthorized);
+        var provider = CreateProvider(handler, Configured(), out _);
+
+        // Act
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        // Degraded, but a session that can still connect directly is better than an exception on the hub.
+        var server = Assert.Single(servers);
+        Assert.Equal(["stun:fallback.example.com:3478"], server.Urls);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_AfterAFailure_RetriesWithoutWaitingOutTheWholeLifetime()
+    {
+        // Arrange
+        var handler = new RecordingHandler(ValidResponse);
+        handler.FailWith(HttpStatusCode.ServiceUnavailable);
+        var provider = CreateProvider(handler, Configured(ttlSeconds: 86400), out var time);
+
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        handler.Recover();
+
+        // Act
+        // Half of a 24 hour lifetime is 12 hours away; a failed attempt must not wait that long to retry.
+        time.Advance(TimeSpan.FromSeconds(31));
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("cf-user", servers[1].Username);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WhenTheKeyChanges_MintsAgainWithTheNewKey()
+    {
+        // Arrange
+        // The key or token can be rotated from an administration screen or by a secret store. Continuing to
+        // serve credentials minted with the old key would make the change look as though it were ignored.
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(), out _, out var monitor);
+
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        monitor.Set(Configured(keyId: "key-2", apiToken: "token-2"));
+
+        // Act
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.EndsWith("/keys/key-1/credentials/generate-ice-servers", handler.Requests[0].Url, StringComparison.Ordinal);
+        Assert.EndsWith("/keys/key-2/credentials/generate-ice-servers", handler.Requests[1].Url, StringComparison.Ordinal);
+        Assert.Equal("Bearer token-2", handler.Requests[1].Authorization);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_WithConcurrentCallers_MintsOnlyOneSet()
+    {
+        // Arrange
+        // Every realtime connection resolves servers, so a cold cache under load must not turn into a burst
+        // of identical calls to Cloudflare.
+        var handler = new RecordingHandler(ValidResponse) { DelayMilliseconds = 25 };
+        var provider = CreateProvider(handler, Configured(), out _);
+
+        // Act
+        await Task.WhenAll(Enumerable.Range(0, 16).Select(async _ =>
+            await provider.GetIceServersAsync(TestContext.Current.CancellationToken)).ToArray());
+
+        // Assert
+        Assert.Single(handler.Requests);
+    }
+
+    private static CloudflareTurnOptions Configured(
+        string keyId = "key-1",
+        string apiToken = "token-1",
+        int ttlSeconds = 600)
+        => new()
+        {
+            KeyId = keyId,
+            ApiToken = apiToken,
+            TtlSeconds = ttlSeconds,
+            ApiBaseAddress = "https://cloudflare.test",
+        };
+
+    private static CloudflareRealtimeIceServerProvider CreateProvider(
+        RecordingHandler handler,
+        CloudflareTurnOptions options,
+        out TestTimeProvider time)
+        => CreateProvider(handler, options, out time, out _);
+
+    private static CloudflareRealtimeIceServerProvider CreateProvider(
+        RecordingHandler handler,
+        CloudflareTurnOptions options,
+        out TestTimeProvider time,
+        out TestOptionsMonitor<CloudflareTurnOptions> monitor)
+    {
+        time = new TestTimeProvider();
+        monitor = new TestOptionsMonitor<CloudflareTurnOptions>(options);
+
+        // A deployment that has not opted into Cloudflare still has its own configured servers; this stands in
+        // for them so the fallback is observable.
+        var services = new ServiceCollection()
+            .Configure<RealtimeTransportOptions>(o => o.StunUrls = ["stun:fallback.example.com:3478"])
+            .BuildServiceProvider();
+
+        return new CloudflareRealtimeIceServerProvider(
+            new TestHttpClientFactory(handler),
+            monitor,
+            new OptionsRealtimeIceServerProvider(services),
+            time,
+            NullLogger<CloudflareRealtimeIceServerProvider>.Instance);
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, string Url, string Authorization, string Body);
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly string _body;
+        private HttpStatusCode? _failure;
+
+        public RecordingHandler(string body)
+        {
+            _body = body;
+        }
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        public int DelayMilliseconds { get; init; }
+
+        public void FailWith(HttpStatusCode statusCode) => _failure = statusCode;
+
+        public void Recover() => _failure = null;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            lock (Requests)
+            {
+                Requests.Add(new RecordedRequest(
+                    request.Method,
+                    request.RequestUri!.ToString(),
+                    request.Headers.Authorization?.ToString(),
+                    body));
+            }
+
+            if (DelayMilliseconds > 0)
+            {
+                await Task.Delay(DelayMilliseconds, cancellationToken);
+            }
+
+            return _failure is { } failure
+                ? new HttpResponseMessage(failure)
+                : new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                };
+        }
+    }
+
+    private sealed class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+
+        public TestHttpClientFactory(HttpMessageHandler handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan amount) => _utcNow = _utcNow.Add(amount);
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        private readonly List<Action<T, string>> _listeners = [];
+
+        public TestOptionsMonitor(T value)
+        {
+            CurrentValue = value;
+        }
+
+        public T CurrentValue { get; private set; }
+
+        public T Get(string name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string> listener)
+        {
+            _listeners.Add(listener);
+
+            return new Unsubscriber(() => _listeners.Remove(listener));
+        }
+
+        public void Set(T value)
+        {
+            CurrentValue = value;
+
+            foreach (var listener in _listeners.ToArray())
+            {
+                listener(value, Options.DefaultName);
+            }
+        }
+
+        private sealed class Unsubscriber : IDisposable
+        {
+            private readonly Action _dispose;
+
+            public Unsubscriber(Action dispose)
+            {
+                _dispose = dispose;
+            }
+
+            public void Dispose() => _dispose();
+        }
+    }
+}

--- a/tests/CrestApps.Core.Tests/Core/Realtime/RealtimeWebRtcIceServersTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/RealtimeWebRtcIceServersTests.cs
@@ -94,4 +94,40 @@ public sealed class RealtimeWebRtcIceServersTests
         // Without a secret or static credentials there is nothing to authenticate with, so no TURN entry is added.
         Assert.DoesNotContain(result, s => s.Urls.Contains("turn:turn.example.com:3478"));
     }
+    [Fact]
+    public async Task ResolveAsync_WithNoProviderRegistered_StillResolvesFromConfiguration()
+    {
+        // Resolving needed no registration before IRealtimeIceServerProvider existed. A host that composes
+        // these services by hand rather than through AddCoreAIChat must keep working after upgrading.
+        using var services = new ServiceCollection()
+            .Configure<RealtimeTransportOptions>(o => o.StunUrls = ["stun:stun.example.com:3478"])
+            .BuildServiceProvider();
+
+        var result = await RealtimeWebRtcIceServers.ResolveAsync(services, TestContext.Current.CancellationToken);
+
+        var server = Assert.Single(result);
+        Assert.Equal(["stun:stun.example.com:3478"], server.Urls);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithAProviderRegistered_UsesIt()
+    {
+        // The seam both hubs resolve through, so a deployment on a hosted TURN service reaches it from the
+        // browser list and the server-relay peer alike.
+        using var services = new ServiceCollection()
+            .AddSingleton<IRealtimeIceServerProvider>(new StubIceServerProvider())
+            .BuildServiceProvider();
+
+        var result = await RealtimeWebRtcIceServers.ResolveAsync(services, TestContext.Current.CancellationToken);
+
+        var server = Assert.Single(result);
+        Assert.Equal(["turn:provided.example.com:3478"], server.Urls);
+    }
+
+    private sealed class StubIceServerProvider : IRealtimeIceServerProvider
+    {
+        public ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyList<WebRtcIceServer>>(
+                [new WebRtcIceServer { Urls = ["turn:provided.example.com:3478"] }]);
+    }
 }


### PR DESCRIPTION
## The problem

A hosted TURN service issues credentials with a fixed lifetime — Cloudflare and Twilio typically 24 hours. Naming a generated username and password in `RealtimeTransportOptions` therefore means realtime voice stops working the next day, and the failure is quiet: the relay is refused, ICE falls back, and callers behind a strict NAT simply get no audio with nothing in the logs to say why.

There was no way to source credentials from anywhere else. The ICE servers were composed from options read once, and `TurnSecret` only helps with coturn, which is the one case where a secret can be signed locally.

## The change

Both halves of a realtime session now resolve through a new `IRealtimeIceServerProvider` — the list handed to the browser *and* the server-relay peer — so the two can never disagree about which relay to use or which credentials to present.

The interface is asynchronous, which is what lets an implementation fetch credentials over the network:

```csharp
ValueTask<IReadOnlyList<WebRtcIceServer>> GetIceServersAsync(CancellationToken cancellationToken = default);
```

Nothing blocks. All three call sites were already async, and the default options-based provider returns a completed `ValueTask` because it needs no I/O.

`CloudflareRealtimeIceServerProvider` implements it for Cloudflare Realtime. Enable with:

```csharp
services.AddCloudflareRealtimeTurn();
```

```json
{ "CrestApps": { "AI": { "RealtimeTransport": { "Cloudflare": {
  "KeyId": "<TURN Token ID>", "ApiToken": "<API token>", "TtlSeconds": 86400
} } } } }
```

Nothing expires: the key and token are long-lived and every credential the browser sees is minted on demand. Credentials are reused until halfway through their lifetime and then replaced — roughly two API calls per lifetime rather than one per connection — which guarantees a credential handed to a browser stays valid for at least as long again, so no call can outlive the credentials it started with.

## Behaviors worth reviewing

- **Registering before the key exists is safe.** While `KeyId`/`ApiToken` are unset the provider defers to whatever was configured, so a deployment on its own coturn is untouched.
- **A Cloudflare outage does not drop callers to STUN only.** The credentials already issued keep being served — they are good for about half their lifetime — and the refresh is retried in 30 seconds rather than waiting out the lifetime.
- **Rotating the key takes effect on the next connection.** The options are watched via `IOptionsMonitor`, and a change drops the cached credentials.
- **Cloudflare's URL list is returned verbatim.** It spans UDP, TCP, and TLS on 443; the TLS entry is what gets a caller out of a network that allows nothing else, so narrowing it would remove the case TURN exists for.
- **Back-compatible.** `RealtimeWebRtcIceServers.ResolveAsync` falls back to the options path when no provider is registered, so a host composing these services by hand rather than through `AddCoreAIChat` keeps working.

## Testing

9 new tests plus 2 covering the new resolution seam. Full suite: **3114 passing**, Release build clean with **0 warnings**.

I mutation-tested the three load-bearing behaviors to confirm the tests are not passing vacuously — each mutation was verified to actually apply, then reverted:

| Mutation | Result |
|---|---|
| Cache disabled (always refetch) | 2 tests fail |
| Stale-on-error removed (fall back instead of serving cached) | 1 test fails |
| Options-change invalidation removed | 1 test fails |

The provider is exercised through a recording `HttpMessageHandler` and a controllable `TimeProvider`, so credential lifetime and refresh timing are asserted deterministically with no clock dependence.

## Not covered

The Cloudflare API is stubbed, not contacted. The request shape (URL, bearer header, `{"ttl":N}` body) and the documented response shape are asserted, but a live call against a real TURN key is still worth doing once before relying on this in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
