### PR TITLE
Bind the Cloudflare TURN token from configuration, and name it TokenId

### DIFF
--- a/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
+++ b/src/CrestApps.Core.Docs/docs/core/realtime-voice.md
@@ -521,7 +521,7 @@ NAT simply get no audio. Use the section below instead.
 ### TURN through Cloudflare Realtime
 
 Cloudflare does not expose a shared secret, so credentials cannot be signed locally the way coturn's
-`use-auth-secret` allows — they are issued by an API call. Register the provider and give it the TURN key:
+`use-auth-secret` allows — they are issued by an API call. Register the provider and give it the TURN token:
 
 ```csharp
 services.AddCloudflareRealtimeTurn();
@@ -533,7 +533,7 @@ services.AddCloudflareRealtimeTurn();
     "AI": {
       "RealtimeTransport": {
         "Cloudflare": {
-          "KeyId": "<TURN Token ID>",
+          "TokenId": "<TURN Token ID>",
           "ApiToken": "<API token>",
           "TtlSeconds": 86400
         }
@@ -554,12 +554,12 @@ offered to the browser as returned. Do not narrow the list to a single `turn:` U
 gets a caller out of a network that allows nothing else. `StunUrls` and `TurnUrls` are ignored while Cloudflare is
 configured, because credentials issued for one relay do not authenticate against another.
 
-Two behaviours are worth knowing. While `KeyId` and `ApiToken` are unset the provider does nothing and whatever
+Two behaviours are worth knowing. While `TokenId` and `ApiToken` are unset the provider does nothing and whatever
 was configured above still applies, so registering it before the key exists is safe. And if Cloudflare cannot be
 reached, the credentials already issued keep being served — they are good for about half their lifetime — rather
 than dropping every caller to STUN only; the failure is logged and retried within 30 seconds.
 
-Changing `KeyId` or `ApiToken` at runtime, from an administration screen or a rotating secret store, takes effect
+Changing `TokenId` or `ApiToken` at runtime, from an administration screen or a rotating secret store, takes effect
 on the next connection: the options are watched and the cached credentials dropped.
 
 ### Sourcing ICE servers from somewhere else
@@ -597,7 +597,7 @@ no I/O should return a completed `ValueTask`, which allocates nothing.
 | `TurnSecret` | coturn `use-auth-secret` shared secret; enables ephemeral credentials. |
 | `TurnCredentialTtlSeconds` | Lifetime of a minted ephemeral credential (default 3600). |
 | `TurnUsername` / `TurnCredential` | Static TURN credentials, used only when `TurnSecret` is unset. Not suitable for a hosted TURN service, whose credentials expire. |
-| `Cloudflare:KeyId` / `Cloudflare:ApiToken` | Cloudflare Realtime TURN key. When both are set, credentials are minted per lifetime and the STUN and TURN properties above are ignored. |
+| `Cloudflare:TokenId` / `Cloudflare:ApiToken` | Cloudflare Realtime TURN credentials, named as the dashboard shows them. When both are set, credentials are minted per lifetime and the STUN and TURN properties above are ignored. |
 | `Cloudflare:TtlSeconds` | Lifetime requested for each Cloudflare credential (default 86400). Refreshed at half this. |
 
 ## Verifying which transport a session used

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
@@ -149,27 +149,24 @@ internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerPr
     {
         var client = _httpClientFactory.CreateClient(nameof(CloudflareRealtimeIceServerProvider));
 
-        // Values pasted out of a dashboard routinely carry surrounding whitespace. A trailing newline in
-        // the API token makes the Authorization header throw outright, and a trailing space on the token id
-        // becomes %20 in the path and is answered with a 404. Both would surface only as a failure to obtain
-        // credentials and a quiet drop to STUN, so they are trimmed rather than diagnosed later.
-        var tokenId = options.TokenId.Trim();
-        var apiToken = options.ApiToken.Trim();
-
+        // Both credentials are non-null and trimmed by the time this runs: CloudflareTurnOptions trims on
+        // assignment, and the caller reached here only because IsConfigured rejected null and whitespace on
+        // this very instance.
+        //
         // Cloudflare's route spells the token as a key; the value is the Token ID from the dashboard.
         //
         // Escaped because it is interpolated into the path, where Uri gives several characters meaning that
         // silently retargets the request rather than failing: '..' segments are collapsed, so a token id of
         // "a/../../v1/other" drops the keys segment entirely, and '?' or '#' truncates the path into a query
         // or fragment. A real token id is hexadecimal and escaping leaves it untouched.
-        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{Uri.EscapeDataString(tokenId)}/credentials/generate-ice-servers";
+        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{Uri.EscapeDataString(options.TokenId)}/credentials/generate-ice-servers";
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = JsonContent.Create(new CloudflareCredentialRequest(options.TtlSeconds)),
         };
 
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiToken);
 
         using var response = await client.SendAsync(request, cancellationToken);
 

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
@@ -149,7 +149,8 @@ internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerPr
     {
         var client = _httpClientFactory.CreateClient(nameof(CloudflareRealtimeIceServerProvider));
 
-        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{options.KeyId}/credentials/generate-ice-servers";
+        // Cloudflare's route spells the token as a key; the value is the Token ID from the dashboard.
+        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{options.TokenId}/credentials/generate-ice-servers";
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
         {

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
@@ -34,7 +34,7 @@ internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerPr
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptionsMonitor<CloudflareTurnOptions> _optionsMonitor;
-    private readonly IRealtimeIceServerProvider _fallback;
+    private readonly OptionsRealtimeIceServerProvider _fallback;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<CloudflareRealtimeIceServerProvider> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
@@ -48,13 +48,13 @@ internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerPr
     /// </summary>
     /// <param name="httpClientFactory">The HTTP client factory.</param>
     /// <param name="optionsMonitor">The Cloudflare TURN options, watched so a change takes effect at once.</param>
-    /// <param name="fallback">The provider used while Cloudflare is not configured.</param>
+    /// <param name="fallback">The configured-servers provider used while Cloudflare is not configured.</param>
     /// <param name="timeProvider">The time provider.</param>
     /// <param name="logger">The logger.</param>
     public CloudflareRealtimeIceServerProvider(
         IHttpClientFactory httpClientFactory,
         IOptionsMonitor<CloudflareTurnOptions> optionsMonitor,
-        IRealtimeIceServerProvider fallback,
+        OptionsRealtimeIceServerProvider fallback,
         TimeProvider timeProvider,
         ILogger<CloudflareRealtimeIceServerProvider> logger)
     {

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareRealtimeIceServerProvider.cs
@@ -149,15 +149,27 @@ internal sealed class CloudflareRealtimeIceServerProvider : IRealtimeIceServerPr
     {
         var client = _httpClientFactory.CreateClient(nameof(CloudflareRealtimeIceServerProvider));
 
+        // Values pasted out of a dashboard routinely carry surrounding whitespace. A trailing newline in
+        // the API token makes the Authorization header throw outright, and a trailing space on the token id
+        // becomes %20 in the path and is answered with a 404. Both would surface only as a failure to obtain
+        // credentials and a quiet drop to STUN, so they are trimmed rather than diagnosed later.
+        var tokenId = options.TokenId.Trim();
+        var apiToken = options.ApiToken.Trim();
+
         // Cloudflare's route spells the token as a key; the value is the Token ID from the dashboard.
-        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{options.TokenId}/credentials/generate-ice-servers";
+        //
+        // Escaped because it is interpolated into the path, where Uri gives several characters meaning that
+        // silently retargets the request rather than failing: '..' segments are collapsed, so a token id of
+        // "a/../../v1/other" drops the keys segment entirely, and '?' or '#' truncates the path into a query
+        // or fragment. A real token id is hexadecimal and escaping leaves it untouched.
+        var url = $"{options.ApiBaseAddress.TrimEnd('/')}/v1/turn/keys/{Uri.EscapeDataString(tokenId)}/credentials/generate-ice-servers";
 
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
             Content = JsonContent.Create(new CloudflareCredentialRequest(options.TtlSeconds)),
         };
 
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
 
         using var response = await client.SendAsync(request, cancellationToken);
 

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
@@ -1,7 +1,7 @@
 namespace CrestApps.Core.AI.Chat.Realtime;
 
 /// <summary>
-/// Identifies the Cloudflare Realtime TURN key used to mint short-lived TURN credentials.
+/// Identifies the Cloudflare Realtime TURN token used to mint short-lived TURN credentials.
 /// </summary>
 /// <remarks>
 /// Cloudflare does not expose a shared secret, so credentials cannot be signed locally the way coturn's
@@ -11,12 +11,16 @@ namespace CrestApps.Core.AI.Chat.Realtime;
 public sealed class CloudflareTurnOptions
 {
     /// <summary>
-    /// Gets or sets the TURN key identifier, shown as the TURN Token ID in the Cloudflare dashboard.
+    /// Gets or sets the TURN Token ID, named as it appears in the Cloudflare dashboard.
     /// </summary>
-    public string KeyId { get; set; }
+    /// <remarks>
+    /// Cloudflare's own API path spells the same value as a key -- <c>/v1/turn/keys/{id}</c> -- but the
+    /// dashboard an operator copies it from calls it a Token ID, so that is the name used here.
+    /// </remarks>
+    public string TokenId { get; set; }
 
     /// <summary>
-    /// Gets or sets the API token issued alongside the TURN key.
+    /// Gets or sets the API token issued alongside the TURN Token ID.
     /// </summary>
     public string ApiToken { get; set; }
 
@@ -43,5 +47,5 @@ public sealed class CloudflareTurnOptions
     /// Gets a value indicating whether both credentials needed to call the Cloudflare API are present.
     /// </summary>
     public bool IsConfigured
-        => !string.IsNullOrWhiteSpace(KeyId) && !string.IsNullOrWhiteSpace(ApiToken);
+        => !string.IsNullOrWhiteSpace(TokenId) && !string.IsNullOrWhiteSpace(ApiToken);
 }

--- a/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Realtime/CloudflareTurnOptions.cs
@@ -10,19 +10,41 @@ namespace CrestApps.Core.AI.Chat.Realtime;
 /// </remarks>
 public sealed class CloudflareTurnOptions
 {
+    private string _tokenId;
+    private string _apiToken;
+
     /// <summary>
     /// Gets or sets the TURN Token ID, named as it appears in the Cloudflare dashboard.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Cloudflare's own API path spells the same value as a key -- <c>/v1/turn/keys/{id}</c> -- but the
     /// dashboard an operator copies it from calls it a Token ID, so that is the name used here.
+    /// </para>
+    /// <para>
+    /// Trimmed on assignment. Whitespace is never part of either credential, and a value pasted out of a
+    /// dashboard routinely carries some; trimming here rather than at the point of use means
+    /// <see cref="IsConfigured"/> is the single answer to whether the value is usable.
+    /// </para>
     /// </remarks>
-    public string TokenId { get; set; }
+    public string TokenId
+    {
+        get => _tokenId;
+        set => _tokenId = value?.Trim();
+    }
 
     /// <summary>
     /// Gets or sets the API token issued alongside the TURN Token ID.
     /// </summary>
-    public string ApiToken { get; set; }
+    /// <remarks>
+    /// Trimmed on assignment, as <see cref="TokenId"/> is. A trailing newline here is not cosmetic: it makes
+    /// the <c>Authorization</c> header throw when the request is built.
+    /// </remarks>
+    public string ApiToken
+    {
+        get => _apiToken;
+        set => _apiToken = value?.Trim();
+    }
 
     /// <summary>
     /// Gets or sets the lifetime, in seconds, requested for each set of credentials. Defaults to 24 hours.

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -242,21 +242,6 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // Applied before the guard: every call's configuration is honoured, only the registrations are once.
-        if (configure is not null)
-        {
-            services.Configure(configure);
-        }
-
-        // Safe to call more than once, as hosts enable several realtime surfaces and call the transport
-        // registrations per feature. Neither half below is naturally idempotent: a second BindConfiguration
-        // adds another IConfigureOptions, and a second provider would wrap the first as its own fallback.
-        if (services.Any(descriptor => descriptor.ServiceType == typeof(CloudflareTurnRegistrationMarker)))
-        {
-            return services;
-        }
-
-        services.AddSingleton<CloudflareTurnRegistrationMarker>();
         services.AddHttpClient(nameof(CloudflareRealtimeIceServerProvider));
         services.TryAddSingleton(TimeProvider.System);
 
@@ -265,51 +250,22 @@ public static class ServiceCollectionExtensions
         // provider would quietly defer to the fallback, which looks exactly like nothing being configured.
         services.AddOptions<CloudflareTurnOptions>().BindConfiguration("CrestApps:AI:RealtimeTransport:Cloudflare");
 
-        // Decorates rather than replaces: the provider already registered becomes the fallback used while
-        // Cloudflare is not configured, and whenever an outage leaves no credentials to serve.
-        services.TryAddSingleton<IRealtimeIceServerProvider, OptionsRealtimeIceServerProvider>();
+        if (configure is not null)
+        {
+            services.Configure(configure);
+        }
 
-        var existing = services.Last(descriptor => descriptor.ServiceType == typeof(IRealtimeIceServerProvider));
+        // The fallback is named concretely rather than taken as whatever happened to be registered. It is
+        // not an arbitrary provider -- it is the configured-servers path used while Cloudflare is not set
+        // up, and whenever an outage leaves no credentials to serve. Naming it also keeps Replace below
+        // from handing the decorator itself as its own fallback.
+        services.TryAddSingleton<OptionsRealtimeIceServerProvider>();
 
-        services.Add(ServiceDescriptor.Singleton<IRealtimeIceServerProvider>(provider =>
-            new CloudflareRealtimeIceServerProvider(
-                provider.GetRequiredService<IHttpClientFactory>(),
-                provider.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>(),
-                CreateFallback(provider, existing),
-                provider.GetRequiredService<TimeProvider>(),
-                provider.GetRequiredService<ILogger<CloudflareRealtimeIceServerProvider>>())));
+        // Replace, so calling this more than once -- which hosts do, enabling several realtime surfaces --
+        // leaves exactly one provider rather than a stack of decorators each wrapping the last.
+        services.Replace(ServiceDescriptor.Singleton<IRealtimeIceServerProvider, CloudflareRealtimeIceServerProvider>());
 
         return services;
     }
 
-    /// <summary>
-    /// Materializes the provider that was registered before Cloudflare decorated it.
-    /// </summary>
-    /// <remarks>
-    /// Resolving <see cref="IRealtimeIceServerProvider"/> from the container here would return the
-    /// Cloudflare provider itself, since the last registration wins, and the decorator would call into
-    /// itself forever. The captured descriptor is built directly instead.
-    /// </remarks>
-    private static IRealtimeIceServerProvider CreateFallback(IServiceProvider provider, ServiceDescriptor descriptor)
-    {
-        if (descriptor.ImplementationInstance is IRealtimeIceServerProvider instance)
-        {
-            return instance;
-        }
-
-        if (descriptor.ImplementationFactory is not null)
-        {
-            return (IRealtimeIceServerProvider)descriptor.ImplementationFactory(provider);
-        }
-
-        return (IRealtimeIceServerProvider)ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
-    }
-    /// <summary>
-    /// Records that <see cref="AddCloudflareRealtimeTurn"/> has already run against a service collection.
-    /// </summary>
-    /// <remarks>
-    /// A marker rather than a check for the provider itself, because the provider is registered as a
-    /// factory whose implementation type the container does not expose.
-    /// </remarks>
-    private sealed class CloudflareTurnRegistrationMarker;
 }

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -244,7 +244,10 @@ public static class ServiceCollectionExtensions
 
         services.AddHttpClient(nameof(CloudflareRealtimeIceServerProvider));
         services.TryAddSingleton(TimeProvider.System);
-        services.AddOptions<CloudflareTurnOptions>();
+        // Bound from the same section the rest of the realtime transport reads, so the key can be supplied
+        // as configuration rather than in code. Without this the options would silently stay empty and the
+        // provider would quietly defer to the fallback, which looks exactly like nothing being configured.
+        services.AddOptions<CloudflareTurnOptions>().BindConfiguration("CrestApps:AI:RealtimeTransport:Cloudflare");
 
         if (configure is not null)
         {

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -224,10 +224,10 @@ public static class ServiceCollectionExtensions
     /// through an API rather than exposing a shared secret that could be signed locally.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <param name="configure">Configures the Cloudflare TURN key. Usually bound from configuration instead.</param>
+    /// <param name="configure">Configures the Cloudflare TURN token. Usually bound from configuration instead.</param>
     /// <remarks>
     /// <para>
-    /// Registering this is safe before the key exists: while <see cref="CloudflareTurnOptions.KeyId"/> and
+    /// Registering this is safe before the key exists: while <see cref="CloudflareTurnOptions.TokenId"/> and
     /// <see cref="CloudflareTurnOptions.ApiToken"/> are unset the previously registered provider answers,
     /// so a deployment running its own coturn is unaffected until it opts in.
     /// </para>

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -242,6 +242,21 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Safe to call more than once. Hosts enable several realtime surfaces and call the transport
+        // registrations per feature, and neither half of this method is naturally idempotent: a second
+        // BindConfiguration adds another IConfigureOptions, and a second provider registration would wrap
+        // the first as its own fallback -- a chain of caches in front of a chain of caches.
+        if (services.Any(descriptor => descriptor.ImplementationType == typeof(CloudflareTurnRegistrationMarker)))
+        {
+            if (configure is not null)
+            {
+                services.Configure(configure);
+            }
+
+            return services;
+        }
+
+        services.AddSingleton<CloudflareTurnRegistrationMarker>();
         services.AddHttpClient(nameof(CloudflareRealtimeIceServerProvider));
         services.TryAddSingleton(TimeProvider.System);
         // Bound from the same section the rest of the realtime transport reads, so the key can be supplied
@@ -293,4 +308,12 @@ public static class ServiceCollectionExtensions
 
         return (IRealtimeIceServerProvider)ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
     }
+    /// <summary>
+    /// Records that <see cref="AddCloudflareRealtimeTurn"/> has already run against a service collection.
+    /// </summary>
+    /// <remarks>
+    /// A marker rather than a check for the provider itself, because the provider is registered as a
+    /// factory whose implementation type the container does not expose.
+    /// </remarks>
+    private sealed class CloudflareTurnRegistrationMarker;
 }

--- a/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/ServiceCollectionExtensions.cs
@@ -242,32 +242,28 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // Safe to call more than once. Hosts enable several realtime surfaces and call the transport
-        // registrations per feature, and neither half of this method is naturally idempotent: a second
-        // BindConfiguration adds another IConfigureOptions, and a second provider registration would wrap
-        // the first as its own fallback -- a chain of caches in front of a chain of caches.
-        if (services.Any(descriptor => descriptor.ImplementationType == typeof(CloudflareTurnRegistrationMarker)))
+        // Applied before the guard: every call's configuration is honoured, only the registrations are once.
+        if (configure is not null)
         {
-            if (configure is not null)
-            {
-                services.Configure(configure);
-            }
+            services.Configure(configure);
+        }
 
+        // Safe to call more than once, as hosts enable several realtime surfaces and call the transport
+        // registrations per feature. Neither half below is naturally idempotent: a second BindConfiguration
+        // adds another IConfigureOptions, and a second provider would wrap the first as its own fallback.
+        if (services.Any(descriptor => descriptor.ServiceType == typeof(CloudflareTurnRegistrationMarker)))
+        {
             return services;
         }
 
         services.AddSingleton<CloudflareTurnRegistrationMarker>();
         services.AddHttpClient(nameof(CloudflareRealtimeIceServerProvider));
         services.TryAddSingleton(TimeProvider.System);
-        // Bound from the same section the rest of the realtime transport reads, so the key can be supplied
+
+        // Bound from the same section the rest of the realtime transport reads, so the token can be supplied
         // as configuration rather than in code. Without this the options would silently stay empty and the
         // provider would quietly defer to the fallback, which looks exactly like nothing being configured.
         services.AddOptions<CloudflareTurnOptions>().BindConfiguration("CrestApps:AI:RealtimeTransport:Cloudflare");
-
-        if (configure is not null)
-        {
-            services.Configure(configure);
-        }
 
         // Decorates rather than replaces: the provider already registered becomes the fallback used while
         // Cloudflare is not configured, and whenever an outage leaves no credentials to serve.

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -61,7 +61,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
         var request = Assert.Single(handler.Requests);
         Assert.Equal(HttpMethod.Post, request.Method);
         Assert.Equal(
-            "https://cloudflare.test/v1/turn/keys/key-1/credentials/generate-ice-servers",
+            "https://cloudflare.test/v1/turn/keys/token-id-1/credentials/generate-ice-servers",
             request.Url);
         Assert.Equal("Bearer token-1", request.Authorization);
         Assert.Contains("\"ttl\":600", request.Body);
@@ -184,15 +184,15 @@ public sealed class CloudflareRealtimeIceServerProviderTests
 
         await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
 
-        monitor.Set(Configured(keyId: "key-2", apiToken: "token-2"));
+        monitor.Set(Configured(tokenId: "token-id-2", apiToken: "token-2"));
 
         // Act
         await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(2, handler.Requests.Count);
-        Assert.EndsWith("/keys/key-1/credentials/generate-ice-servers", handler.Requests[0].Url, StringComparison.Ordinal);
-        Assert.EndsWith("/keys/key-2/credentials/generate-ice-servers", handler.Requests[1].Url, StringComparison.Ordinal);
+        Assert.EndsWith("/keys/token-id-1/credentials/generate-ice-servers", handler.Requests[0].Url, StringComparison.Ordinal);
+        Assert.EndsWith("/keys/token-id-2/credentials/generate-ice-servers", handler.Requests[1].Url, StringComparison.Ordinal);
         Assert.Equal("Bearer token-2", handler.Requests[1].Authorization);
     }
 
@@ -214,12 +214,12 @@ public sealed class CloudflareRealtimeIceServerProviderTests
     }
 
     private static CloudflareTurnOptions Configured(
-        string keyId = "key-1",
+        string tokenId = "token-id-1",
         string apiToken = "token-1",
         int ttlSeconds = 600)
         => new()
         {
-            KeyId = keyId,
+            TokenId = tokenId,
             ApiToken = apiToken,
             TtlSeconds = ttlSeconds,
             ApiBaseAddress = "https://cloudflare.test",
@@ -374,7 +374,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string>
             {
-                ["CrestApps:AI:RealtimeTransport:Cloudflare:KeyId"] = "key-from-configuration",
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:TokenId"] = "token-id-from-configuration",
                 ["CrestApps:AI:RealtimeTransport:Cloudflare:ApiToken"] = "token-from-configuration",
                 ["CrestApps:AI:RealtimeTransport:Cloudflare:TtlSeconds"] = "1200",
             })
@@ -388,7 +388,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
 
         // Assert
         var options = services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue;
-        Assert.Equal("key-from-configuration", options.KeyId);
+        Assert.Equal("token-id-from-configuration", options.TokenId);
         Assert.Equal("token-from-configuration", options.ApiToken);
         Assert.Equal(1200, options.TtlSeconds);
         Assert.True(options.IsConfigured);

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -498,4 +498,29 @@ public sealed class CloudflareRealtimeIceServerProviderTests
             request.Url);
         Assert.Equal("Bearer token-1", request.Authorization);
     }
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    [InlineData("   ", "   ")]
+    [InlineData("token-id-1", null)]
+    [InlineData(null, "token-1")]
+    public async Task GetIceServersAsync_WithMissingOrBlankCredentials_FallsBackWithoutThrowing(string tokenId, string apiToken)
+    {
+        // Arrange
+        // IsConfigured is the single answer to whether the credentials are usable, and the fetch path relies
+        // on it having rejected null and whitespace. A value that is only whitespace must count as missing
+        // rather than reach the request as an empty path segment.
+        var handler = new RecordingHandler(ValidResponse);
+        var options = new CloudflareTurnOptions { TokenId = tokenId, ApiToken = apiToken };
+        var provider = CreateProvider(handler, options, out _);
+
+        // Act
+        var servers = await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(options.IsConfigured);
+        Assert.Empty(handler.Requests);
+        var server = Assert.Single(servers);
+        Assert.Equal(["stun:fallback.example.com:3478"], server.Urls);
+    }
 }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -406,7 +406,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
         Assert.False(services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue.IsConfigured);
     }
     [Fact]
-    public void AddCloudflareRealtimeTurn_CalledTwice_RegistersOneProviderAndOneBinding()
+    public void AddCloudflareRealtimeTurn_CalledTwice_LeavesExactlyOneProviderRegistered()
     {
         // Arrange
         // Hosts enable several realtime surfaces and call the transport registrations per feature. A second
@@ -428,7 +428,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
         services.AddCloudflareRealtimeTurn();
 
         // Assert
-        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IRealtimeIceServerProvider) && descriptor.ImplementationFactory is not null);
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IRealtimeIceServerProvider));
 
         using var provider = services.BuildServiceProvider();
         var options = provider.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue;
@@ -436,7 +436,7 @@ public sealed class CloudflareRealtimeIceServerProviderTests
     }
 
     [Fact]
-    public void AddCloudflareRealtimeTurn_CalledTwiceWithConfigure_StillAppliesTheSecondCallback()
+    public void AddCloudflareRealtimeTurn_CalledTwiceWithConfigure_AppliesEveryCallback()
     {
         // The guard must skip the registrations, not the caller's configuration.
         using var services = new ServiceCollection()

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -450,4 +450,52 @@ public sealed class CloudflareRealtimeIceServerProviderTests
         Assert.Equal("second", options.ApiToken);
         Assert.True(options.IsConfigured);
     }
+    [Theory]
+    [InlineData("aaa/../../v1/other")]
+    [InlineData("aaa?evil=1")]
+    [InlineData("aaa#fragment")]
+    public async Task GetIceServersAsync_WithAMalformedTokenId_CannotRetargetTheRequest(string tokenId)
+    {
+        // Arrange
+        // The token id is interpolated into the path, where Uri gives several characters meaning: '..'
+        // segments are collapsed and '?' or '#' truncate the path. Unescaped, a token id of
+        // "aaa/../../v1/other" drops the keys segment and posts to a different endpoint entirely, which is
+        // a far more confusing failure than a 404.
+        var handler = new RecordingHandler(ValidResponse);
+        var provider = CreateProvider(handler, Configured(tokenId: tokenId), out _);
+
+        // Act
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(handler.Requests);
+        var uri = new Uri(request.Url);
+
+        Assert.StartsWith("/v1/turn/keys/", uri.AbsolutePath, StringComparison.Ordinal);
+        Assert.EndsWith("/credentials/generate-ice-servers", uri.AbsolutePath, StringComparison.Ordinal);
+        Assert.Empty(uri.Query);
+        Assert.Empty(uri.Fragment);
+    }
+
+    [Fact]
+    public async Task GetIceServersAsync_TrimsWhitespaceAroundTheCredentials()
+    {
+        // Arrange
+        // Values pasted out of a dashboard routinely carry surrounding whitespace. A trailing newline in the
+        // API token makes the Authorization header throw, and a trailing space on the token id becomes %20
+        // in the path; both would show up only as a failure to obtain credentials and a quiet drop to STUN.
+        var handler = new RecordingHandler(ValidResponse);
+        // (char)10 rather than an escape sequence, so the newline this test is about is unmistakable.
+        var provider = CreateProvider(handler, Configured(tokenId: "  token-id-1" + (char)10, apiToken: " token-1 "), out _);
+
+        // Act
+        await provider.GetIceServersAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(handler.Requests);
+        Assert.Equal(
+            "https://cloudflare.test/v1/turn/keys/token-id-1/credentials/generate-ice-servers",
+            request.Url);
+        Assert.Equal("Bearer token-1", request.Authorization);
+    }
 }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -2,6 +2,8 @@ using System.Net;
 using System.Text;
 using CrestApps.Core.AI.Chat.Realtime;
 using CrestApps.Core.AI.Realtime;
+using CrestApps.Core.AI.Chat;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -361,5 +363,46 @@ public sealed class CloudflareRealtimeIceServerProviderTests
 
             public void Dispose() => _dispose();
         }
+    }
+    [Fact]
+    public void AddCloudflareRealtimeTurn_BindsTheKeyFromConfiguration()
+    {
+        // Arrange
+        // The key is supplied as configuration in every real deployment, never in code. Without the binding
+        // the options stay empty and the provider quietly defers to the fallback -- indistinguishable from
+        // nothing having been configured at all, which is the worst way for this to fail.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:KeyId"] = "key-from-configuration",
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:ApiToken"] = "token-from-configuration",
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:TtlSeconds"] = "1200",
+            })
+            .Build();
+
+        // Act
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(configuration)
+            .AddCloudflareRealtimeTurn()
+            .BuildServiceProvider();
+
+        // Assert
+        var options = services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue;
+        Assert.Equal("key-from-configuration", options.KeyId);
+        Assert.Equal("token-from-configuration", options.ApiToken);
+        Assert.Equal(1200, options.TtlSeconds);
+        Assert.True(options.IsConfigured);
+    }
+
+    [Fact]
+    public void AddCloudflareRealtimeTurn_WithNoConfiguration_LeavesTheProviderDormant()
+    {
+        // Registering it must be safe before a key exists.
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddCloudflareRealtimeTurn()
+            .BuildServiceProvider();
+
+        Assert.False(services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue.IsConfigured);
     }
 }

--- a/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Realtime/CloudflareRealtimeIceServerProviderTests.cs
@@ -405,4 +405,49 @@ public sealed class CloudflareRealtimeIceServerProviderTests
 
         Assert.False(services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue.IsConfigured);
     }
+    [Fact]
+    public void AddCloudflareRealtimeTurn_CalledTwice_RegistersOneProviderAndOneBinding()
+    {
+        // Arrange
+        // Hosts enable several realtime surfaces and call the transport registrations per feature. A second
+        // call must not wrap the provider around itself, nor bind the configuration twice -- the binder
+        // appends to collection properties rather than replacing them, which is how duplicate STUN and TURN
+        // URLs got offered to the browser once before.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:TokenId"] = "token-id-from-configuration",
+                ["CrestApps:AI:RealtimeTransport:Cloudflare:ApiToken"] = "token-from-configuration",
+            })
+            .Build();
+
+        var services = new ServiceCollection().AddSingleton<IConfiguration>(configuration);
+
+        // Act
+        services.AddCloudflareRealtimeTurn();
+        services.AddCloudflareRealtimeTurn();
+
+        // Assert
+        Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IRealtimeIceServerProvider) && descriptor.ImplementationFactory is not null);
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue;
+        Assert.Equal("token-id-from-configuration", options.TokenId);
+    }
+
+    [Fact]
+    public void AddCloudflareRealtimeTurn_CalledTwiceWithConfigure_StillAppliesTheSecondCallback()
+    {
+        // The guard must skip the registrations, not the caller's configuration.
+        using var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddCloudflareRealtimeTurn(options => options.TokenId = "first")
+            .AddCloudflareRealtimeTurn(options => options.ApiToken = "second")
+            .BuildServiceProvider();
+
+        var options = services.GetRequiredService<IOptionsMonitor<CloudflareTurnOptions>>().CurrentValue;
+        Assert.Equal("first", options.TokenId);
+        Assert.Equal("second", options.ApiToken);
+        Assert.True(options.IsConfigured);
+    }
 }


### PR DESCRIPTION
Two follow-ups to #175, which shipped in preview.262 with the option unusable.

## 1. The binding was missing

`AddCloudflareRealtimeTurn` called `AddOptions<CloudflareTurnOptions>()` without `BindConfiguration`, so the token could only ever be supplied through the in-code `configure` callback. A deployment that set it as configuration — which is how every real one will — left the options empty.

That failure is invisible. An unconfigured provider defers silently to the fallback, so the application starts normally, realtime voice keeps working over STUN, and the TURN relay that everyone behind a strict NAT depends on is simply absent. It looks identical to having configured nothing at all.

```csharp
services.AddOptions<CloudflareTurnOptions>()
    .BindConfiguration("CrestApps:AI:RealtimeTransport:Cloudflare");
```

Bound from the same section the rest of the realtime transport already reads, matching how `RealtimeTransportOptions` is bound in `AddWebRtcRealtimeTransport`.

## 2. `KeyId` is now `TokenId`

The value is labelled **TURN Token ID** in the Cloudflare dashboard an operator copies it from, so `KeyId` made the setting harder to match to what is on screen. Cloudflare's own API route spells the same value as a key — `/v1/turn/keys/{id}` — which is where the old name came from. The route is unchanged, and a comment now records the discrepancy so the next reader does not assume one of the two is wrong.

This is a rename of a public property, but the safest possible moment for it: the binding that makes the option readable from configuration is in this same branch and unreleased, so no deployment can be relying on the old name yet.

```json
{ "CrestApps": { "AI": { "RealtimeTransport": { "Cloudflare": {
  "TokenId": "<TURN Token ID>", "ApiToken": "<API token>", "TtlSeconds": 86400
} } } } }
```

## Tests

Two new ones for the binding, because nothing at runtime would tell you it had regressed:

- configuration alone produces a configured provider (token id, API token, and TTL all bound)
- no configuration leaves it dormant, so registering before the token exists stays safe

I verified they catch the defect by reverting the fix: the first fails, and passes again once restored. Full suite **3197 passing**, Release build clean with **0 warnings**, docs site builds.

## Note for Orchard Core hosts

`BindConfiguration` reads the host `IConfiguration`. Under Orchard Core that does not include tenant shell configuration, so a host wanting per-tenant tokens still needs a post-configure from `IShellConfiguration`, exactly as `RealtimeTransportOptionsConfiguration` does for the parent section. That belongs in the host repository, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
