### PR TITLE
Let a tool instance vector-search an existing AI data source

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -626,10 +626,20 @@ microphone, desk speakers):
     **data source**, **retrieval model** (`Chunk` by default, or `Hierarchical`), **retrieved documents**
     (top N), **strictness**, **filter**, and whether answers are limited to the retrieved content. These
     are the same parameters a chat interaction configures, applied the same way.
-  - The model's search phrase is embedded with the **same embedding deployment the knowledge base index
+  - The model's search phrases are embedded with the **same embedding deployment the knowledge base index
     was indexed with** — `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by
-    `DataSourceIndexProfileMetadata` — so the query and the stored chunks are compared in the same vector
+    `DataSourceIndexProfileMetadata` — so the queries and the stored chunks are compared in the same vector
     space.
+  - A single call may carry up to three phrases, for a question spanning genuinely distinct topics. They are
+    embedded in **one batched request** and searched **in parallel**, then merged by chunk into a single
+    ranking, so a passage matched by two phrases is returned once under one citation and the union is trimmed
+    to one top-N. Previously the model had to call the tool once per phrase, spending its tool-call iteration
+    budget and getting back independent result sets that nothing deduplicated. Ranking uses **Reciprocal Rank
+    Fusion**, because similarity scores are not comparable across query vectors — ordering the union by raw
+    score lets whichever phrase happens to produce higher similarities crowd the others out entirely.
+    Strictness still applies first as an absolute quality floor on each chunk's best raw score. The cap is
+    enforced by truncation rather than rejection, and exact repeats are dropped before searching; a single
+    phrase behaves exactly as it did.
   - `Hierarchical` retrieval collapses the matching chunks onto their source documents and returns each
     document's complete text under one citation, read back through the data source's own source handler.
     When those documents cannot be read, the search degrades to the matching chunks rather than failing.

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -614,6 +614,33 @@ microphone, desk speakers):
   embedded page excerpt, HTML stripped), so the model has real content to answer from rather than only a
   link.
 
+## Data source search tool instances
+
+- Added a **data source search** tool instance source (`AddDataSourceSearchSource()`) that turns any
+  existing AI data source into its own model-callable vector search function. Until now a data source
+  reached the model only by being attached to an AI profile or chat interaction, which allowed exactly
+  one per conversation and gave the model no say in which knowledge base to consult. An instance binds
+  one data source, so several instances can expose several knowledge bases side by side, each under its
+  own function name and description, and the model picks.
+  - Each instance carries its own retrieval parameters rather than reading them off the resource:
+    **data source**, **retrieval model** (`Chunk` by default, or `Hierarchical`), **retrieved documents**
+    (top N), **strictness**, **filter**, and whether answers are limited to the retrieved content. These
+    are the same parameters a chat interaction configures, applied the same way.
+  - The model's search phrase is embedded with the **same embedding deployment the knowledge base index
+    was indexed with** — `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by
+    `DataSourceIndexProfileMetadata` — so the query and the stored chunks are compared in the same vector
+    space.
+  - `Hierarchical` retrieval collapses the matching chunks onto their source documents and returns each
+    document's complete text under one citation, read back through the data source's own source handler.
+    When those documents cannot be read, the search degrades to the matching chunks rather than failing.
+  - Both editors (MVC and Blazor) gained the matching form section, and `DataSourceRetrievalMode` was
+    added alongside the existing `DocumentRetrievalMode`. The two are separate because
+    `DocumentRetrievalMode` lives in `CrestApps.Core.AI.Documents`, which depends on
+    `CrestApps.Core.AI` — where the new source lives.
+- Refactored the retrieval pipeline behind the profile-bound `DataSourceSearchTool` into a shared
+  internal path both it and the new instances use, so the two honor identical thresholds, filter
+  translation, citation numbering, and output format. Behavior of the existing tool is unchanged.
+
 ## Change Logs
 
 - **Fixed: totals from an uploaded spreadsheet could come back several times too large.** A worksheet

--- a/src/CrestApps.Core.Docs/docs/core/tool-instances.md
+++ b/src/CrestApps.Core.Docs/docs/core/tool-instances.md
@@ -509,7 +509,7 @@ A host that already curates **AI data sources** — an index profile synchronize
 )
 ```
 
-Each instance binds **one** data source plus the retrieval parameters applied to every search it runs, so several instances can expose several knowledge bases side by side, each under its own function name and description. The model supplies only the search phrase.
+Each instance binds **one** data source plus the retrieval parameters applied to every search it runs, so several instances can expose several knowledge bases side by side, each under its own function name and description. The model supplies only the search phrases.
 
 | Setting | Default | Purpose |
 |---|---|---|
@@ -520,9 +520,34 @@ Each instance binds **one** data source plus the retrieval parameters applied to
 | `Filter` | *(none)* | An OData filter expression translated to the index provider's own filter syntax before the search runs. |
 | `IsInScope` | `false` | When set, a search that finds nothing tells the model the answer is unavailable rather than inviting it to fall back to general knowledge. |
 
-The model's phrase is embedded with the **same embedding deployment the knowledge base index was indexed with** — resolved from `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by `DataSourceIndexProfileMetadata` on that profile — so the query and the stored chunks live in the same vector space. This is the identical resolution the indexing service performs, which is what keeps a profile indexed under the top-level embedding deployment queryable.
+The model's phrases are embedded with the **same embedding deployment the knowledge base index was indexed with** — resolved from `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by `DataSourceIndexProfileMetadata` on that profile — so the queries and the stored chunks live in the same vector space. This is the identical resolution the indexing service performs, which is what keeps a profile indexed under the top-level embedding deployment queryable.
 
 Results are returned with `[doc:N]` citations, one index per source document, and each citation is registered on the active invocation context so a host can render it as a link.
+
+### Searching several phrases at once
+
+A question can span genuinely distinct topics — *"how does our vacation policy compare with sick leave?"* — and a single embedding averaging both lands between the two clusters, matching neither well. The model may therefore pass up to **three** phrases in one call:
+
+```json
+{ "queries": ["vacation policy", "sick leave policy"] }
+```
+
+What that buys, and what it costs:
+
+- **One embedding call, not N.** All phrases are embedded in a single batched request, so covering three topics costs one round trip to the embedding model rather than three.
+- **One tool call, not N.** Without this the model must invoke the tool once per phrase, spending its tool-call iteration budget and returning three independent result sets that nothing deduplicates.
+- **N index queries, run in parallel.** Each phrase is still its own vector search — that cost does not batch. They are issued concurrently, which matters on a realtime session where a grounded turn cannot start speaking until retrieval returns.
+- **One fused ranking.** Results are merged by chunk, so a passage matched by two phrases is returned once under one citation, and the whole union is trimmed to a single top-N.
+
+Ranking uses **Reciprocal Rank Fusion** rather than raw score. Similarity scores are not comparable across query vectors: a broad phrase whose best match scores 0.60 and a narrow phrase whose best match scores 0.95 are each returning their own best answer, so ordering the union by score lets the narrow phrase crowd the broad one out entirely. RRF ranks by each result's *position within its own phrase's results*, so every phrase's best hit competes on equal footing. Strictness still applies first, as an absolute quality floor on each chunk's best raw score — it answers *"was this ever a good match?"*, while RRF decides the order among survivors.
+
+:::warning
+Given an array, a model will cheerfully send six rewordings of one idea. Near-synonyms retrieve nearly identical chunks, so the extra phrases cost index queries and buy nothing. The schema description says so explicitly, and the cap of `DataSourceRetrieval.MaxQueries` (3) is enforced server-side by **truncation, not rejection** — an over-eager caller still gets an answer rather than an error it has to recover from. Exact repeats are dropped before searching.
+:::
+
+:::note
+One phrase is the common case and collapses to the previous behavior exactly: a single result set fused with itself is ordered by score. The profile-bound `DataSourceSearchTool` always passes one phrase, so it is unaffected.
+:::
 
 :::note
 `Hierarchical` reads every matched document back through the data source's own source handler, so it returns far more context than `Chunk` — a handful of whole documents instead of a handful of paragraphs. If those documents cannot be read (a deleted source index, revoked credentials), the search degrades to the matching chunks rather than failing.

--- a/src/CrestApps.Core.Docs/docs/core/tool-instances.md
+++ b/src/CrestApps.Core.Docs/docs/core/tool-instances.md
@@ -498,6 +498,40 @@ The defaults target the WordPress REST search endpoint, so a WordPress site need
 | `TitlePath` / `UrlPath` / `SnippetPath` | `title` / `url` / `_embedded.self[0].excerpt.rendered` | Dotted paths (supporting `[index]`) to each result's fields. Point `SnippetPath` at `_embedded.self[0].content.rendered` for the full body. |
 | `MaxResults` | global default | Caps the number of results returned. |
 
+## Built-In Data Source Search Tool
+
+A host that already curates **AI data sources** — an index profile synchronized into a knowledge base index of embedded chunks — can expose any one of them to the model as its own callable vector search function. Register the source with `AddDataSourceSearchSource()`:
+
+```csharp
+.AddToolInstances(toolInstances => toolInstances
+    .AddYesSqlStores()
+    .AddDataSourceSearchSource()
+)
+```
+
+Each instance binds **one** data source plus the retrieval parameters applied to every search it runs, so several instances can expose several knowledge bases side by side, each under its own function name and description. The model supplies only the search phrase.
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `DataSourceId` | *(required)* | The AI data source this instance searches. |
+| `RetrievalMode` | `Chunk` | `Chunk` returns only the matching chunks. `Hierarchical` collapses the matches onto their source documents and returns each document's complete text. |
+| `TopNDocuments` | site default | The number of top-scoring results to return, between `AIDataSourceOptions.MinTopNDocuments` and `MaxTopNDocuments`. |
+| `Strictness` | site default | How relevant a result must be to survive, between `AIDataSourceOptions.MinStrictness` and `MaxStrictness`. Higher values keep only closer matches. |
+| `Filter` | *(none)* | An OData filter expression translated to the index provider's own filter syntax before the search runs. |
+| `IsInScope` | `false` | When set, a search that finds nothing tells the model the answer is unavailable rather than inviting it to fall back to general knowledge. |
+
+The model's phrase is embedded with the **same embedding deployment the knowledge base index was indexed with** — resolved from `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by `DataSourceIndexProfileMetadata` on that profile — so the query and the stored chunks live in the same vector space. This is the identical resolution the indexing service performs, which is what keeps a profile indexed under the top-level embedding deployment queryable.
+
+Results are returned with `[doc:N]` citations, one index per source document, and each citation is registered on the active invocation context so a host can render it as a link.
+
+:::note
+`Hierarchical` reads every matched document back through the data source's own source handler, so it returns far more context than `Chunk` — a handful of whole documents instead of a handful of paragraphs. If those documents cannot be read (a deleted source index, revoked credentials), the search degrades to the matching chunks rather than failing.
+:::
+
+:::tip
+This source and the profile-bound `DataSourceSearchTool` share one retrieval pipeline, so an instance honors exactly the same parameters, thresholds, and output format as the data source attached directly to an AI profile. The difference is where the parameters come from: the instance carries its own, instead of reading `AIDataSourceRagMetadata` off the profile or chat interaction.
+:::
+
 ## Creating Instances in the Sample Hosts
 
 In the sample hosts, open **AI Tool Instances**, then:

--- a/src/Primitives/CrestApps.Core.AI/Models/DataSourceRetrievalMode.cs
+++ b/src/Primitives/CrestApps.Core.AI/Models/DataSourceRetrievalMode.cs
@@ -1,0 +1,19 @@
+namespace CrestApps.Core.AI.Models;
+
+/// <summary>
+/// Specifies how matching content is returned from an AI data source knowledge base.
+/// </summary>
+public enum DataSourceRetrievalMode
+{
+    /// <summary>
+    /// Returns only the individual chunks that matched the query. This keeps the context small and is the
+    /// default.
+    /// </summary>
+    Chunk = 0,
+
+    /// <summary>
+    /// Returns the full source documents the matching chunks belong to. This gives the model complete
+    /// context at the cost of a much larger payload.
+    /// </summary>
+    Hierarchical = 1,
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
@@ -27,6 +27,14 @@ namespace CrestApps.Core.AI.Services;
 internal static class DataSourceRetrieval
 {
     /// <summary>
+    /// The most phrases one search may embed and run. Each phrase costs its own index query, and a model
+    /// handed an array will happily send six rewordings of one idea — which retrieves nearly the same chunks
+    /// six times over. Extra phrases are dropped rather than rejected, so an over-eager caller still gets an
+    /// answer instead of an error it has to recover from.
+    /// </summary>
+    public const int MaxQueries = 3;
+
+    /// <summary>
     /// Searches the requested data source and returns the text to hand back to the AI model.
     /// </summary>
     /// <param name="services">The request services used to resolve the stores, index provider, and embedding generator.</param>
@@ -44,6 +52,15 @@ internal static class DataSourceRetrieval
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(request);
+
+        var queries = NormalizeQueries(request.Queries);
+
+        if (queries.Count == 0)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: no search phrase was supplied.", toolName);
+
+            return "No search phrase was supplied. Provide at least one phrase to search for.";
+        }
 
         var dataSourceStore = services.GetRequiredService<IAIDataSourceStore>();
         var dataSource = await dataSourceStore.FindByIdAsync(request.DataSourceId, cancellationToken);
@@ -90,13 +107,20 @@ internal static class DataSourceRetrieval
             return "Embedding configuration is missing for the knowledge base index.";
         }
 
-        var embeddings = await embeddingGenerator.GenerateAsync([request.Query], cancellationToken: cancellationToken);
+        // One batched call regardless of how many phrases were asked for: the embedding API takes the whole
+        // set, so N phrases cost one round trip rather than N.
+        var embeddings = await embeddingGenerator.GenerateAsync(queries, cancellationToken: cancellationToken);
 
-        if (embeddings == null || embeddings.Count == 0 || embeddings[0]?.Vector == null)
+        var vectors = embeddings?
+            .Where(embedding => embedding?.Vector != null)
+            .Select(embedding => embedding.Vector.ToArray())
+            .ToList() ?? [];
+
+        if (vectors.Count == 0)
         {
-            logger.LogWarning("AI tool '{ToolName}' failed: could not generate embedding for query.", toolName);
+            logger.LogWarning("AI tool '{ToolName}' failed: could not generate embeddings for the search phrases.", toolName);
 
-            return "Failed to generate embedding for the search query.";
+            return "Failed to generate embeddings for the search phrases.";
         }
 
         var siteSettings = services.GetRequiredService<IOptionsMonitor<AIDataSourceOptions>>().CurrentValue;
@@ -118,15 +142,20 @@ internal static class DataSourceRetrieval
             }
         }
 
-        var results = await contentManager.SearchAsync(
-            masterIndexProfile,
-            embeddings[0].Vector.ToArray(),
-            request.DataSourceId,
-            DataSourceSearchResultSelector.GetCandidateCount(topN),
-            providerFilter,
-            cancellationToken);
+        var candidateCount = DataSourceSearchResultSelector.GetCandidateCount(topN);
 
-        if (results == null || !results.Any())
+        // The phrases are independent queries against a thread-safe index client, so they run together rather
+        // than one after another. That matters on a realtime session, where a grounded turn cannot start
+        // speaking until retrieval returns.
+        var resultSets = await Task.WhenAll(vectors.Select(vector => contentManager.SearchAsync(
+            masterIndexProfile,
+            vector,
+            request.DataSourceId,
+            candidateCount,
+            providerFilter,
+            cancellationToken)));
+
+        if (resultSets.All(resultSet => resultSet == null || !resultSet.Any()))
         {
             return request.IsInScope
                 ? "No relevant content was found in the data source for this query. The answer is not available in the configured data source."
@@ -134,7 +163,7 @@ internal static class DataSourceRetrieval
         }
 
         var minimumScore = siteSettings.GetMinimumScore(request.Strictness);
-        var selected = DataSourceSearchResultSelector.SelectTopResults(results, topN, minimumScore);
+        var selected = DataSourceSearchResultSelector.FuseTopResults(resultSets, topN, minimumScore);
 
         if (selected.Count == 0)
         {
@@ -169,6 +198,49 @@ internal static class DataSourceRetrieval
         builder.Append(references.Render());
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// Trims the requested phrases to the set actually worth searching: blanks dropped, exact repeats
+    /// collapsed, and the remainder capped at <see cref="MaxQueries"/>.
+    /// </summary>
+    /// <param name="queries">The requested phrases.</param>
+    /// <returns>The phrases to embed and search.</returns>
+    private static List<string> NormalizeQueries(IReadOnlyList<string> queries)
+    {
+        if (queries is not { Count: > 0 })
+        {
+            return [];
+        }
+
+        var normalized = new List<string>(Math.Min(queries.Count, MaxQueries));
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var query in queries)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                continue;
+            }
+
+            var trimmed = query.Trim();
+
+            // An exact repeat costs a whole index query and returns the same chunks, so it never survives.
+            // Near-synonyms cannot be caught here — the schema description is what discourages those.
+            if (!seen.Add(trimmed))
+            {
+                continue;
+            }
+
+            normalized.Add(trimmed);
+
+            if (normalized.Count == MaxQueries)
+            {
+                break;
+            }
+        }
+
+        return normalized;
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
@@ -1,0 +1,473 @@
+using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Deployments;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.Infrastructure.Indexing;
+using CrestApps.Core.Infrastructure.Indexing.DataSources;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+using CrestApps.Core.Support;
+using Cysharp.Text;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CrestApps.Core.AI.Services;
+
+/// <summary>
+/// Runs a vector search against one AI data source knowledge base and renders the matches as prompt-ready
+/// text with citations. The query is embedded with the same embedding deployment the knowledge base index
+/// profile was indexed with, so a phrase searched here lands in the same vector space as the stored chunks.
+/// </summary>
+/// <remarks>
+/// This is shared by the profile-bound <c>DataSourceSearchTool</c> and by the configured data source search
+/// tool instances, so both honor identical retrieval parameters and produce identically formatted results.
+/// </remarks>
+internal static class DataSourceRetrieval
+{
+    /// <summary>
+    /// Searches the requested data source and returns the text to hand back to the AI model.
+    /// </summary>
+    /// <param name="services">The request services used to resolve the stores, index provider, and embedding generator.</param>
+    /// <param name="request">The query-time retrieval parameters.</param>
+    /// <param name="toolName">The name of the calling tool, used for logging.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The formatted search results, or a message explaining why no content could be returned.</returns>
+    public static async Task<string> SearchAsync(
+        IServiceProvider services,
+        DataSourceRetrievalRequest request,
+        string toolName,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dataSourceStore = services.GetRequiredService<IAIDataSourceStore>();
+        var dataSource = await dataSourceStore.FindByIdAsync(request.DataSourceId, cancellationToken);
+
+        if (dataSource == null)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: data source '{DataSourceId}' was not found.", toolName, request.DataSourceId);
+
+            return $"Data source '{request.DataSourceId}' was not found.";
+        }
+
+        if (string.IsNullOrEmpty(dataSource.AIKnowledgeBaseIndexProfileName))
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: no knowledge base index configured for data source '{DataSourceId}'.", toolName, request.DataSourceId);
+
+            return "No knowledge base index is configured for this data source. Please configure a knowledge base index in the data source settings.";
+        }
+
+        var indexProfileStore = services.GetRequiredService<ISearchIndexProfileStore>();
+        var masterIndexProfile = await indexProfileStore.FindByNameAsync(dataSource.AIKnowledgeBaseIndexProfileName, cancellationToken);
+
+        if (masterIndexProfile == null)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: knowledge base index '{IndexProfileName}' was not found.", toolName, dataSource.AIKnowledgeBaseIndexProfileName);
+
+            return $"Knowledge base index '{dataSource.AIKnowledgeBaseIndexProfileName}' was not found.";
+        }
+
+        var contentManager = services.GetKeyedService<IDataSourceContentManager>(masterIndexProfile.ProviderName);
+
+        if (contentManager == null)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: no vector search service for provider '{ProviderName}'.", toolName, masterIndexProfile.ProviderName);
+
+            return $"No vector search service is available for provider '{masterIndexProfile.ProviderName}'.";
+        }
+
+        var embeddingGenerator = await CreateEmbeddingGeneratorAsync(services, masterIndexProfile, cancellationToken);
+
+        if (embeddingGenerator == null)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: embedding configuration is missing for the knowledge base index.", toolName);
+
+            return "Embedding configuration is missing for the knowledge base index.";
+        }
+
+        var embeddings = await embeddingGenerator.GenerateAsync([request.Query], cancellationToken: cancellationToken);
+
+        if (embeddings == null || embeddings.Count == 0 || embeddings[0]?.Vector == null)
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: could not generate embedding for query.", toolName);
+
+            return "Failed to generate embedding for the search query.";
+        }
+
+        var siteSettings = services.GetRequiredService<IOptionsMonitor<AIDataSourceOptions>>().CurrentValue;
+        var topN = siteSettings.GetTopNDocuments(request.TopNDocuments);
+
+        string providerFilter = null;
+
+        if (!string.IsNullOrWhiteSpace(request.Filter))
+        {
+            var filterTranslator = services.GetKeyedService<IODataFilterTranslator>(masterIndexProfile.ProviderName);
+
+            if (filterTranslator != null)
+            {
+                providerFilter = filterTranslator.Translate(request.Filter);
+            }
+            else
+            {
+                logger.LogWarning("No OData filter translator available for provider '{ProviderName}'. Filter will be ignored.", masterIndexProfile.ProviderName);
+            }
+        }
+
+        var results = await contentManager.SearchAsync(
+            masterIndexProfile,
+            embeddings[0].Vector.ToArray(),
+            request.DataSourceId,
+            DataSourceSearchResultSelector.GetCandidateCount(topN),
+            providerFilter,
+            cancellationToken);
+
+        if (results == null || !results.Any())
+        {
+            return request.IsInScope
+                ? "No relevant content was found in the data source for this query. The answer is not available in the configured data source."
+                : "No relevant content was found in the data source for this query. Answer using your general knowledge instead.";
+        }
+
+        var minimumScore = siteSettings.GetMinimumScore(request.Strictness);
+        var selected = DataSourceSearchResultSelector.SelectTopResults(results, topN, minimumScore);
+
+        if (selected.Count == 0)
+        {
+            return request.IsInScope
+                ? "No results met the strictness and quality thresholds. The answer is not available in the configured data source."
+                : "No results met the strictness and quality thresholds. Answer using your general knowledge instead.";
+        }
+
+        var textNormalizer = services.GetRequiredService<IAITextNormalizer>();
+        var references = new ReferenceCollector(AIInvocationScope.Current);
+
+        using var builder = ZString.CreateStringBuilder();
+        builder.AppendLine("Relevant content from data source:");
+
+        if (request.RetrievalMode == DataSourceRetrievalMode.Hierarchical)
+        {
+            builder.Append(await AppendHierarchicalContextAsync(
+                services,
+                dataSource,
+                selected,
+                topN,
+                textNormalizer,
+                references,
+                logger,
+                cancellationToken));
+        }
+        else
+        {
+            builder.Append(AppendChunkContext(selected, textNormalizer, references));
+        }
+
+        builder.Append(references.Render());
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Creates the embedding generator the supplied knowledge base index profile was indexed with, so a
+    /// query is embedded by the same model that produced the stored chunk vectors.
+    /// </summary>
+    /// <param name="services">The request services.</param>
+    /// <param name="indexProfile">The knowledge base index profile.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The embedding generator, or <see langword="null"/> when no embedding deployment is configured.</returns>
+    private static async Task<IEmbeddingGenerator<string, Embedding<float>>> CreateEmbeddingGeneratorAsync(
+        IServiceProvider services,
+        SearchIndexProfile indexProfile,
+        CancellationToken cancellationToken)
+    {
+        // Resolve the query-embedding deployment exactly the way the indexing service does: it lives on
+        // the index profile itself (indexProfile.EmbeddingDeploymentName) and is only optionally overridden
+        // by the data-source metadata. The metadata being absent must NOT fail search, or a profile that
+        // indexed fine using the top-level embedding deployment could never be queried.
+        var deploymentName = indexProfile.EmbeddingDeploymentName;
+
+        if (indexProfile.TryGet(out DataSourceIndexProfileMetadata profileMetadata) &&
+            !string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
+        {
+            deploymentName = profileMetadata.EmbeddingDeploymentName;
+        }
+
+        if (string.IsNullOrWhiteSpace(deploymentName))
+        {
+            return null;
+        }
+
+        var deployment = await services.GetRequiredService<IAIDeploymentManager>().FindByNameAsync(deploymentName, cancellationToken);
+
+        if (deployment == null)
+        {
+            return null;
+        }
+
+        return await services.GetRequiredService<IAIClientFactory>().CreateEmbeddingGeneratorAsync(deployment);
+    }
+
+    /// <summary>
+    /// Renders each matching chunk on its own, which keeps the injected context as small as the match itself.
+    /// </summary>
+    /// <param name="results">The selected search results.</param>
+    /// <param name="textNormalizer">The text normalizer used to clean citation titles.</param>
+    /// <param name="references">The citation collector.</param>
+    /// <returns>The rendered chunks.</returns>
+    private static string AppendChunkContext(
+        IReadOnlyList<DataSourceSearchResult> results,
+        IAITextNormalizer textNormalizer,
+        ReferenceCollector references)
+    {
+        using var builder = ZString.CreateStringBuilder();
+
+        foreach (var result in results)
+        {
+            if (string.IsNullOrWhiteSpace(result.Content))
+            {
+                continue;
+            }
+
+            var entry = references.Track(result.ReferenceId, ResolveReferenceTitle(textNormalizer, result.Title, result.ReferenceId), result.ReferenceType);
+
+            builder.AppendLine("---");
+
+            if (!string.IsNullOrWhiteSpace(entry.Title))
+            {
+                builder.Append(entry.Label);
+                builder.Append(" Title: ");
+                builder.AppendLine(entry.Title);
+            }
+
+            builder.Append(entry.Label);
+            builder.Append(' ');
+            builder.AppendLine(result.Content);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Renders the full source document behind each match instead of the matching chunk alone. Matches are
+    /// collapsed per source document, and every document is read back through the data source's own source
+    /// handler so the model sees the complete text rather than a window into it.
+    /// </summary>
+    /// <param name="services">The request services.</param>
+    /// <param name="dataSource">The data source being searched.</param>
+    /// <param name="results">The selected search results.</param>
+    /// <param name="topN">The maximum number of source documents to return.</param>
+    /// <param name="textNormalizer">The text normalizer used to clean citation titles.</param>
+    /// <param name="references">The citation collector.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The rendered documents, falling back to the chunk rendering when the documents cannot be read.</returns>
+    private static async Task<string> AppendHierarchicalContextAsync(
+        IServiceProvider services,
+        AIDataSource dataSource,
+        IReadOnlyList<DataSourceSearchResult> results,
+        int topN,
+        IAITextNormalizer textNormalizer,
+        ReferenceCollector references,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var sourceType = AIDataSourceSourceHelper.GetSource(dataSource);
+        var sourceHandler = services.GetKeyedService<IAIDataSourceSourceHandler>(sourceType);
+
+        var groups = results
+            .Where(result => !string.IsNullOrWhiteSpace(result.ReferenceId))
+            .GroupBy(result => result.ReferenceId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => new
+            {
+                ReferenceId = group.Key,
+                Score = group.Max(result => result.Score),
+                Title = group.Select(result => result.Title).FirstOrDefault(title => !string.IsNullOrWhiteSpace(title)),
+                ReferenceType = group.Select(result => result.ReferenceType).FirstOrDefault(type => !string.IsNullOrWhiteSpace(type)),
+                Chunks = group.OrderBy(result => result.ChunkIndex).Select(result => result.Content).ToList(),
+            })
+            .OrderByDescending(group => group.Score)
+            .Take(topN)
+            .ToList();
+
+        if (sourceHandler == null || groups.Count == 0)
+        {
+            if (sourceHandler == null)
+            {
+                logger.LogWarning("Hierarchical retrieval is unavailable because source type '{SourceType}' is not registered. Falling back to chunk retrieval.", sourceType);
+            }
+
+            return AppendChunkContext(results, textNormalizer, references);
+        }
+
+        var documents = new Dictionary<string, SourceDocument>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            await foreach (var pair in sourceHandler.ReadByIdsAsync(dataSource, groups.Select(group => group.ReferenceId), cancellationToken))
+            {
+                if (!string.IsNullOrWhiteSpace(pair.Key) && pair.Value != null)
+                {
+                    documents[pair.Key] = pair.Value;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A source that can no longer be read (a deleted index, revoked credentials) must not sink the
+            // search: the matching chunks are already in hand, so degrade to chunk retrieval instead.
+            logger.LogWarning(ex, "Failed to read full documents for data source '{DataSourceId}'. Falling back to chunk retrieval.", dataSource.ItemId);
+
+            return AppendChunkContext(results, textNormalizer, references);
+        }
+
+        using var builder = ZString.CreateStringBuilder();
+
+        foreach (var group in groups)
+        {
+            documents.TryGetValue(group.ReferenceId, out var document);
+
+            var content = string.IsNullOrWhiteSpace(document?.Content)
+                ? string.Join("\n", group.Chunks.Where(chunk => !string.IsNullOrWhiteSpace(chunk)))
+                : document.Content;
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                continue;
+            }
+
+            var title = ResolveReferenceTitle(textNormalizer, document?.Title ?? group.Title, group.ReferenceId);
+            var entry = references.Track(group.ReferenceId, title, group.ReferenceType);
+
+            builder.AppendLine("---");
+
+            if (!string.IsNullOrWhiteSpace(entry.Title))
+            {
+                builder.Append(entry.Label);
+                builder.Append(" Title: ");
+                builder.AppendLine(entry.Title);
+            }
+
+            builder.Append(entry.Label);
+            builder.Append(' ');
+            builder.AppendLine(content);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Resolves a citation title that never exposes a serialized source document.
+    /// </summary>
+    /// <param name="textNormalizer">The text normalizer.</param>
+    /// <param name="title">The indexed document title.</param>
+    /// <param name="referenceId">The document reference identifier used as the fallback title.</param>
+    /// <returns>The resolved citation title.</returns>
+    private static string ResolveReferenceTitle(IAITextNormalizer textNormalizer, string title, string referenceId)
+    {
+        var normalizedTitle = textNormalizer.NormalizeTitle(title);
+
+        if (string.IsNullOrWhiteSpace(normalizedTitle) || DocumentTitleResolver.LooksLikeSerializedDocument(normalizedTitle))
+        {
+            return referenceId;
+        }
+
+        return normalizedTitle;
+    }
+
+    /// <summary>
+    /// Assigns one citation index per source document and renders the trailing reference list, registering
+    /// each citation on the active invocation context so the UI can turn it into a link.
+    /// </summary>
+    private sealed class ReferenceCollector
+    {
+        private readonly Dictionary<string, (int Index, string Title, string ReferenceType)> _seen = new(StringComparer.OrdinalIgnoreCase);
+        private readonly AIInvocationContext _invocationContext;
+        private int _fallbackIndex;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReferenceCollector"/> class.
+        /// </summary>
+        /// <param name="invocationContext">The active invocation context, or <see langword="null"/> when the tool runs outside one.</param>
+        public ReferenceCollector(AIInvocationContext invocationContext)
+        {
+            _invocationContext = invocationContext;
+        }
+
+        /// <summary>
+        /// Records one rendered result and returns the citation label and title to print with it.
+        /// </summary>
+        /// <param name="referenceId">The source document reference identifier.</param>
+        /// <param name="title">The resolved citation title.</param>
+        /// <param name="referenceType">The reference type used to build links.</param>
+        public (string Label, string Title) Track(string referenceId, string title, string referenceType)
+        {
+            if (string.IsNullOrEmpty(referenceId))
+            {
+                return ($"[doc:{NextIndex()}]", title);
+            }
+
+            if (!_seen.TryGetValue(referenceId, out var entry))
+            {
+                entry = (NextIndex(), title, referenceType);
+                _seen[referenceId] = entry;
+            }
+
+            return ($"[doc:{entry.Index}]", entry.Title);
+        }
+
+        /// <summary>
+        /// Renders the reference list appended after the retrieved content.
+        /// </summary>
+        public string Render()
+        {
+            if (_seen.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            using var builder = ZString.CreateStringBuilder();
+            builder.AppendLine();
+            builder.AppendLine("References:");
+
+            foreach (var kvp in _seen)
+            {
+                builder.Append("[doc:");
+                builder.Append(kvp.Value.Index);
+                builder.Append("] = ");
+                builder.AppendLine(kvp.Key);
+            }
+
+            if (_invocationContext != null)
+            {
+                foreach (var kvp in _seen)
+                {
+                    var template = $"[doc:{kvp.Value.Index}]";
+
+                    _invocationContext.ToolReferences.TryAdd(template, new AICompletionReference
+                    {
+                        Text = string.IsNullOrWhiteSpace(kvp.Value.Title) ? template : kvp.Value.Title,
+                        Title = kvp.Value.Title,
+                        Index = kvp.Value.Index,
+                        ReferenceId = kvp.Key,
+                        ReferenceType = kvp.Value.ReferenceType,
+                    });
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private int NextIndex()
+        {
+            return _invocationContext?.NextReferenceIndex() ?? ++_fallbackIndex;
+        }
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
@@ -13,9 +13,10 @@ internal sealed class DataSourceRetrievalRequest
     public string DataSourceId { get; init; }
 
     /// <summary>
-    /// Gets the natural-language phrase to embed and search for.
+    /// Gets the natural-language phrases to embed and search for. Every phrase is embedded in one batched
+    /// call and searched independently, and the result sets are fused into a single ranking.
     /// </summary>
-    public string Query { get; init; }
+    public IReadOnlyList<string> Queries { get; init; }
 
     /// <summary>
     /// Gets the number of top-scoring results to return. When not set, the configured site default is used.

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
@@ -1,0 +1,45 @@
+using CrestApps.Core.AI.Models;
+
+namespace CrestApps.Core.AI.Services;
+
+/// <summary>
+/// The query-time parameters used to search a single AI data source knowledge base.
+/// </summary>
+internal sealed class DataSourceRetrievalRequest
+{
+    /// <summary>
+    /// Gets the identifier of the data source to search.
+    /// </summary>
+    public string DataSourceId { get; init; }
+
+    /// <summary>
+    /// Gets the natural-language phrase to embed and search for.
+    /// </summary>
+    public string Query { get; init; }
+
+    /// <summary>
+    /// Gets the number of top-scoring results to return. When not set, the configured site default is used.
+    /// </summary>
+    public int? TopNDocuments { get; init; }
+
+    /// <summary>
+    /// Gets the strictness threshold used to derive the minimum score a result must reach.
+    /// </summary>
+    public int? Strictness { get; init; }
+
+    /// <summary>
+    /// Gets the OData filter expression translated to the provider's own filter syntax before searching.
+    /// </summary>
+    public string Filter { get; init; }
+
+    /// <summary>
+    /// Gets the retrieval mode that decides whether matching chunks or their full source documents are returned.
+    /// </summary>
+    public DataSourceRetrievalMode RetrievalMode { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the model must answer only from the retrieved content. This only
+    /// changes the guidance returned when nothing relevant is found.
+    /// </summary>
+    public bool IsInScope { get; init; }
+}

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceSearchResultSelector.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceSearchResultSelector.cs
@@ -25,6 +25,12 @@ internal static class DataSourceSearchResultSelector
     ];
 
     /// <summary>
+    /// The damping constant used by Reciprocal Rank Fusion. 60 is the value from the original paper and the
+    /// one every mainstream implementation uses.
+    /// </summary>
+    private const int RankFusionConstant = 60;
+
+    /// <summary>
     /// Gets the candidate count to request from the vector store so result filtering has enough headroom.
     /// </summary>
     /// <param name="topN">The final result count requested by the caller.</param>
@@ -59,13 +65,102 @@ internal static class DataSourceSearchResultSelector
         }
 
         return results
-            .Where(result => result != null)
-            .Where(result => !string.IsNullOrWhiteSpace(result.Content))
-            .Where(result => minimumScore <= 0 || result.Score >= minimumScore)
-            .Where(result => !ShouldExclude(result))
+            .Where(result => IsAcceptable(result, minimumScore))
             .OrderByDescending(result => result.Score)
             .Take(topN)
             .ToList();
+    }
+
+    /// <summary>
+    /// Fuses the result sets of several queries into one ranking with Reciprocal Rank Fusion, keeping each
+    /// matching chunk once.
+    /// </summary>
+    /// <remarks>
+    /// Similarity scores are not comparable across query vectors: a broad phrase whose best match scores 0.6
+    /// and a narrow phrase whose best match scores 0.9 are both returning their own best answer. Ranking the
+    /// union by raw score therefore lets whichever phrase happens to produce higher similarities crowd the
+    /// others out. RRF ranks by each result's <em>position</em> within its own query's list instead, so a
+    /// result that placed first for any phrase competes on equal footing. Strictness still applies as an
+    /// absolute quality floor before fusion, using each chunk's best raw score across the phrases that
+    /// returned it — it answers "was this ever a good match?", while RRF decides the order among survivors.
+    /// With a single query set the fused order is the score order, so one phrase behaves exactly as before.
+    /// </remarks>
+    /// <param name="resultSets">The per-query result sets, one per searched phrase.</param>
+    /// <param name="topN">The maximum number of results to return.</param>
+    /// <param name="minimumScore">The minimum score threshold.</param>
+    /// <returns>The fused, filtered, and trimmed results.</returns>
+    public static IReadOnlyList<DataSourceSearchResult> FuseTopResults(
+        IEnumerable<IEnumerable<DataSourceSearchResult>> resultSets,
+        int topN,
+        float minimumScore)
+    {
+        if (resultSets == null || topN <= 0)
+        {
+            return [];
+        }
+
+        var fused = new Dictionary<string, (DataSourceSearchResult Best, double Score)>(StringComparer.Ordinal);
+
+        foreach (var resultSet in resultSets)
+        {
+            if (resultSet == null)
+            {
+                continue;
+            }
+
+            var ranked = resultSet
+                .Where(result => IsAcceptable(result, minimumScore))
+                .OrderByDescending(result => result.Score)
+                .ToList();
+
+            for (var index = 0; index < ranked.Count; index++)
+            {
+                var result = ranked[index];
+                var key = GetChunkKey(result);
+
+                // The standard RRF damping constant. It keeps a result that placed first for one phrase from
+                // dominating one that placed second for several.
+                var contribution = 1d / (RankFusionConstant + index + 1);
+
+                if (fused.TryGetValue(key, out var existing))
+                {
+                    fused[key] = (existing.Best.Score >= result.Score ? existing.Best : result, existing.Score + contribution);
+                }
+                else
+                {
+                    fused[key] = (result, contribution);
+                }
+            }
+        }
+
+        return fused.Values
+            .OrderByDescending(entry => entry.Score)
+            .ThenByDescending(entry => entry.Best.Score)
+            .Take(topN)
+            .Select(entry => entry.Best)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Builds the identity used to recognize the same chunk returned by more than one query.
+    /// </summary>
+    /// <param name="result">The search result.</param>
+    /// <returns>The chunk identity.</returns>
+    private static string GetChunkKey(DataSourceSearchResult result)
+    {
+        // A result with no reference id cannot be identified by document, so its content stands in. That is
+        // what a caller would compare by eye, and it still collapses the same passage returned twice.
+        return string.IsNullOrEmpty(result.ReferenceId)
+            ? $"content:{result.Content}"
+            : $"ref:{result.ReferenceId}:{result.ChunkIndex}";
+    }
+
+    private static bool IsAcceptable(DataSourceSearchResult result, float minimumScore)
+    {
+        return result != null &&
+            !string.IsNullOrWhiteSpace(result.Content) &&
+            (minimumScore <= 0 || result.Score >= minimumScore) &&
+            !ShouldExclude(result);
     }
 
     private static bool ShouldExclude(DataSourceSearchResult result)

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolConstants.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolConstants.cs
@@ -1,0 +1,20 @@
+namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
+
+/// <summary>
+/// Well-known identifiers for the built-in AI data source search tool instance source.
+/// </summary>
+public static class DataSourceSearchToolConstants
+{
+    /// <summary>
+    /// The registered source name of the data source search source. It is stored as the
+    /// <see cref="CrestApps.Core.Models.SourceCatalogEntry.Source"/> of every
+    /// <see cref="AIToolInstance"/> created from it.
+    /// </summary>
+    public const string SourceName = "data-source-search";
+
+    /// <summary>
+    /// The category applied to the data source search source so it is grouped with the other
+    /// knowledge-base tools.
+    /// </summary>
+    public const string Category = "Knowledgebase";
+}

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using CrestApps.Core.AI.Extensions;
+using CrestApps.Core.AI.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
+
+/// <summary>
+/// An <see cref="AIFunction"/> produced by the data source search tool instance source. Each function is
+/// bound to a single configured <see cref="CrestApps.Core.AI.Models.AIDataSource"/> and searches only that
+/// data source, so a host can expose one callable function per knowledge base it wants the model to reach.
+/// </summary>
+/// <remarks>
+/// The model supplies only the search phrase. That phrase is embedded with the same embedding deployment
+/// the data source's knowledge base index was indexed with, so it is compared against the stored chunks in
+/// the same vector space. Every other retrieval parameter — retrieval mode, retrieved document count,
+/// strictness, and filter — comes from the instance settings the user configured.
+/// </remarks>
+public sealed class DataSourceSearchToolFunction : AIFunction
+{
+    private static readonly JsonElement _jsonSchema = JsonSerializer.Deserialize<JsonElement>(
+    """
+    {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "A short set of keywords describing what to look for, extracted from the user's request. Pass the essential search terms (nouns and distinctive words), not the user's full sentence or question."
+        }
+      },
+      "required": ["query"],
+      "additionalProperties": false
+    }
+    """);
+
+    private readonly string _name;
+    private readonly string _description;
+    private readonly DataSourceSearchToolSettings _settings;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataSourceSearchToolFunction"/> class.
+    /// </summary>
+    /// <param name="name">The function name exposed to the AI model.</param>
+    /// <param name="description">The description exposed to the AI model.</param>
+    /// <param name="settings">The configured instance settings applied to every search.</param>
+    public DataSourceSearchToolFunction(string name, string description, DataSourceSearchToolSettings settings)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        _name = name;
+        _description = string.IsNullOrWhiteSpace(description)
+            ? name
+            : description;
+        _settings = settings;
+    }
+
+    /// <summary>
+    /// Gets the function name exposed to the AI model.
+    /// </summary>
+    public override string Name => _name;
+
+    /// <summary>
+    /// Gets the description exposed to the AI model.
+    /// </summary>
+    public override string Description => _description;
+
+    /// <summary>
+    /// Gets the JSON schema describing the arguments the model may supply.
+    /// </summary>
+    public override JsonElement JsonSchema => _jsonSchema;
+
+    /// <summary>
+    /// Gets additional metadata applied to the function.
+    /// </summary>
+    public override IReadOnlyDictionary<string, object> AdditionalProperties { get; } = new Dictionary<string, object>
+    {
+        ["Strict"] = false,
+    };
+
+    /// <summary>
+    /// Searches the configured data source for the supplied query.
+    /// </summary>
+    /// <param name="arguments">The arguments supplied by the AI model.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    protected override async ValueTask<object> InvokeCoreAsync(AIFunctionArguments arguments, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var services = arguments.Services;
+        var logger = services?.GetService<ILoggerFactory>()?.CreateLogger<DataSourceSearchToolFunction>()
+            ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<DataSourceSearchToolFunction>.Instance;
+
+        if (!arguments.TryGetFirstString("query", out var query) || string.IsNullOrWhiteSpace(query))
+        {
+            logger.LogWarning("AI tool '{ToolName}' missing required argument 'query'.", _name);
+
+            return "Unable to find a 'query' argument in the arguments parameter.";
+        }
+
+        if (services is null)
+        {
+            return "No services are available to search the data source.";
+        }
+
+        if (string.IsNullOrEmpty(_settings.DataSourceId))
+        {
+            logger.LogWarning("AI tool '{ToolName}' failed: no data source is configured for this instance.", _name);
+
+            return "No data source is configured for this tool. Configure one in the tool instance settings.";
+        }
+
+        try
+        {
+            return await DataSourceRetrieval.SearchAsync(
+                services,
+                new DataSourceRetrievalRequest
+                {
+                    DataSourceId = _settings.DataSourceId,
+                    Query = query,
+                    TopNDocuments = _settings.TopNDocuments,
+                    Strictness = _settings.Strictness,
+                    Filter = _settings.Filter,
+                    RetrievalMode = _settings.RetrievalMode,
+                    IsInScope = _settings.IsInScope,
+                },
+                _name,
+                logger,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AI tool '{ToolName}' failed to search data source '{DataSourceId}'.", _name, _settings.DataSourceId);
+
+            return "An error occurred while searching the data source.";
+        }
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
@@ -13,10 +13,12 @@ namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
 /// data source, so a host can expose one callable function per knowledge base it wants the model to reach.
 /// </summary>
 /// <remarks>
-/// The model supplies only the search phrase. That phrase is embedded with the same embedding deployment
-/// the data source's knowledge base index was indexed with, so it is compared against the stored chunks in
-/// the same vector space. Every other retrieval parameter — retrieval mode, retrieved document count,
-/// strictness, and filter — comes from the instance settings the user configured.
+/// The model supplies only the search phrases — one, or up to <see cref="DataSourceRetrieval.MaxQueries"/>
+/// when the question spans genuinely distinct topics. They are embedded in a single batched call using the
+/// same embedding deployment the data source's knowledge base index was indexed with, so they are compared
+/// against the stored chunks in the same vector space, then searched in parallel and fused into one ranking.
+/// Every other retrieval parameter — retrieval mode, retrieved document count, strictness, and filter —
+/// comes from the instance settings the user configured.
 /// </remarks>
 public sealed class DataSourceSearchToolFunction : AIFunction
 {
@@ -25,12 +27,15 @@ public sealed class DataSourceSearchToolFunction : AIFunction
     {
       "type": "object",
       "properties": {
-        "query": {
-          "type": "string",
-          "description": "A short set of keywords describing what to look for, extracted from the user's request. Pass the essential search terms (nouns and distinctive words), not the user's full sentence or question."
+        "queries": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "maxItems": 3,
+          "description": "One search phrase per genuinely distinct topic the question covers. Each phrase is a short set of keywords (nouns and distinctive words), not the user's full sentence. Pass a SINGLE phrase unless the question really spans separate subjects — for example ['vacation policy', 'sick leave policy'] for a question comparing the two. Never pass synonyms, rewordings, or singular/plural variants of the same idea: they retrieve the same content twice and waste the search budget."
         }
       },
-      "required": ["query"],
+      "required": ["queries"],
       "additionalProperties": false
     }
     """);
@@ -93,11 +98,13 @@ public sealed class DataSourceSearchToolFunction : AIFunction
         var logger = services?.GetService<ILoggerFactory>()?.CreateLogger<DataSourceSearchToolFunction>()
             ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<DataSourceSearchToolFunction>.Instance;
 
-        if (!arguments.TryGetFirstString("query", out var query) || string.IsNullOrWhiteSpace(query))
-        {
-            logger.LogWarning("AI tool '{ToolName}' missing required argument 'query'.", _name);
+        var queries = ReadQueries(arguments);
 
-            return "Unable to find a 'query' argument in the arguments parameter.";
+        if (queries.Count == 0)
+        {
+            logger.LogWarning("AI tool '{ToolName}' missing required argument 'queries'.", _name);
+
+            return "Unable to find a 'queries' argument in the arguments parameter.";
         }
 
         if (services is null)
@@ -119,7 +126,7 @@ public sealed class DataSourceSearchToolFunction : AIFunction
                 new DataSourceRetrievalRequest
                 {
                     DataSourceId = _settings.DataSourceId,
-                    Query = query,
+                    Queries = queries,
                     TopNDocuments = _settings.TopNDocuments,
                     Strictness = _settings.Strictness,
                     Filter = _settings.Filter,
@@ -139,6 +146,91 @@ public sealed class DataSourceSearchToolFunction : AIFunction
             logger.LogError(ex, "AI tool '{ToolName}' failed to search data source '{DataSourceId}'.", _name, _settings.DataSourceId);
 
             return "An error occurred while searching the data source.";
+        }
+    }
+
+    /// <summary>
+    /// Reads the search phrases the model supplied.
+    /// </summary>
+    /// <remarks>
+    /// The schema asks for an array under <c>queries</c>, but models routinely send a bare string, and some
+    /// send the singular <c>query</c> the rest of the tooling uses. Both are accepted: refusing them would
+    /// turn a trivially recoverable shape mismatch into a wasted tool call the model has to diagnose.
+    /// </remarks>
+    /// <param name="arguments">The arguments supplied by the AI model.</param>
+    /// <returns>The phrases to search for, in the order supplied.</returns>
+    private static List<string> ReadQueries(AIFunctionArguments arguments)
+    {
+        var queries = new List<string>();
+
+        foreach (var key in (string[])["queries", "query"])
+        {
+            if (!arguments.TryGetFirst(key, out var raw))
+            {
+                continue;
+            }
+
+            Collect(raw, queries);
+
+            if (queries.Count > 0)
+            {
+                break;
+            }
+        }
+
+        return queries;
+    }
+
+    private static void Collect(object value, List<string> queries)
+    {
+        switch (value)
+        {
+            case string text:
+                Add(text, queries);
+
+                break;
+
+            case JsonElement { ValueKind: JsonValueKind.String } element:
+                Add(element.GetString(), queries);
+
+                break;
+
+            case JsonElement { ValueKind: JsonValueKind.Array } element:
+                foreach (var item in element.EnumerateArray())
+                {
+                    Collect(item, queries);
+                }
+
+                break;
+
+            case IEnumerable<string> texts:
+                foreach (var text in texts)
+                {
+                    Add(text, queries);
+                }
+
+                break;
+
+            case System.Collections.IEnumerable items:
+                foreach (var item in items)
+                {
+                    Collect(item, queries);
+                }
+
+                break;
+
+            default:
+                Add(value?.ToString(), queries);
+
+                break;
+        }
+    }
+
+    private static void Add(string text, List<string> queries)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            queries.Add(text);
         }
     }
 }

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolInstanceSource.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolInstanceSource.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.AI;
+
+namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
+
+/// <summary>
+/// The built-in <see cref="IAIToolInstanceSource"/> that lets users expose one existing AI data source to
+/// the model as a callable vector search function. Each configured <see cref="AIToolInstance"/> binds one
+/// data source together with its retrieval parameters; the AI model only supplies the search phrase.
+/// </summary>
+public sealed class DataSourceSearchToolInstanceSource : IAIToolInstanceSource
+{
+    /// <summary>
+    /// Creates the <see cref="DataSourceSearchToolFunction"/> bound to the supplied instance's settings.
+    /// </summary>
+    /// <param name="instance">The configured tool instance whose settings should be bound to the produced tool.</param>
+    /// <returns>The configured data source search function.</returns>
+    public AITool CreateTool(AIToolInstance instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+
+        var settings = instance.GetOrCreate<DataSourceSearchToolSettings>();
+
+        var functionName = instance.GetFunctionName();
+        var description = string.IsNullOrWhiteSpace(instance.Description)
+            ? "Searches the configured knowledge base using semantic vector search and returns the most relevant content with citations."
+            : instance.Description;
+
+        return new DataSourceSearchToolFunction(functionName, description, settings);
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolServiceCollectionExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolServiceCollectionExtensions.cs
@@ -1,0 +1,41 @@
+using CrestApps.Core.Builders;
+using Microsoft.Extensions.Localization;
+
+namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
+
+/// <summary>
+/// Convenience registration for the built-in <see cref="DataSourceSearchToolInstanceSource"/>, which turns
+/// an existing AI data source into a model-callable vector search function.
+/// </summary>
+public static class DataSourceSearchToolServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the built-in data source search source on the tool instances builder so users can create
+    /// configured instances that search one of the existing AI data sources.
+    /// </summary>
+    /// <param name="builder">The tool instances builder.</param>
+    /// <param name="configure">
+    /// An optional delegate used to override the source display metadata (display name, description,
+    /// category). Sensible defaults are applied when not overridden.
+    /// </param>
+    /// <returns>The tool instances builder, for chaining.</returns>
+    public static CrestAppsAIToolInstancesBuilder AddDataSourceSearchSource(
+        this CrestAppsAIToolInstancesBuilder builder,
+        Action<AIToolInstanceSourceEntry> configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddSource<DataSourceSearchToolInstanceSource>(DataSourceSearchToolConstants.SourceName, entry =>
+        {
+            entry.DisplayName = new LocalizedString(DataSourceSearchToolConstants.SourceName, "Data source search (vector)");
+            entry.Description = new LocalizedString(
+                DataSourceSearchToolConstants.SourceName,
+                "Searches one of the existing AI data sources using semantic vector search against its knowledge base index.");
+            entry.Category = new LocalizedString(DataSourceSearchToolConstants.Category, DataSourceSearchToolConstants.Category);
+
+            configure?.Invoke(entry);
+        });
+
+        return builder;
+    }
+}

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolSettings.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolSettings.cs
@@ -1,0 +1,47 @@
+using CrestApps.Core.AI.Models;
+
+namespace CrestApps.Core.AI.Tooling.Instances.DataSources;
+
+/// <summary>
+/// The user-provided settings for a data source search tool instance. The settings are persisted in the
+/// owning <see cref="AIToolInstance.Properties"/> and bind the produced function to a single
+/// <see cref="AIDataSource"/> along with the retrieval parameters applied to every search it runs.
+/// </summary>
+public sealed class DataSourceSearchToolSettings
+{
+    /// <summary>
+    /// Gets or sets the identifier of the AI data source this instance searches.
+    /// </summary>
+    public string DataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the retrieval mode. <see cref="DataSourceRetrievalMode.Chunk"/> returns only the
+    /// matching chunks; <see cref="DataSourceRetrievalMode.Hierarchical"/> returns the full source
+    /// documents those chunks belong to.
+    /// </summary>
+    public DataSourceRetrievalMode RetrievalMode { get; set; } = DataSourceRetrievalMode.Chunk;
+
+    /// <summary>
+    /// Gets or sets the number of top-scoring documents to retrieve. When not set, the configured site
+    /// default is used. Values outside the supported range fall back to that default.
+    /// </summary>
+    public int? TopNDocuments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the strictness threshold used to decide how relevant a result must be to be returned.
+    /// Values range from 1 to 5, with higher values applying a narrower filter.
+    /// </summary>
+    public int? Strictness { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OData filter expression that narrows the search to a subset of the indexed data.
+    /// It is translated to the index provider's own filter syntax before the search runs.
+    /// </summary>
+    public string Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the model must answer only from the retrieved content.
+    /// When <see langword="false"/> (the default), the model may fall back to its general knowledge.
+    /// </summary>
+    public bool IsInScope { get; set; }
+}

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -1,20 +1,12 @@
 using System.Text.Json;
-using CrestApps.Core.AI.Clients;
-using CrestApps.Core.AI.DataSources;
-using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Extensions;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Orchestration;
 using CrestApps.Core.AI.Services;
 using CrestApps.Core.AI.Tooling;
-using CrestApps.Core.Infrastructure.Indexing;
-using CrestApps.Core.Infrastructure.Indexing.DataSources;
-using CrestApps.Core.Support;
-using Cysharp.Text;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace CrestApps.Core.AI.Tools;
 
@@ -83,7 +75,6 @@ public sealed class DataSourceSearchTool : AIFunction
         try
         {
             var invocationContext = AIInvocationScope.Current;
-            var textNormalizer = arguments.Services.GetRequiredService<IAITextNormalizer>();
             var executionContext = invocationContext?.ToolExecutionContext;
 
             if (executionContext == null)
@@ -102,200 +93,22 @@ public sealed class DataSourceSearchTool : AIFunction
                 return "No data source is configured for this profile.";
             }
 
-            var dataSourceStore = arguments.Services.GetRequiredService<IAIDataSourceStore>();
-            var dataSource = await dataSourceStore.FindByIdAsync(dataSourceId, cancellationToken);
-
-            if (dataSource == null)
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: data source '{DataSourceId}' was not found.", Name, dataSourceId);
-
-                return $"Data source '{dataSourceId}' was not found.";
-            }
-
-            if (string.IsNullOrEmpty(dataSource.AIKnowledgeBaseIndexProfileName))
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: no knowledge base index configured for data source '{DataSourceId}'.", Name, dataSourceId);
-
-                return "No knowledge base index is configured for this data source. Please configure a knowledge base index in the data source settings.";
-            }
-
-            var indexProfileStore = arguments.Services.GetRequiredService<ISearchIndexProfileStore>();
-            var masterIndexProfile = await indexProfileStore.FindByNameAsync(dataSource.AIKnowledgeBaseIndexProfileName, cancellationToken);
-
-            if (masterIndexProfile == null)
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: knowledge base index '{IndexProfileName}' was not found.", Name, dataSource.AIKnowledgeBaseIndexProfileName);
-
-                return $"Knowledge base index '{dataSource.AIKnowledgeBaseIndexProfileName}' was not found.";
-            }
-
-            var contentManager = arguments.Services.GetKeyedService<IDataSourceContentManager>(masterIndexProfile.ProviderName);
-
-            if (contentManager == null)
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: no vector search service for provider '{ProviderName}'.", Name, masterIndexProfile.ProviderName);
-
-                return $"No vector search service is available for provider '{masterIndexProfile.ProviderName}'.";
-            }
-
-            var aiClientFactory = arguments.Services.GetRequiredService<IAIClientFactory>();
-            var deploymentManager = arguments.Services.GetRequiredService<IAIDeploymentManager>();
-
-            // Resolve the query-embedding deployment exactly the way the indexing service does: it lives on
-            // the index profile itself (masterIndexProfile.EmbeddingDeploymentName) and is only optionally
-            // overridden by the data-source metadata. The metadata being absent must NOT fail search, or a
-            // profile that indexed fine using the top-level embedding deployment could never be queried.
-            masterIndexProfile.TryGet(out DataSourceIndexProfileMetadata profileMetadata);
-
-            var deploymentName = masterIndexProfile.EmbeddingDeploymentName;
-
-            if (profileMetadata != null && !string.IsNullOrEmpty(profileMetadata.EmbeddingDeploymentName))
-            {
-                deploymentName = profileMetadata.EmbeddingDeploymentName;
-            }
-
-            if (string.IsNullOrWhiteSpace(deploymentName))
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: embedding configuration is missing for the knowledge base index.", Name);
-
-                return "Embedding configuration is missing for the knowledge base index.";
-            }
-
-            var deployment = await deploymentManager.FindByNameAsync(deploymentName, cancellationToken);
-
-            var embeddingGenerator = deployment == null
-                ? null
-                : await aiClientFactory.CreateEmbeddingGeneratorAsync(deployment);
-
-            if (embeddingGenerator == null)
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: embedding configuration is missing for the knowledge base index.", Name);
-
-                return "Embedding configuration is missing for the knowledge base index.";
-            }
-
-            var embeddings = await embeddingGenerator.GenerateAsync([query], cancellationToken: cancellationToken);
-
-            if (embeddings == null || embeddings.Count == 0 || embeddings[0]?.Vector == null)
-            {
-                logger.LogWarning("AI tool '{ToolName}' failed: could not generate embedding for query.", Name);
-
-                return "Failed to generate embedding for the search query.";
-            }
-
             var ragMetadata = GetRagMetadata(executionContext);
-            var siteSettings = arguments.Services.GetRequiredService<IOptionsMonitor<AIDataSourceOptions>>().CurrentValue;
-            var topN = siteSettings.GetTopNDocuments(ragMetadata?.TopNDocuments);
 
-            string providerFilter = null;
-
-            if (!string.IsNullOrWhiteSpace(ragMetadata?.Filter))
-            {
-                var filterTranslator = arguments.Services.GetKeyedService<IODataFilterTranslator>(masterIndexProfile.ProviderName);
-
-                if (filterTranslator != null)
+            return await DataSourceRetrieval.SearchAsync(
+                arguments.Services,
+                new DataSourceRetrievalRequest
                 {
-                    providerFilter = filterTranslator.Translate(ragMetadata.Filter);
-                }
-                else
-                {
-                    logger.LogWarning("No OData filter translator available for provider '{ProviderName}'. Filter will be ignored.", masterIndexProfile.ProviderName);
-                }
-            }
-
-            var results = await contentManager.SearchAsync(
-                masterIndexProfile,
-                embeddings[0].Vector.ToArray(),
-                dataSourceId,
-                DataSourceSearchResultSelector.GetCandidateCount(topN),
-                providerFilter,
+                    DataSourceId = dataSourceId,
+                    Query = query,
+                    TopNDocuments = ragMetadata?.TopNDocuments,
+                    Strictness = ragMetadata?.Strictness,
+                    Filter = ragMetadata?.Filter,
+                    IsInScope = ragMetadata?.IsInScope == true,
+                },
+                Name,
+                logger,
                 cancellationToken);
-
-            if (results == null || !results.Any())
-            {
-                return ragMetadata?.IsInScope == true
-                    ? "No relevant content was found in the data source for this query. The answer is not available in the configured data source."
-                    : "No relevant content was found in the data source for this query. Answer using your general knowledge instead.";
-            }
-
-            var minimumScore = siteSettings.GetMinimumScore(ragMetadata?.Strictness);
-            results = DataSourceSearchResultSelector.SelectTopResults(results, topN, minimumScore);
-
-            if (!results.Any())
-            {
-                return ragMetadata?.IsInScope == true
-                    ? "No results met the strictness and quality thresholds. The answer is not available in the configured data source."
-                    : "No results met the strictness and quality thresholds. Answer using your general knowledge instead.";
-            }
-
-            using var builder = ZString.CreateStringBuilder();
-            builder.AppendLine("Relevant content from data source:");
-
-            var seenReferences = new Dictionary<string, (int Index, string Title, string ReferenceType)>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var result in results)
-            {
-                if (string.IsNullOrWhiteSpace(result.Content))
-                {
-                    continue;
-                }
-
-                if (!string.IsNullOrEmpty(result.ReferenceId) && !seenReferences.ContainsKey(result.ReferenceId))
-                {
-                    seenReferences[result.ReferenceId] = (invocationContext.NextReferenceIndex(), ResolveReferenceTitle(textNormalizer, result.Title, result.ReferenceId), result.ReferenceType);
-                }
-
-                var refLabel = !string.IsNullOrEmpty(result.ReferenceId) && seenReferences.TryGetValue(result.ReferenceId, out var entry)
-                ? $"[doc:{entry.Index}]"
-                : $"[doc:{invocationContext.NextReferenceIndex()}]";
-
-                var displayTitle = !string.IsNullOrEmpty(result.ReferenceId) && seenReferences.TryGetValue(result.ReferenceId, out var titleEntry)
-                    ? titleEntry.Title
-                    : ResolveReferenceTitle(textNormalizer, result.Title, result.ReferenceId);
-
-                builder.AppendLine("---");
-
-                if (!string.IsNullOrWhiteSpace(displayTitle))
-                {
-                    builder.Append(refLabel);
-                    builder.Append(" Title: ");
-                    builder.AppendLine(displayTitle);
-                }
-
-                builder.Append(refLabel);
-                builder.Append(' ');
-                builder.AppendLine(result.Content);
-            }
-
-            if (seenReferences.Count > 0)
-            {
-                builder.AppendLine();
-                builder.AppendLine("References:");
-
-                foreach (var kvp in seenReferences)
-                {
-                    builder.Append("[doc:");
-
-                    builder.Append(kvp.Value.Index);
-                    builder.Append("] = ");
-                    builder.AppendLine(kvp.Key);
-                }
-
-                foreach (var kvp in seenReferences)
-                {
-                    var template = $"[doc:{kvp.Value.Index}]";
-                    invocationContext.ToolReferences.TryAdd(template, new AICompletionReference
-                    {
-                        Text = string.IsNullOrWhiteSpace(kvp.Value.Title) ? template : kvp.Value.Title,
-                        Title = kvp.Value.Title,
-                        Index = kvp.Value.Index,
-                        ReferenceId = kvp.Key,
-                        ReferenceType = kvp.Value.ReferenceType,
-                    });
-                }
-            }
-
-            return builder.ToString();
         }
         catch (Exception ex)
         {
@@ -303,25 +116,6 @@ public sealed class DataSourceSearchTool : AIFunction
 
             return "An error occurred while searching the data source.";
         }
-    }
-
-    /// <summary>
-    /// Resolves a citation title that never exposes a serialized source document.
-    /// </summary>
-    /// <param name="textNormalizer">The text normalizer.</param>
-    /// <param name="title">The indexed document title.</param>
-    /// <param name="referenceId">The document reference identifier used as the fallback title.</param>
-    /// <returns>The resolved citation title.</returns>
-    private static string ResolveReferenceTitle(IAITextNormalizer textNormalizer, string title, string referenceId)
-    {
-        var normalizedTitle = textNormalizer.NormalizeTitle(title);
-
-        if (string.IsNullOrWhiteSpace(normalizedTitle) || DocumentTitleResolver.LooksLikeSerializedDocument(normalizedTitle))
-        {
-            return referenceId;
-        }
-
-        return normalizedTitle;
     }
 
     private static AIDataSourceRagMetadata GetRagMetadata(AIToolExecutionContext executionContext)

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -100,7 +100,7 @@ public sealed class DataSourceSearchTool : AIFunction
                 new DataSourceRetrievalRequest
                 {
                     DataSourceId = dataSourceId,
-                    Query = query,
+                    Queries = [query],
                     TopNDocuments = ragMetadata?.TopNDocuments,
                     Strictness = ragMetadata?.Strictness,
                     Filter = ragMetadata?.Filter,

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Create.razor
@@ -5,6 +5,9 @@
 @using CrestApps.Core.AI
 @using CrestApps.Core.AI.Tooling
 @using CrestApps.Core.AI.Tooling.Instances
+@using CrestApps.Core.AI.DataSources
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.Tooling.Instances.DataSources
 @using CrestApps.Core.AI.Tooling.Instances.Documentation
 @using CrestApps.Core.AI.Tooling.Parameters
 @using CrestApps.Core.Startup.Shared.ViewModels
@@ -17,6 +20,7 @@
 @inject NavigationManager Navigation
 @inject TimeProvider TimeProvider
 @inject IOptions<AIOptions> AIOptions
+@inject IAIDataSourceStore DataSourceStore
 
 <PageTitle>Create Tool Instance</PageTitle>
 
@@ -354,6 +358,61 @@
             </div>
         }
 
+        @if (string.Equals(_model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            <h5 class="mt-4 border-bottom pb-2"><i class="fa-solid fa-database"></i> Data source search (vector)</h5>
+            <p class="text-muted small">Searches one of the existing AI data sources. The model's search phrase is embedded with the same embedding deployment the data source's knowledge base index was built with, so it is matched against the stored chunks in the same vector space.</p>
+
+            <div class="mb-3">
+                <label class="form-label">Data source <span class="text-danger">*</span></label>
+                <InputSelect class="form-select" @bind-Value="_model.DataSourceId">
+                    <option value="">Select data source</option>
+                    @foreach (var dataSource in _model.DataSources)
+                    {
+                        <option value="@dataSource.Value">@dataSource.Key</option>
+                    }
+                </InputSelect>
+                <div class="form-text">The knowledge base this tool searches.</div>
+                <ValidationMessage For="() => _model.DataSourceId" />
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Retrieval model</label>
+                <InputSelect class="form-select" @bind-Value="_model.DataSourceRetrievalMode">
+                    @foreach (var retrievalMode in Enum.GetValues<DataSourceRetrievalMode>())
+                    {
+                        <option value="@retrievalMode">@retrievalMode</option>
+                    }
+                </InputSelect>
+                <div class="form-text"><strong>Chunk</strong> returns only the matching chunks. <strong>Hierarchical</strong> returns the full source documents those chunks belong to, which costs far more context.</div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <label class="form-label">Retrieved documents</label>
+                    <InputNumber @bind-Value="_model.DataSourceTopNDocuments" class="form-control" min="@AIDataSourceOptions.MinTopNDocuments" max="@AIDataSourceOptions.MaxTopNDocuments" placeholder="Default" />
+                    <div class="form-text">Between @AIDataSourceOptions.MinTopNDocuments and @AIDataSourceOptions.MaxTopNDocuments. Leave empty to use the configured default.</div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <label class="form-label">Strictness</label>
+                    <InputNumber @bind-Value="_model.DataSourceStrictness" class="form-control" min="@AIDataSourceOptions.MinStrictness" max="@AIDataSourceOptions.MaxStrictness" placeholder="Default" />
+                    <div class="form-text">Between @AIDataSourceOptions.MinStrictness and @AIDataSourceOptions.MaxStrictness. Higher values return only closer matches.</div>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Filter</label>
+                <InputText @bind-Value="_model.DataSourceFilter" class="form-control font-monospace" placeholder="filters/status eq 'published'" />
+                <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
+            </div>
+
+            <div class="form-check mb-3">
+                <InputCheckbox @bind-Value="_model.DataSourceIsInScope" class="form-check-input" />
+                <label class="form-check-label">Limit answers to the retrieved content</label>
+                <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
+            </div>
+        }
+
         <ToolInstanceParameterEditor Source="@_model.Source"
                                      Parameters="_model.Parameters"
                                      HttpMethod="@_model.HttpMethod"
@@ -375,6 +434,19 @@
     };
 
     private List<string> _errors = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadDataSourcesAsync();
+    }
+
+    private async Task LoadDataSourcesAsync()
+    {
+        _model.DataSources = (await DataSourceStore.GetAllAsync())
+            .OrderBy(dataSource => dataSource.DisplayText, StringComparer.OrdinalIgnoreCase)
+            .Select(dataSource => new KeyValuePair<string, string>(dataSource.DisplayText, dataSource.ItemId))
+            .ToList();
+    }
 
     private void OnSourceChanged(ChangeEventArgs e)
     {
@@ -487,6 +559,28 @@
             if (string.IsNullOrWhiteSpace(model.WebsiteSearchUrlPath))
             {
                 _errors.Add("URL field path is required.");
+            }
+
+            return;
+        }
+
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(model.DataSourceId))
+            {
+                _errors.Add("A data source is required.");
+            }
+
+            if (model.DataSourceTopNDocuments.HasValue &&
+                (model.DataSourceTopNDocuments < AIDataSourceOptions.MinTopNDocuments || model.DataSourceTopNDocuments > AIDataSourceOptions.MaxTopNDocuments))
+            {
+                _errors.Add($"Retrieved documents must be between {AIDataSourceOptions.MinTopNDocuments} and {AIDataSourceOptions.MaxTopNDocuments}.");
+            }
+
+            if (model.DataSourceStrictness.HasValue &&
+                (model.DataSourceStrictness < AIDataSourceOptions.MinStrictness || model.DataSourceStrictness > AIDataSourceOptions.MaxStrictness))
+            {
+                _errors.Add($"Strictness must be between {AIDataSourceOptions.MinStrictness} and {AIDataSourceOptions.MaxStrictness}.");
             }
 
             return;
@@ -712,6 +806,21 @@
                 UrlPath = model.WebsiteSearchUrlPath?.Trim(),
                 SnippetPath = string.IsNullOrWhiteSpace(model.WebsiteSearchSnippetPath) ? null : model.WebsiteSearchSnippetPath.Trim(),
                 MaxResults = model.WebsiteSearchMaxResults,
+            });
+
+            return;
+        }
+
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            instance.Put(new DataSourceSearchToolSettings
+            {
+                DataSourceId = model.DataSourceId?.Trim(),
+                RetrievalMode = model.DataSourceRetrievalMode,
+                TopNDocuments = model.DataSourceTopNDocuments,
+                Strictness = model.DataSourceStrictness,
+                Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
+                IsInScope = model.DataSourceIsInScope,
             });
 
             return;

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Edit.razor
@@ -4,6 +4,9 @@
 @using CrestApps.Core.AI
 @using CrestApps.Core.AI.Tooling
 @using CrestApps.Core.AI.Tooling.Instances
+@using CrestApps.Core.AI.DataSources
+@using CrestApps.Core.AI.Models
+@using CrestApps.Core.AI.Tooling.Instances.DataSources
 @using CrestApps.Core.AI.Tooling.Instances.Documentation
 @using CrestApps.Core.AI.Tooling.Parameters
 @using CrestApps.Core.Startup.Shared.ViewModels
@@ -16,6 +19,7 @@
 @inject NavigationManager Navigation
 @inject TimeProvider TimeProvider
 @inject IOptions<AIOptions> AIOptions
+@inject IAIDataSourceStore DataSourceStore
 
 <PageTitle>Edit Tool Instance</PageTitle>
 
@@ -376,6 +380,61 @@ else
                 </div>
             }
 
+            @if (string.Equals(_model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+            {
+                <h5 class="mt-4 border-bottom pb-2"><i class="fa-solid fa-database"></i> Data source search (vector)</h5>
+                <p class="text-muted small">Searches one of the existing AI data sources. The model's search phrase is embedded with the same embedding deployment the data source's knowledge base index was built with, so it is matched against the stored chunks in the same vector space.</p>
+
+                <div class="mb-3">
+                    <label class="form-label">Data source <span class="text-danger">*</span></label>
+                    <InputSelect class="form-select" @bind-Value="_model.DataSourceId">
+                        <option value="">Select data source</option>
+                        @foreach (var dataSource in _model.DataSources)
+                        {
+                            <option value="@dataSource.Value">@dataSource.Key</option>
+                        }
+                    </InputSelect>
+                    <div class="form-text">The knowledge base this tool searches.</div>
+                    <ValidationMessage For="() => _model.DataSourceId" />
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Retrieval model</label>
+                    <InputSelect class="form-select" @bind-Value="_model.DataSourceRetrievalMode">
+                        @foreach (var retrievalMode in Enum.GetValues<DataSourceRetrievalMode>())
+                        {
+                            <option value="@retrievalMode">@retrievalMode</option>
+                        }
+                    </InputSelect>
+                    <div class="form-text"><strong>Chunk</strong> returns only the matching chunks. <strong>Hierarchical</strong> returns the full source documents those chunks belong to, which costs far more context.</div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Retrieved documents</label>
+                        <InputNumber @bind-Value="_model.DataSourceTopNDocuments" class="form-control" min="@AIDataSourceOptions.MinTopNDocuments" max="@AIDataSourceOptions.MaxTopNDocuments" placeholder="Default" />
+                        <div class="form-text">Between @AIDataSourceOptions.MinTopNDocuments and @AIDataSourceOptions.MaxTopNDocuments. Leave empty to use the configured default.</div>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label class="form-label">Strictness</label>
+                        <InputNumber @bind-Value="_model.DataSourceStrictness" class="form-control" min="@AIDataSourceOptions.MinStrictness" max="@AIDataSourceOptions.MaxStrictness" placeholder="Default" />
+                        <div class="form-text">Between @AIDataSourceOptions.MinStrictness and @AIDataSourceOptions.MaxStrictness. Higher values return only closer matches.</div>
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Filter</label>
+                    <InputText @bind-Value="_model.DataSourceFilter" class="form-control font-monospace" placeholder="filters/status eq 'published'" />
+                    <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
+                </div>
+
+                <div class="form-check mb-3">
+                    <InputCheckbox @bind-Value="_model.DataSourceIsInScope" class="form-check-input" />
+                    <label class="form-check-label">Limit answers to the retrieved content</label>
+                    <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
+                </div>
+            }
+
             <ToolInstanceParameterEditor Source="@_model.Source"
                                          Parameters="_model.Parameters"
                                          HttpMethod="@_model.HttpMethod"
@@ -423,7 +482,18 @@ else
         }
 
         _model = ToViewModel(instance);
+
+        await LoadDataSourcesAsync();
     }
+
+    private async Task LoadDataSourcesAsync()
+    {
+        _model.DataSources = (await DataSourceStore.GetAllAsync())
+            .OrderBy(dataSource => dataSource.DisplayText, StringComparer.OrdinalIgnoreCase)
+            .Select(dataSource => new KeyValuePair<string, string>(dataSource.DisplayText, dataSource.ItemId))
+            .ToList();
+    }
+
 
     private async Task HandleSubmitAsync()
     {
@@ -520,6 +590,28 @@ else
             if (string.IsNullOrWhiteSpace(model.WebsiteSearchUrlPath))
             {
                 _errors.Add("URL field path is required.");
+            }
+
+            return;
+        }
+
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrWhiteSpace(model.DataSourceId))
+            {
+                _errors.Add("A data source is required.");
+            }
+
+            if (model.DataSourceTopNDocuments.HasValue &&
+                (model.DataSourceTopNDocuments < AIDataSourceOptions.MinTopNDocuments || model.DataSourceTopNDocuments > AIDataSourceOptions.MaxTopNDocuments))
+            {
+                _errors.Add($"Retrieved documents must be between {AIDataSourceOptions.MinTopNDocuments} and {AIDataSourceOptions.MaxTopNDocuments}.");
+            }
+
+            if (model.DataSourceStrictness.HasValue &&
+                (model.DataSourceStrictness < AIDataSourceOptions.MinStrictness || model.DataSourceStrictness > AIDataSourceOptions.MaxStrictness))
+            {
+                _errors.Add($"Strictness must be between {AIDataSourceOptions.MinStrictness} and {AIDataSourceOptions.MaxStrictness}.");
             }
 
             return;
@@ -719,6 +811,21 @@ else
             return;
         }
 
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            instance.Put(new DataSourceSearchToolSettings
+            {
+                DataSourceId = model.DataSourceId?.Trim(),
+                RetrievalMode = model.DataSourceRetrievalMode,
+                TopNDocuments = model.DataSourceTopNDocuments,
+                Strictness = model.DataSourceStrictness,
+                Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
+                IsInScope = model.DataSourceIsInScope,
+            });
+
+            return;
+        }
+
         var protector = DataProtectionProvider.CreateProtector(HttpApiRequestToolConstants.DataProtectionPurpose);
         var existing = instance.TryGet<HttpApiRequestToolSettings>(out var stored) ? stored : new HttpApiRequestToolSettings();
 
@@ -839,6 +946,16 @@ else
             model.WebsiteSearchUrlPath = websiteSearchSettings.UrlPath;
             model.WebsiteSearchSnippetPath = websiteSearchSettings.SnippetPath;
             model.WebsiteSearchMaxResults = websiteSearchSettings.MaxResults;
+        }
+
+        if (instance.TryGet<DataSourceSearchToolSettings>(out var dataSourceSettings))
+        {
+            model.DataSourceId = dataSourceSettings.DataSourceId;
+            model.DataSourceRetrievalMode = dataSourceSettings.RetrievalMode;
+            model.DataSourceTopNDocuments = dataSourceSettings.TopNDocuments;
+            model.DataSourceStrictness = dataSourceSettings.Strictness;
+            model.DataSourceFilter = dataSourceSettings.Filter;
+            model.DataSourceIsInScope = dataSourceSettings.IsInScope;
         }
 
         return model;

--- a/src/Startup/CrestApps.Core.Blazor.Web/Program.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Program.cs
@@ -1,4 +1,4 @@
-using CrestApps.Core;
+﻿using CrestApps.Core;
 using CrestApps.Core.AI;
 using CrestApps.Core.AI.WebCrawlers;
 using CrestApps.Core.AI.A2A;
@@ -16,6 +16,7 @@ using CrestApps.Core.AI.Documents.Pdf;
 using CrestApps.Core.AI.Elasticsearch;
 using CrestApps.Core.AI.Markdown;
 using CrestApps.Core.AI.Mcp;
+using CrestApps.Core.AI.Tooling.Instances.DataSources;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using CrestApps.Core.AI.Mcp.Ftp;
 using CrestApps.Core.AI.Mcp.Models;
@@ -138,6 +139,7 @@ builder.Services
         .AddToolInstances(toolInstances => toolInstances
             .AddHttpApiRequestSource()
             .AddDocumentationSearchSources()
+            .AddDataSourceSearchSource()
             .AddEntityCoreStores()
         )
         .AddDocumentProcessing(documentProcessing => documentProcessing

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIToolInstanceViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIToolInstanceViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Tooling.Instances;
 using CrestApps.Core.Startup.Shared.ViewModels;
 
@@ -250,4 +251,41 @@ public sealed class AIToolInstanceViewModel
     /// Gets or sets the maximum number of results the website search source returns for a single search.
     /// </summary>
     public int? WebsiteSearchMaxResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the AI data source searched by the data source search source.
+    /// </summary>
+    public string DataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the existing AI data sources offered in the data source dropdown, as display text
+    /// keyed by identifier.
+    /// </summary>
+    public IReadOnlyList<KeyValuePair<string, string>> DataSources { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the retrieval mode applied by the data source search source.
+    /// </summary>
+    public DataSourceRetrievalMode DataSourceRetrievalMode { get; set; } = DataSourceRetrievalMode.Chunk;
+
+    /// <summary>
+    /// Gets or sets the number of top-scoring documents the data source search source retrieves.
+    /// </summary>
+    public int? DataSourceTopNDocuments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the strictness threshold applied by the data source search source.
+    /// </summary>
+    public int? DataSourceStrictness { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OData filter expression applied by the data source search source.
+    /// </summary>
+    public string DataSourceFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the data source search source instructs the model to answer
+    /// only from the retrieved content.
+    /// </summary>
+    public bool DataSourceIsInScope { get; set; }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
@@ -1,6 +1,9 @@
 using System.Security.Cryptography;
 using System.Text.Json;
 using CrestApps.Core.AI;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Tooling.Instances.DataSources;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.AI.Tooling.Instances;
@@ -31,6 +34,7 @@ public sealed class AIToolInstanceController : Controller
     };
 
     private readonly ISourceCatalog<AIToolInstance> _catalog;
+    private readonly IAIDataSourceStore _dataSourceStore;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly TimeProvider _timeProvider;
     private readonly AIOptions _aiOptions;
@@ -40,18 +44,21 @@ public sealed class AIToolInstanceController : Controller
     /// Initializes a new instance of the <see cref="AIToolInstanceController"/> class.
     /// </summary>
     /// <param name="catalog">The tool instance catalog.</param>
+    /// <param name="dataSourceStore">The store used to list the AI data sources an instance can search.</param>
     /// <param name="dataProtectionProvider">The data protection provider used to protect secrets.</param>
     /// <param name="timeProvider">The time provider used for timestamps.</param>
     /// <param name="aiOptions">The AI options used to enumerate registered tool instance sources.</param>
     /// <param name="contextResolvers">The resolvers whose keys are offered for context-filled parameters.</param>
     public AIToolInstanceController(
         ISourceCatalog<AIToolInstance> catalog,
+        IAIDataSourceStore dataSourceStore,
         IDataProtectionProvider dataProtectionProvider,
         TimeProvider timeProvider,
         IOptions<AIOptions> aiOptions,
         IEnumerable<IAIToolParameterContextResolver> contextResolvers)
     {
         _catalog = catalog;
+        _dataSourceStore = dataSourceStore;
         _dataProtectionProvider = dataProtectionProvider;
         _timeProvider = timeProvider;
         _aiOptions = aiOptions.Value;
@@ -73,7 +80,7 @@ public sealed class AIToolInstanceController : Controller
     /// <summary>
     /// Renders the create form.
     /// </summary>
-    public IActionResult Create()
+    public async Task<IActionResult> Create()
     {
         var sources = BuildSourceList();
 
@@ -85,6 +92,7 @@ public sealed class AIToolInstanceController : Controller
         };
 
         PopulateParameterMetadata(model);
+        await PopulateDataSourcesAsync(model);
 
         return View(model);
     }
@@ -103,6 +111,7 @@ public sealed class AIToolInstanceController : Controller
         {
             model.Sources = BuildSourceList();
             PopulateParameterMetadata(model);
+            await PopulateDataSourcesAsync(model);
 
             return View(model);
         }
@@ -134,7 +143,11 @@ public sealed class AIToolInstanceController : Controller
             return NotFound();
         }
 
-        return View(ToViewModel(instance));
+        var model = ToViewModel(instance);
+
+        await PopulateDataSourcesAsync(model);
+
+        return View(model);
     }
 
     /// <summary>
@@ -160,6 +173,7 @@ public sealed class AIToolInstanceController : Controller
         {
             model.Sources = BuildSourceList();
             PopulateParameterMetadata(model);
+            await PopulateDataSourcesAsync(model);
 
             return View(model);
         }
@@ -316,6 +330,13 @@ public sealed class AIToolInstanceController : Controller
         if (string.Equals(model.Source, DocumentationToolConstants.WebsiteSearchSourceName, StringComparison.OrdinalIgnoreCase))
         {
             ValidateWebsiteSearch(model);
+
+            return;
+        }
+
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            ValidateDataSourceSearch(model);
 
             return;
         }
@@ -493,6 +514,30 @@ public sealed class AIToolInstanceController : Controller
         }
     }
 
+    private void ValidateDataSourceSearch(AIToolInstanceViewModel model)
+    {
+        if (string.IsNullOrWhiteSpace(model.DataSourceId))
+        {
+            ModelState.AddModelError(nameof(model.DataSourceId), "A data source is required.");
+        }
+
+        if (model.DataSourceTopNDocuments.HasValue &&
+            (model.DataSourceTopNDocuments < AIDataSourceOptions.MinTopNDocuments || model.DataSourceTopNDocuments > AIDataSourceOptions.MaxTopNDocuments))
+        {
+            ModelState.AddModelError(
+                nameof(model.DataSourceTopNDocuments),
+                $"Retrieved documents must be between {AIDataSourceOptions.MinTopNDocuments} and {AIDataSourceOptions.MaxTopNDocuments}.");
+        }
+
+        if (model.DataSourceStrictness.HasValue &&
+            (model.DataSourceStrictness < AIDataSourceOptions.MinStrictness || model.DataSourceStrictness > AIDataSourceOptions.MaxStrictness))
+        {
+            ModelState.AddModelError(
+                nameof(model.DataSourceStrictness),
+                $"Strictness must be between {AIDataSourceOptions.MinStrictness} and {AIDataSourceOptions.MaxStrictness}.");
+        }
+    }
+
     private void ValidateAbsoluteUrl(string value, string key, string label, bool required)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -582,6 +627,21 @@ public sealed class AIToolInstanceController : Controller
             return;
         }
 
+        if (string.Equals(model.Source, DataSourceSearchToolConstants.SourceName, StringComparison.OrdinalIgnoreCase))
+        {
+            instance.Put(new DataSourceSearchToolSettings
+            {
+                DataSourceId = model.DataSourceId?.Trim(),
+                RetrievalMode = model.DataSourceRetrievalMode,
+                TopNDocuments = model.DataSourceTopNDocuments,
+                Strictness = model.DataSourceStrictness,
+                Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
+                IsInScope = model.DataSourceIsInScope,
+            });
+
+            return;
+        }
+
         var protector = _dataProtectionProvider.CreateProtector(HttpApiRequestToolConstants.DataProtectionPurpose);
         var existing = instance.GetOrCreate<HttpApiRequestToolSettings>();
 
@@ -653,6 +713,18 @@ public sealed class AIToolInstanceController : Controller
         {
             return protector.Protect(existingValue);
         }
+    }
+
+    private async Task PopulateDataSourcesAsync(AIToolInstanceViewModel model)
+    {
+        model.DataSources = (await _dataSourceStore.GetAllAsync())
+            .OrderBy(dataSource => dataSource.DisplayText, StringComparer.OrdinalIgnoreCase)
+            .Select(dataSource => new SelectListItem
+            {
+                Value = dataSource.ItemId,
+                Text = dataSource.DisplayText,
+            })
+            .ToList();
     }
 
     private AIToolInstanceViewModel ToViewModel(AIToolInstance instance)
@@ -728,6 +800,16 @@ public sealed class AIToolInstanceController : Controller
             model.WebsiteSearchUrlPath = websiteSearchSettings.UrlPath;
             model.WebsiteSearchSnippetPath = websiteSearchSettings.SnippetPath;
             model.WebsiteSearchMaxResults = websiteSearchSettings.MaxResults;
+        }
+
+        if (instance.TryGet<DataSourceSearchToolSettings>(out var dataSourceSettings))
+        {
+            model.DataSourceId = dataSourceSettings.DataSourceId;
+            model.DataSourceRetrievalMode = dataSourceSettings.RetrievalMode;
+            model.DataSourceTopNDocuments = dataSourceSettings.TopNDocuments;
+            model.DataSourceStrictness = dataSourceSettings.Strictness;
+            model.DataSourceFilter = dataSourceSettings.Filter;
+            model.DataSourceIsInScope = dataSourceSettings.IsInScope;
         }
 
         return model;

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Tooling.Instances;
 using CrestApps.Core.AI.Tooling.Parameters;
 using CrestApps.Core.Startup.Shared.ViewModels;
@@ -282,4 +283,40 @@ public sealed class AIToolInstanceViewModel
     /// Gets or sets the maximum number of results the website search source returns for a single search.
     /// </summary>
     public int? WebsiteSearchMaxResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the AI data source searched by the data source search source.
+    /// </summary>
+    public string DataSourceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the existing AI data sources shown in the data source dropdown.
+    /// </summary>
+    public IReadOnlyList<SelectListItem> DataSources { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the retrieval mode applied by the data source search source.
+    /// </summary>
+    public DataSourceRetrievalMode DataSourceRetrievalMode { get; set; } = DataSourceRetrievalMode.Chunk;
+
+    /// <summary>
+    /// Gets or sets the number of top-scoring documents the data source search source retrieves.
+    /// </summary>
+    public int? DataSourceTopNDocuments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the strictness threshold applied by the data source search source.
+    /// </summary>
+    public int? DataSourceStrictness { get; set; }
+
+    /// <summary>
+    /// Gets or sets the OData filter expression applied by the data source search source.
+    /// </summary>
+    public string DataSourceFilter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the data source search source instructs the model to answer
+    /// only from the retrieved content.
+    /// </summary>
+    public bool DataSourceIsInScope { get; set; }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
@@ -1,3 +1,4 @@
+@using CrestApps.Core.AI.Models
 @using CrestApps.Core.AI.Tooling.Instances
 @using CrestApps.Core.Mvc.Web.Areas.Tooling.ViewModels
 @model AIToolInstanceViewModel
@@ -330,6 +331,54 @@
                     <label asp-for="WebsiteSearchMaxResults" class="form-label">Max results</label>
                     <input asp-for="WebsiteSearchMaxResults" class="form-control" type="number" min="1" max="50" placeholder="Default" />
                     <span asp-validation-for="WebsiteSearchMaxResults" class="text-danger"></span>
+                </div>
+            </div>
+
+            <div class="source-fields" data-source="data-source-search">
+                <h5 class="mt-4 border-bottom pb-2"><i class="fa-solid fa-database"></i> Data source search (vector)</h5>
+                <p class="text-muted small">Searches one of the existing AI data sources. The model's search phrase is embedded with the same embedding deployment the data source's knowledge base index was built with, so it is matched against the stored chunks in the same vector space.</p>
+                <div class="mb-3">
+                    <label asp-for="DataSourceId" class="form-label">Data source <span class="text-danger">*</span></label>
+                    <select asp-for="DataSourceId" class="form-select" asp-items="Model.DataSources">
+                        <option value="">Select data source</option>
+                    </select>
+                    <span asp-validation-for="DataSourceId" class="text-danger"></span>
+                    <div class="form-text">The knowledge base this tool searches.</div>
+                </div>
+                <div class="mb-3">
+                    <label asp-for="DataSourceRetrievalMode" class="form-label">Retrieval model</label>
+                    <select asp-for="DataSourceRetrievalMode" class="form-select">
+                        @foreach (var retrievalMode in Enum.GetValues<DataSourceRetrievalMode>())
+                        {
+                            <option value="@retrievalMode">@retrievalMode</option>
+                        }
+                    </select>
+                    <div class="form-text"><strong>Chunk</strong> returns only the matching chunks. <strong>Hierarchical</strong> returns the full source documents those chunks belong to, which costs far more context.</div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6 mb-3">
+                        <label asp-for="DataSourceTopNDocuments" class="form-label">Retrieved documents</label>
+                        <input asp-for="DataSourceTopNDocuments" class="form-control" type="number" min="@AIDataSourceOptions.MinTopNDocuments" max="@AIDataSourceOptions.MaxTopNDocuments" placeholder="Default" />
+                        <span asp-validation-for="DataSourceTopNDocuments" class="text-danger"></span>
+                        <div class="form-text">Between @AIDataSourceOptions.MinTopNDocuments and @AIDataSourceOptions.MaxTopNDocuments. Leave empty to use the configured default.</div>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <label asp-for="DataSourceStrictness" class="form-label">Strictness</label>
+                        <input asp-for="DataSourceStrictness" class="form-control" type="number" min="@AIDataSourceOptions.MinStrictness" max="@AIDataSourceOptions.MaxStrictness" placeholder="Default" />
+                        <span asp-validation-for="DataSourceStrictness" class="text-danger"></span>
+                        <div class="form-text">Between @AIDataSourceOptions.MinStrictness and @AIDataSourceOptions.MaxStrictness. Higher values return only closer matches.</div>
+                    </div>
+                </div>
+                <div class="mb-3">
+                    <label asp-for="DataSourceFilter" class="form-label">Filter</label>
+                    <input asp-for="DataSourceFilter" class="form-control font-monospace" placeholder="filters/status eq 'published'" />
+                    <span asp-validation-for="DataSourceFilter" class="text-danger"></span>
+                    <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
+                </div>
+                <div class="form-check mb-3">
+                    <input asp-for="DataSourceIsInScope" class="form-check-input" type="checkbox" />
+                    <label asp-for="DataSourceIsInScope" class="form-check-label">Limit answers to the retrieved content</label>
+                    <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
                 </div>
             </div>
 

--- a/src/Startup/CrestApps.Core.Mvc.Web/Program.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Program.cs
@@ -1,4 +1,4 @@
-using CrestApps.Core;
+﻿using CrestApps.Core;
 using CrestApps.Core.AI;
 using CrestApps.Core.AI.WebCrawlers;
 using CrestApps.Core.AI.A2A;
@@ -15,6 +15,7 @@ using CrestApps.Core.AI.Documents.Pdf;
 using CrestApps.Core.AI.Elasticsearch;
 using CrestApps.Core.AI.Markdown;
 using CrestApps.Core.AI.Mcp;
+using CrestApps.Core.AI.Tooling.Instances.DataSources;
 using CrestApps.Core.AI.Tooling.Instances.Documentation;
 using CrestApps.Core.AI.Mcp.Ftp;
 using CrestApps.Core.AI.Mcp.Models;
@@ -158,6 +159,7 @@ builder.Services
         .AddToolInstances(toolInstances => toolInstances
             .AddHttpApiRequestSource()
             .AddDocumentationSearchSources()
+            .AddDataSourceSearchSource()
             .AddYesSqlStores()
         )
         .AddMcpServer(mcpServer => mcpServer

--- a/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
@@ -88,7 +88,7 @@ public sealed class DataSourceSearchToolInstanceTests
 
         var result = await function.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
         {
-            ["query"] = "vacation policy",
+            ["queries"] = new[] { "vacation policy" },
         })
         {
             Services = new ServiceCollection().BuildServiceProvider(),
@@ -308,6 +308,204 @@ public sealed class DataSourceSearchToolInstanceTests
         Assert.Contains("not available", result, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Verifies that several phrases are embedded in one batched call and each gets its own index query, so
+    /// covering N topics costs one embedding round trip rather than N.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_MultiplePhrases_EmbedsInOneBatchAndSearchesEach()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Content = "Employees accrue 15 days per year.",
+                Score = 0.9f,
+            },
+        ]);
+
+        var embeddingGenerator = new RecordingEmbeddingGenerator();
+        var services = BuildServices(contentManager, embeddingGenerator);
+
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        await InvokeAsync(function, services, "vacation policy", "sick leave policy");
+
+        Assert.Equal(1, embeddingGenerator.BatchCount);
+        Assert.Equal(["vacation policy", "sick leave policy"], embeddingGenerator.ReceivedInputs);
+        Assert.Equal(2, contentManager.SearchCount);
+    }
+
+    /// <summary>
+    /// Verifies that a chunk matched by more than one phrase is returned once under a single citation, rather
+    /// than repeated per phrase as separate independent calls would.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_MultiplePhrases_ReturnsOverlappingChunkOnce()
+    {
+        var shared = new DataSourceSearchResult
+        {
+            ReferenceId = "doc-1",
+            Title = "Leave policy",
+            Content = "Employees accrue 15 days per year.",
+            ChunkIndex = 0,
+            Score = 0.9f,
+        };
+
+        // Both phrases return the same chunk; only the second also returns a chunk of its own.
+        var contentManager = new RecordingContentManager(_ =>
+        [
+            shared,
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-2",
+                Title = "Sick leave",
+                Content = "Sick days do not roll over.",
+                ChunkIndex = 0,
+                Score = 0.7f,
+            },
+        ]);
+
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await InvokeAsync(function, services, "vacation policy", "sick leave policy");
+
+        Assert.Equal(1, CountOccurrences(result, "Employees accrue 15 days per year."));
+        Assert.Equal(1, CountOccurrences(result, "Sick days do not roll over."));
+        Assert.Equal(1, CountOccurrences(result, "[doc:1] = doc-1"));
+    }
+
+    /// <summary>
+    /// Verifies that a model which ignores the schema cap is truncated rather than rejected, so an over-eager
+    /// caller still gets an answer and never runs more index queries than the cap allows.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_CapsThePhraseCount_AndDropsExactRepeats()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Content = "Employees accrue 15 days per year.",
+                Score = 0.9f,
+            },
+        ]);
+
+        var embeddingGenerator = new RecordingEmbeddingGenerator();
+        var services = BuildServices(contentManager, embeddingGenerator);
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await InvokeAsync(function, services, "one", "two", "  two  ", "three", "four", "five");
+
+        Assert.Equal(DataSourceRetrieval.MaxQueries, contentManager.SearchCount);
+        Assert.Equal(["one", "two", "three"], embeddingGenerator.ReceivedInputs);
+        Assert.Contains("Employees accrue 15 days per year.", result);
+    }
+
+    /// <summary>
+    /// Verifies that a model sending a bare string instead of the array the schema asks for is still served,
+    /// rather than losing a tool call to a shape mismatch it has to diagnose.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_AcceptsABareStringInsteadOfAnArray()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Content = "Employees accrue 15 days per year.",
+                Score = 0.9f,
+            },
+        ]);
+
+        var embeddingGenerator = new RecordingEmbeddingGenerator();
+        var services = BuildServices(contentManager, embeddingGenerator);
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await function.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
+        {
+            ["queries"] = "vacation policy",
+        })
+        {
+            Services = services,
+        },
+        cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["vacation policy"], embeddingGenerator.ReceivedInputs);
+        Assert.Equal(1, contentManager.SearchCount);
+        Assert.Contains("Employees accrue 15 days per year.", result?.ToString());
+    }
+
+    /// <summary>
+    /// Verifies that a single phrase still ranks purely by score, so the fusion added for multiple phrases
+    /// leaves the one-phrase path — the profile-bound tool's path — behaving exactly as it did.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_SinglePhrase_RanksByScoreDescending()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult { ReferenceId = "doc-low", Content = "Third best.", Score = 0.5f },
+            new DataSourceSearchResult { ReferenceId = "doc-high", Content = "Best match.", Score = 0.95f },
+            new DataSourceSearchResult { ReferenceId = "doc-mid", Content = "Second best.", Score = 0.8f },
+        ]);
+
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Equal(1, contentManager.SearchCount);
+        Assert.True(result.IndexOf("Best match.", StringComparison.Ordinal) < result.IndexOf("Second best.", StringComparison.Ordinal));
+        Assert.True(result.IndexOf("Second best.", StringComparison.Ordinal) < result.IndexOf("Third best.", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that ranking is by position within each phrase's own results, not by raw similarity across
+    /// phrases. A phrase whose whole result set scores lower still gets its best hit near the top, instead of
+    /// being buried under a phrase that happens to produce higher similarities.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_MultiplePhrases_RankByPositionNotRawScoreAcrossPhrases()
+    {
+        // Similarity scores are only comparable within one query vector. The broad phrase's best match scores
+        // 0.60 while every hit for the narrow phrase scores above 0.90 — ranking the union by raw score would
+        // bury the broad phrase's answer beneath all three of the narrow phrase's.
+        var narrow = new DataSourceSearchResult[]
+        {
+            new() { ReferenceId = "narrow-1", Content = "Narrow first.", Score = 0.95f },
+            new() { ReferenceId = "narrow-2", Content = "Narrow second.", Score = 0.93f },
+            new() { ReferenceId = "narrow-3", Content = "Narrow third.", Score = 0.91f },
+        };
+
+        var broad = new DataSourceSearchResult[]
+        {
+            new() { ReferenceId = "broad-1", Content = "Broad first.", Score = 0.60f },
+        };
+
+        var narrowVector = "narrow phrase".GetHashCode(StringComparison.Ordinal);
+
+        var contentManager = new RecordingContentManager(vector => vector[0] == narrowVector ? narrow : broad);
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await InvokeAsync(function, services, "narrow phrase", "broad phrase");
+
+        var narrowFirst = result.IndexOf("Narrow first.", StringComparison.Ordinal);
+        var narrowSecond = result.IndexOf("Narrow second.", StringComparison.Ordinal);
+        var broadFirst = result.IndexOf("Broad first.", StringComparison.Ordinal);
+
+        Assert.All(new[] { narrowFirst, narrowSecond, broadFirst }, index => Assert.True(index >= 0));
+
+        // Each phrase's top hit outranks the narrow phrase's runner-up, despite scoring 0.33 lower.
+        Assert.True(narrowFirst < broadFirst, "The highest-ranked result overall should still come first.");
+        Assert.True(broadFirst < narrowSecond, "A phrase's own top hit should outrank another phrase's runner-up.");
+    }
+
     private static int CountOccurrences(string text, string value)
     {
         return text.Split(value).Length - 1;
@@ -328,11 +526,11 @@ public sealed class DataSourceSearchToolInstanceTests
         return (DataSourceSearchToolFunction)new DataSourceSearchToolInstanceSource().CreateTool(instance);
     }
 
-    private static async Task<string> InvokeAsync(DataSourceSearchToolFunction function, IServiceProvider services, string query)
+    private static async Task<string> InvokeAsync(DataSourceSearchToolFunction function, IServiceProvider services, params string[] queries)
     {
         var result = await function.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
         {
-            ["query"] = query,
+            ["queries"] = queries,
         })
         {
             Services = services,
@@ -444,15 +642,21 @@ public sealed class DataSourceSearchToolInstanceTests
 
         public List<string> ReceivedInputs { get; } = [];
 
+        public int BatchCount { get; private set; }
+
         public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
             IEnumerable<string> values,
             EmbeddingGenerationOptions options = null,
             CancellationToken cancellationToken = default)
         {
-            ReceivedInputs.AddRange(values);
+            var batch = values.ToList();
 
+            BatchCount++;
+            ReceivedInputs.AddRange(batch);
+
+            // Each phrase gets its own distinguishable vector so a test can tell which phrase a search ran for.
             return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(
-                ReceivedInputs.Select(_ => new Embedding<float>(new float[] { 0.1f, 0.2f, 0.3f })).ToList()));
+                batch.Select(value => new Embedding<float>(new float[] { value.GetHashCode(StringComparison.Ordinal) })).ToList()));
         }
 
         public object GetService(Type serviceType, object serviceKey = null) => null;
@@ -465,10 +669,17 @@ public sealed class DataSourceSearchToolInstanceTests
     private sealed class RecordingContentManager : IDataSourceContentManager
     {
         private readonly IReadOnlyList<DataSourceSearchResult> _results;
+        private readonly Func<float[], IReadOnlyList<DataSourceSearchResult>> _resultsByVector;
+        private readonly Lock _gate = new();
 
         public RecordingContentManager(IReadOnlyList<DataSourceSearchResult> results)
         {
             _results = results;
+        }
+
+        public RecordingContentManager(Func<float[], IReadOnlyList<DataSourceSearchResult>> resultsByVector)
+        {
+            _resultsByVector = resultsByVector;
         }
 
         public string ReceivedDataSourceId { get; private set; }
@@ -476,6 +687,8 @@ public sealed class DataSourceSearchToolInstanceTests
         public string ReceivedFilter { get; private set; }
 
         public int ReceivedTopN { get; private set; }
+
+        public int SearchCount { get; private set; }
 
         public Task<IEnumerable<DataSourceSearchResult>> SearchAsync(
             IIndexProfileInfo indexProfile,
@@ -485,11 +698,19 @@ public sealed class DataSourceSearchToolInstanceTests
             string filter = null,
             CancellationToken cancellationToken = default)
         {
-            ReceivedDataSourceId = dataSourceId;
-            ReceivedFilter = filter;
-            ReceivedTopN = topN;
+            IReadOnlyList<DataSourceSearchResult> results;
 
-            return Task.FromResult<IEnumerable<DataSourceSearchResult>>(_results);
+            lock (_gate)
+            {
+                ReceivedDataSourceId = dataSourceId;
+                ReceivedFilter = filter;
+                ReceivedTopN = topN;
+                SearchCount++;
+
+                results = _resultsByVector?.Invoke(embedding) ?? _results;
+            }
+
+            return Task.FromResult<IEnumerable<DataSourceSearchResult>>(results);
         }
 
         public Task<long> DeleteByDataSourceIdAsync(

--- a/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
@@ -1,0 +1,567 @@
+using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.DataSources;
+using CrestApps.Core.AI.Deployments;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Services;
+using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Tooling.Instances.DataSources;
+using CrestApps.Core.Infrastructure.Indexing;
+using CrestApps.Core.Infrastructure.Indexing.DataSources;
+using CrestApps.Core.Infrastructure.Indexing.Models;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace CrestApps.Core.Tests.Core.Tools;
+
+public sealed class DataSourceSearchToolInstanceTests
+{
+    private const string DataSourceId = "data-source-1";
+    private const string ProviderName = "TestProvider";
+    private const string KnowledgeBaseName = "kb-index";
+    private const string EmbeddingDeploymentName = "text-embedding-3-small";
+
+    /// <summary>
+    /// Verifies that the source materializes a search function whose model-facing name and description are
+    /// derived from the configured instance.
+    /// </summary>
+    [Fact]
+    public void CreateTool_DerivesNameAndDescriptionFromInstance()
+    {
+        var instance = new AIToolInstance
+        {
+            ItemId = "instance-1",
+            Source = DataSourceSearchToolConstants.SourceName,
+            Name = "policy-handbook",
+            Description = "Searches the employee policy handbook.",
+        };
+
+        instance.Put(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+        });
+
+        var tool = new DataSourceSearchToolInstanceSource().CreateTool(instance);
+
+        var function = Assert.IsType<DataSourceSearchToolFunction>(tool);
+
+        Assert.Equal(instance.GetFunctionName(), function.Name);
+        Assert.Equal("Searches the employee policy handbook.", function.Description);
+    }
+
+    /// <summary>
+    /// Verifies that an instance without a description still exposes a usable description to the model.
+    /// </summary>
+    [Fact]
+    public void CreateTool_FallsBackToDefaultDescription_WhenInstanceHasNone()
+    {
+        var instance = new AIToolInstance
+        {
+            ItemId = "instance-2",
+            Source = DataSourceSearchToolConstants.SourceName,
+            Name = "policy-handbook",
+        };
+
+        var function = Assert.IsType<DataSourceSearchToolFunction>(new DataSourceSearchToolInstanceSource().CreateTool(instance));
+
+        Assert.False(string.IsNullOrWhiteSpace(function.Description));
+        Assert.NotEqual(function.Name, function.Description);
+    }
+
+    /// <summary>
+    /// Verifies that an instance saved without a data source reports the misconfiguration instead of
+    /// searching an unrelated knowledge base.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_ReportsMisconfiguration_WhenNoDataSourceIsSelected()
+    {
+        var instance = new AIToolInstance
+        {
+            ItemId = "instance-3",
+            Source = DataSourceSearchToolConstants.SourceName,
+            Name = "unconfigured",
+        };
+
+        var function = (DataSourceSearchToolFunction)new DataSourceSearchToolInstanceSource().CreateTool(instance);
+
+        var result = await function.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
+        {
+            ["query"] = "vacation policy",
+        })
+        {
+            Services = new ServiceCollection().BuildServiceProvider(),
+        },
+        cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains("No data source is configured", result?.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Verifies that the query is embedded with the knowledge base index profile's own embedding deployment
+    /// — the same one the chunks were indexed with — and that the configured retrieval parameters reach the
+    /// vector search.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_EmbedsQueryWithIndexProfileDeployment_AndAppliesConfiguredParameters()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Title = "Vacation policy",
+                Content = "Employees accrue 15 days per year.",
+                ChunkIndex = 0,
+                ReferenceType = "Content",
+                Score = 0.9f,
+            },
+        ]);
+
+        var embeddingGenerator = new RecordingEmbeddingGenerator();
+        var services = BuildServices(contentManager, embeddingGenerator);
+
+        var function = CreateFunction(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+            TopNDocuments = 7,
+            Strictness = 1,
+            Filter = "status eq 'published'",
+        });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Equal(EmbeddingDeploymentName, embeddingGenerator.RequestedDeploymentName);
+        Assert.Equal(["vacation policy"], embeddingGenerator.ReceivedInputs);
+
+        Assert.Equal(DataSourceId, contentManager.ReceivedDataSourceId);
+        Assert.Equal("translated:status eq 'published'", contentManager.ReceivedFilter);
+        Assert.Equal(DataSourceSearchResultSelector.GetCandidateCount(7), contentManager.ReceivedTopN);
+
+        Assert.Contains("Employees accrue 15 days per year.", result);
+        Assert.Contains("Vacation policy", result);
+        Assert.Contains("[doc:1] = doc-1", result);
+    }
+
+    /// <summary>
+    /// Verifies that chunk retrieval — the default — returns the matching chunks rather than reading the
+    /// full source documents back.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_ChunkMode_ReturnsMatchingChunksOnly()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Title = "Vacation policy",
+                Content = "Employees accrue 15 days per year.",
+                ChunkIndex = 1,
+                Score = 0.9f,
+            },
+        ]);
+
+        var sourceHandler = new RecordingSourceHandler(new Dictionary<string, SourceDocument>
+        {
+            ["doc-1"] = new SourceDocument
+            {
+                Title = "Vacation policy",
+                Content = "The full vacation policy, start to finish.",
+            },
+        });
+
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator(), sourceHandler);
+
+        var function = CreateFunction(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+            RetrievalMode = DataSourceRetrievalMode.Chunk,
+        });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Contains("Employees accrue 15 days per year.", result);
+        Assert.DoesNotContain("The full vacation policy, start to finish.", result);
+        Assert.False(sourceHandler.WasRead);
+    }
+
+    /// <summary>
+    /// Verifies that hierarchical retrieval collapses the matching chunks onto their source document and
+    /// returns that document's complete text under a single citation.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_HierarchicalMode_ReturnsFullSourceDocumentOnce()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Title = "Vacation policy",
+                Content = "Employees accrue 15 days per year.",
+                ChunkIndex = 0,
+                Score = 0.9f,
+            },
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Title = "Vacation policy",
+                Content = "Unused days roll over once.",
+                ChunkIndex = 1,
+                Score = 0.8f,
+            },
+        ]);
+
+        var sourceHandler = new RecordingSourceHandler(new Dictionary<string, SourceDocument>
+        {
+            ["doc-1"] = new SourceDocument
+            {
+                Title = "Vacation policy",
+                Content = "The full vacation policy, start to finish.",
+            },
+        });
+
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator(), sourceHandler);
+
+        var function = CreateFunction(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+            RetrievalMode = DataSourceRetrievalMode.Hierarchical,
+        });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Equal(["doc-1"], sourceHandler.ReceivedDocumentIds);
+        Assert.Contains("The full vacation policy, start to finish.", result);
+        Assert.DoesNotContain("Unused days roll over once.", result);
+
+        // The two chunks belong to one document, so the document is rendered once under one citation.
+        Assert.Equal(1, CountOccurrences(result, "The full vacation policy, start to finish."));
+        Assert.Equal(1, CountOccurrences(result, "[doc:1] Title:"));
+        Assert.DoesNotContain("[doc:2]", result);
+    }
+
+    /// <summary>
+    /// Verifies that hierarchical retrieval degrades to the matching chunks when the source documents can no
+    /// longer be read, rather than returning nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_HierarchicalMode_FallsBackToChunks_WhenSourceCannotBeRead()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Title = "Vacation policy",
+                Content = "Employees accrue 15 days per year.",
+                ChunkIndex = 0,
+                Score = 0.9f,
+            },
+        ]);
+
+        var sourceHandler = new RecordingSourceHandler(new Dictionary<string, SourceDocument>(), throwOnRead: true);
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator(), sourceHandler);
+
+        var function = CreateFunction(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+            RetrievalMode = DataSourceRetrievalMode.Hierarchical,
+        });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Contains("Employees accrue 15 days per year.", result);
+    }
+
+    /// <summary>
+    /// Verifies that a strictness high enough to reject every match tells the model the knowledge base has
+    /// no answer instead of returning an empty block of context.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_ReportsNoMatches_WhenStrictnessRejectsEveryResult()
+    {
+        var contentManager = new RecordingContentManager(
+        [
+            new DataSourceSearchResult
+            {
+                ReferenceId = "doc-1",
+                Content = "Employees accrue 15 days per year.",
+                Score = 0.1f,
+            },
+        ]);
+
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+
+        var function = CreateFunction(new DataSourceSearchToolSettings
+        {
+            DataSourceId = DataSourceId,
+            Strictness = AIDataSourceOptions.MaxStrictness,
+            IsInScope = true,
+        });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Contains("strictness", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not available", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        return text.Split(value).Length - 1;
+    }
+
+    private static DataSourceSearchToolFunction CreateFunction(DataSourceSearchToolSettings settings)
+    {
+        var instance = new AIToolInstance
+        {
+            ItemId = "instance-search",
+            Source = DataSourceSearchToolConstants.SourceName,
+            Name = "knowledge-base",
+            Description = "Searches the knowledge base.",
+        };
+
+        instance.Put(settings);
+
+        return (DataSourceSearchToolFunction)new DataSourceSearchToolInstanceSource().CreateTool(instance);
+    }
+
+    private static async Task<string> InvokeAsync(DataSourceSearchToolFunction function, IServiceProvider services, string query)
+    {
+        var result = await function.InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
+        {
+            ["query"] = query,
+        })
+        {
+            Services = services,
+        },
+        cancellationToken: TestContext.Current.CancellationToken);
+
+        return result?.ToString() ?? string.Empty;
+    }
+
+    private static ServiceProvider BuildServices(
+        RecordingContentManager contentManager,
+        RecordingEmbeddingGenerator embeddingGenerator,
+        RecordingSourceHandler sourceHandler = null)
+    {
+        var dataSource = new AIDataSource
+        {
+            ItemId = DataSourceId,
+            Source = AIDataSourceSourceTypes.SearchIndexProfile,
+            DisplayText = "Knowledge base",
+            AIKnowledgeBaseIndexProfileName = KnowledgeBaseName,
+        };
+
+        var indexProfile = new SearchIndexProfile
+        {
+            Name = KnowledgeBaseName,
+            ProviderName = ProviderName,
+            Type = IndexProfileTypes.DataSource,
+            EmbeddingDeploymentName = EmbeddingDeploymentName,
+        };
+
+        var deployment = new AIDeployment
+        {
+            ItemId = "deployment-1",
+            Name = EmbeddingDeploymentName,
+        };
+
+        var dataSourceStore = new Mock<IAIDataSourceStore>();
+        dataSourceStore
+            .Setup(store => store.FindByIdAsync(DataSourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dataSource);
+
+        var indexProfileStore = new Mock<ISearchIndexProfileStore>();
+        indexProfileStore
+            .Setup(store => store.FindByNameAsync(KnowledgeBaseName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(indexProfile);
+
+        var deploymentManager = new Mock<IAIDeploymentManager>();
+        deploymentManager
+            .Setup(manager => manager.FindByNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string name, CancellationToken _) =>
+            {
+                embeddingGenerator.RequestedDeploymentName = name;
+
+                return ValueTask.FromResult(string.Equals(name, EmbeddingDeploymentName, StringComparison.Ordinal) ? deployment : null);
+            });
+
+        var clientFactory = new Mock<IAIClientFactory>();
+        clientFactory
+            .Setup(factory => factory.CreateEmbeddingGeneratorAsync(It.IsAny<AIDeployment>()))
+            .ReturnsAsync(embeddingGenerator);
+
+        var textNormalizer = new Mock<IAITextNormalizer>();
+        textNormalizer
+            .Setup(normalizer => normalizer.NormalizeTitle(It.IsAny<string>()))
+            .Returns((string title) => title);
+
+        var filterTranslator = new Mock<IODataFilterTranslator>();
+        filterTranslator
+            .Setup(translator => translator.Translate(It.IsAny<string>()))
+            .Returns((string filter) => $"translated:{filter}");
+
+        var services = new ServiceCollection();
+
+        services.AddSingleton(dataSourceStore.Object);
+        services.AddSingleton(indexProfileStore.Object);
+        services.AddSingleton(deploymentManager.Object);
+        services.AddSingleton(clientFactory.Object);
+        services.AddSingleton(textNormalizer.Object);
+        services.AddKeyedSingleton<IDataSourceContentManager>(ProviderName, contentManager);
+        services.AddKeyedSingleton<IODataFilterTranslator>(ProviderName, filterTranslator.Object);
+        services.AddSingleton<IOptionsMonitor<AIDataSourceOptions>>(new StaticOptionsMonitor<AIDataSourceOptions>(new AIDataSourceOptions()));
+        services.AddLogging();
+
+        if (sourceHandler != null)
+        {
+            services.AddKeyedSingleton<IAIDataSourceSourceHandler>(AIDataSourceSourceTypes.SearchIndexProfile, sourceHandler);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value)
+        {
+            CurrentValue = value;
+        }
+
+        public T CurrentValue { get; }
+
+        public T Get(string name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string> listener) => null;
+    }
+
+    private sealed class RecordingEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public string RequestedDeploymentName { get; set; }
+
+        public List<string> ReceivedInputs { get; } = [];
+
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedInputs.AddRange(values);
+
+            return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>(
+                ReceivedInputs.Select(_ => new Embedding<float>(new float[] { 0.1f, 0.2f, 0.3f })).ToList()));
+        }
+
+        public object GetService(Type serviceType, object serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingContentManager : IDataSourceContentManager
+    {
+        private readonly IReadOnlyList<DataSourceSearchResult> _results;
+
+        public RecordingContentManager(IReadOnlyList<DataSourceSearchResult> results)
+        {
+            _results = results;
+        }
+
+        public string ReceivedDataSourceId { get; private set; }
+
+        public string ReceivedFilter { get; private set; }
+
+        public int ReceivedTopN { get; private set; }
+
+        public Task<IEnumerable<DataSourceSearchResult>> SearchAsync(
+            IIndexProfileInfo indexProfile,
+            float[] embedding,
+            string dataSourceId,
+            int topN,
+            string filter = null,
+            CancellationToken cancellationToken = default)
+        {
+            ReceivedDataSourceId = dataSourceId;
+            ReceivedFilter = filter;
+            ReceivedTopN = topN;
+
+            return Task.FromResult<IEnumerable<DataSourceSearchResult>>(_results);
+        }
+
+        public Task<long> DeleteByDataSourceIdAsync(
+            IIndexProfileInfo indexProfile,
+            string dataSourceId,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(0L);
+        }
+    }
+
+    private sealed class RecordingSourceHandler : IAIDataSourceSourceHandler
+    {
+        private readonly IReadOnlyDictionary<string, SourceDocument> _documents;
+        private readonly bool _throwOnRead;
+
+        public RecordingSourceHandler(IReadOnlyDictionary<string, SourceDocument> documents, bool throwOnRead = false)
+        {
+            _documents = documents;
+            _throwOnRead = throwOnRead;
+        }
+
+        public string SourceType => AIDataSourceSourceTypes.SearchIndexProfile;
+
+        public bool WasRead { get; private set; }
+
+        public List<string> ReceivedDocumentIds { get; } = [];
+
+        public ValueTask ValidateAsync(AIDataSource dataSource, CrestApps.Core.Models.ValidationResultDetails result, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<string> GetReferenceTypeAsync(AIDataSource dataSource, CancellationToken cancellationToken = default)
+        {
+            return ValueTask.FromResult(AIDataSourceSourceTypes.SearchIndexProfile);
+        }
+
+        public async IAsyncEnumerable<KeyValuePair<string, SourceDocument>> ReadAsync(
+            AIDataSource dataSource,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+
+            foreach (var pair in _documents)
+            {
+                yield return pair;
+            }
+        }
+
+        public async IAsyncEnumerable<KeyValuePair<string, SourceDocument>> ReadByIdsAsync(
+            AIDataSource dataSource,
+            IEnumerable<string> documentIds,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+
+            WasRead = true;
+            ReceivedDocumentIds.AddRange(documentIds);
+
+            if (_throwOnRead)
+            {
+                throw new InvalidOperationException("The source index is unavailable.");
+            }
+
+            foreach (var id in ReceivedDocumentIds)
+            {
+                if (_documents.TryGetValue(id, out var document))
+                {
+                    yield return new KeyValuePair<string, SourceDocument>(id, document);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a **`data-source-search`** tool instance source. Each instance binds **one** existing AI Data Source plus its own retrieval parameters, so several instances can expose several knowledge bases side by side — each under its own function name and description — and the model picks which to consult. The model supplies only the search phrase.

Until now a data source reached the model only by being attached to an AI profile or chat interaction, which allowed exactly one per conversation and left the choice out of the model's hands.

## Settings per instance

| Setting | Default | Purpose |
|---|---|---|
| `DataSourceId` | *(required)* | The AI data source this instance searches. |
| `RetrievalMode` | `Chunk` | `Chunk` returns only matching chunks; `Hierarchical` returns each matched source document complete. |
| `TopNDocuments` | site default | Retrieved documents, bounded by `AIDataSourceOptions.Min/MaxTopNDocuments`. |
| `Strictness` | site default | How close a match must be, bounded by `AIDataSourceOptions.Min/MaxStrictness`. |
| `Filter` | *(none)* | OData filter, translated to the provider's own syntax before searching. |
| `IsInScope` | `false` | Tells the model the answer is unavailable instead of inviting a general-knowledge fallback. |

These are the same query-time parameters a chat interaction configures, applied the same way. The difference is only where they come from: the instance carries its own, instead of reading `AIDataSourceRagMetadata` off the resource.

## Embedding

The phrase is embedded with the **same embedding deployment the knowledge base index was indexed with**, resolved exactly the way the indexing service resolves it: `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by `DataSourceIndexProfileMetadata` on that profile. Query and stored chunks therefore land in the same vector space.

## Hierarchical retrieval

Collapses the matching chunks onto their source documents, takes the top N documents, and reads each one back through the data source's own `IAIDataSourceSourceHandler`, emitting the full text under a single `[doc:N]` citation. A source that can no longer be read (deleted index, revoked credentials) degrades to the matching chunks rather than failing the search.

## Refactor worth a look

The retrieval pipeline behind the profile-bound `DataSourceSearchTool` is extracted into a shared internal path (`DataSourceRetrieval`) that both it and the new instances use, rather than duplicating ~150 lines. The two now share thresholds, filter translation, citation numbering, and output format. **Existing behavior is unchanged** — the profile-bound tool just resolves its `AIDataSourceRagMetadata` and delegates.

## On the duplicated enum

`DataSourceRetrievalMode` duplicates `DocumentRetrievalMode` deliberately. `DocumentRetrievalMode` lives in `CrestApps.Core.AI.Documents`, which **depends on** `CrestApps.Core.AI` — where the new source lives — so reusing it would invert the dependency, and relocating a public enum across assemblies would break callers pinning these packages transitively. Same two members, same `Chunk` default. Happy to consolidate into one shared enum in the abstractions as a separate, breaking change if that's preferred.

## Also

- Matching editor sections in both hosts (MVC `_Form.cshtml` + controller, Blazor Create/Edit), with range validation against `AIDataSourceOptions`.
- Registered in both sample hosts via `AddDataSourceSearchSource()`.
- Docs section in `core/tool-instances.md`, changelog entry in `2.0.0.md`; docs site builds clean.

## Testing

- 8 new tests covering embedding-deployment reuse, parameter pass-through to the vector search, both retrieval modes, the hierarchical read-back fallback, and strictness rejection.
- Full suite green: **3203 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
