### PR TITLE
Expose AI agents to MCP clients as callable tools

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -651,6 +651,33 @@ microphone, desk speakers):
   internal path both it and the new instances use, so the two honor identical thresholds, filter
   translation, citation numbering, and output format. Behavior of the existing tool is unchanged.
 
+## Agents as MCP server tools
+
+- An **AI agent can now be exposed to MCP clients as a callable tool**, alongside plain tools and tool
+  instances. The client sees one tool per allow-listed agent — named after the agent, described by its
+  description, taking a single `prompt` — and invoking it runs that agent. Previously agents reached the
+  model only through `AgentToolRegistryProvider`, which is completion-scoped, so the MCP server had no way
+  to see them.
+  - adds `McpServerOptions.Agents` (an allow-list of agent profile names) and
+    `McpServerOptions.ExposeAllAgents`, both editable from **Settings → MCP server** in either host
+  - agents are gated by their **own** switch rather than `ExposeAllTools`, on purpose: an agent runs a whole
+    profile with its own tools, data sources, and credentials, so a server that had already opted into
+    exposing tools must not begin exposing agents merely by upgrading
+  - an agent needs a description to be exposed, since that is all an MCP client has to tell agents apart.
+    `AgentAvailability` is ignored — it governs a completion's token budget, not who may reach an agent from
+    outside — and an agent whose name is already taken by an exposed tool is skipped from the listing with a
+    warning, so the listed name always matches what a call will reach
+  - **an agent's own tools are never filtered by the tool allow-list.** That list governs what a client may
+    directly invoke; what an agent uses internally is its own configuration. Intersecting them would force an
+    operator to allow-list every internal tool, making each one directly callable — more exposure, not less,
+    and the opposite of publishing a curated agent
+- **Fixed: a tool invoked over MCP ran without an AI invocation scope.** The call handler now establishes one
+  for the duration of the call. Without it `AgentProxyTool` treated the untrackable recursion depth as unsafe
+  and silently ran the agent with its tools disabled — a plausible-looking wrong answer rather than an error
+  — and citation-emitting tools such as the data source search fell back to local reference numbering instead
+  of registering their citations. An agent still runs its own tools only when its profile sets
+  `AgentMetadata.AllowToolInvocation`, exactly as when the model invokes it as a tool in a chat completion.
+
 ## Change Logs
 
 - **Fixed: totals from an uploaded spreadsheet could come back several times too large.** A worksheet

--- a/src/CrestApps.Core.Docs/docs/mcp/server.md
+++ b/src/CrestApps.Core.Docs/docs/mcp/server.md
@@ -324,6 +324,55 @@ Because `McpServerOptions` is backed by site settings, an operator can choose wh
 
 Both code-registered tools (from `AddCoreAITool<T>()`, see [Custom Tools](../core/tools.md)) and stored tool instances (from any registered [tool instance source](../core/tool-instances.md), such as the [documentation search sources](#exposing-a-documentation-knowledge-base)) participate in the same allow-list.
 
+## Exposing Agents as Tools
+
+An **agent** — an AI profile of type agent — can be exposed to MCP clients as a callable tool, alongside plain tools and tool instances. The client sees one tool per allow-listed agent, named after the agent and described by its description, taking a single `prompt` argument. Invoking it runs that agent.
+
+```csharp
+services.Configure<McpServerOptions>(options =>
+{
+    // Expose specific agents by name.
+    options.Agents = ["researcher", "report-writer"];
+
+    // Or expose every agent that has a description.
+    // When true, the Agents allow-list above is ignored.
+    options.ExposeAllAgents = true;
+});
+```
+
+| Property | Effect |
+|----------|--------|
+| `Agents` | An allow-list of agent profile names to expose. Matching is case-insensitive. |
+| `ExposeAllAgents` | When `true`, every described agent is exposed and the allow-list is ignored. |
+
+:::warning
+Agents are gated by their **own** switch, separate from `ExposeAllTools`. This is deliberate: an agent runs a whole profile — its system message, its tools, its data sources, and the credentials behind them — so a server that had already opted into exposing tools must not start exposing agents merely because it upgraded. The allow-list is a security boundary; an exposed agent is runnable by any client that clears the server's authentication.
+:::
+
+### An agent's own tools are not filtered by the allow-list
+
+The two lists answer different questions, and they never intersect:
+
+| | Question it answers |
+|---|---|
+| `Tools` / `ExposeAllTools` | What may a client **directly name and invoke**? |
+| The agent's own profile | What does the agent use **internally** to do its job? |
+
+An allow-listed agent runs with the tools, tool instances, data sources, and MCP client connections its profile configures — whether or not any of those appear in `Tools`. Nor does using a tool internally make it directly callable: it stays unreachable by name unless separately allow-listed.
+
+Intersecting the two would be backwards. An operator wanting a working agent would have to allow-list every tool it uses internally, and each of those would then become directly callable — forcing *more* exposure, and defeating the point of publishing a curated agent instead of raw tools. Think of it as encapsulation: exposing an agent exposes a function signature, not its implementation.
+
+### What an agent may do when reached over MCP
+
+- **Its own tools run only if the agent opted in.** `AgentMetadata.AllowToolInvocation` must be `true`, exactly as when the model invokes that agent as a tool in a chat completion. It defaults to `false`, so an agent that answers suspiciously generically over MCP is usually missing this flag rather than hitting a server problem.
+- **Nested agents stay suppressed.** An agent reached over MCP can use its tools but cannot delegate to other agents; that bound is what makes running with tools safe.
+- **Availability is irrelevant.** `AgentAvailability.AlwaysAvailable` versus `OnDemand` governs a completion's token budget, not who may reach an agent from outside. The allow-list is the only gate.
+- **A name shared with a tool resolves to the tool.** Agents are enumerated last, and one whose name is already taken is skipped from the listing with a warning, so what is listed is always what a call will reach.
+
+The call handler establishes an AI invocation scope for the duration of every MCP tool call, which is what places an agent at top-level depth and lets it run its configured tools. Without it an agent would silently fall back to a tool-less completion — a worse answer rather than an error.
+
+Because `McpServerOptions` is backed by site settings, agents are chosen from the admin **Settings → MCP server** page without redeploying.
+
 ## Exposing a documentation knowledge base
 
 A common reason to run an MCP server is to answer questions from product or framework documentation that lives on a public site (such as a Docusaurus or MkDocs site). Instead of indexing that content into a vector store, the built-in documentation search [tool instance sources](../core/tool-instances.md) let an operator declare a documentation site as a **tool instance** and scan it on demand.

--- a/src/Primitives/CrestApps.Core.AI.Mcp/McpServerBuilderExtensions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Mcp/McpServerBuilderExtensions.cs
@@ -1,4 +1,8 @@
+using System.Text.Json;
 using CrestApps.Core.AI.Mcp.Services;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.AI.Profiles;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Services;
 using Microsoft.Extensions.AI;
@@ -18,6 +22,26 @@ namespace CrestApps.Core.AI.Mcp;
 public static class McpServerBuilderExtensions
 {
     /// <summary>
+    /// The input schema advertised for an agent exposed as a tool. It mirrors the schema
+    /// <c>AgentProxyTool</c> presents to the model, so an MCP client calls an agent exactly the way the
+    /// orchestrator does.
+    /// </summary>
+    private static readonly JsonElement AgentInputSchema = JsonSerializer.Deserialize<JsonElement>(
+    """
+    {
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "The prompt or message to send to the agent for processing."
+        }
+      },
+      "required": ["prompt"],
+      "additionalProperties": false
+    }
+    """);
+
+    /// <summary>
     /// Registers the standard CrestApps MCP server handlers for tools, prompts, and resources.
     /// This wires the CrestApps tool registry (<see cref="AIToolDefinitionOptions"/>),
     /// <see cref="IMcpServerPromptService"/>, and <see cref="IMcpServerResourceService"/>
@@ -26,6 +50,9 @@ public static class McpServerBuilderExtensions
     /// system tools that the orchestrator auto-includes are never listed or callable over MCP.
     /// Which of those selectable tools and tool instances are actually listed and callable is further
     /// controlled by the <see cref="McpServerOptions"/> site settings allow-list.
+    /// Agent profiles named in <see cref="McpServerOptions.Agents"/> are exposed as tools too, under their
+    /// own switch so enabling every tool never silently enables every agent. Invoking one runs that agent
+    /// with the tools its own profile configures, which the tool allow-list neither grants nor restricts.
     /// </summary>
     /// <param name="builder">The builder.</param>
     public static IMcpServerBuilder WithCrestAppsHandlers(this IMcpServerBuilder builder)
@@ -116,10 +143,41 @@ public static class McpServerBuilderExtensions
                     }
                 }
 
+                // Agents are enumerated last so a name they share with a tool or instance resolves to that
+                // tool, matching the call handler's resolution order.
+                foreach (var agent in await GetAllowedAgentsAsync(request.Services, serverOptions, cancellationToken))
+                {
+                    if (!seenNames.Add(agent.Name))
+                    {
+                        // A name collision is a configuration mistake, not an exceptional one, so it is
+                        // resolved and logged rather than allowed to fail the whole listing.
+                        logger ??= request.Services.GetService<ILogger<IMcpServerPromptService>>();
+                        logger?.LogWarning(
+                            "Agent '{AgentName}' is not exposed over MCP because a tool of the same name is already exposed.",
+                            agent.Name);
+
+                        continue;
+                    }
+
+                    tools.Add(new Tool
+                    {
+                        Name = agent.Name,
+                        Description = agent.Description,
+                        InputSchema = AgentInputSchema,
+                    });
+                }
+
                 return new ListToolsResult { Tools = tools };
             })
             .WithCallToolHandler(async (request, cancellationToken) =>
             {
+                // Tools invoked over MCP run outside any completion, so nothing has established the ambient
+                // invocation scope they expect. Without it an agent silently runs with its tools disabled
+                // (AgentProxyTool treats an untrackable depth as unsafe) and citation-emitting tools fall back
+                // to local reference numbering. Beginning a scope here makes an MCP call behave like the
+                // top-level completion it stands in for.
+                using var invocationScope = AIInvocationScope.Begin();
+
                 var serverOptions = request.Services.GetRequiredService<IOptionsMonitor<McpServerOptions>>().CurrentValue;
                 var exposeAll = serverOptions.ExposeAllTools;
                 var allowList = exposeAll ? null : BuildAllowList(serverOptions.Tools);
@@ -160,6 +218,23 @@ public static class McpServerBuilderExtensions
                             };
                         }
                     }
+                }
+
+                var agent = (await GetAllowedAgentsAsync(request.Services, serverOptions, cancellationToken))
+                    .FirstOrDefault(candidate => string.Equals(candidate.Name, request.Params.Name, StringComparison.OrdinalIgnoreCase));
+
+                if (agent is not null)
+                {
+                    // The agent runs its own configured tools. The allow-list governs which agents a client
+                    // may invoke, never what an agent uses internally to do its job — filtering those would
+                    // force an operator to expose each of them directly, which is the opposite of the point.
+                    var agentTool = new AgentProxyTool(agent.Name, agent.Description);
+                    var agentResult = await agentTool.InvokeAsync(BuildArguments(request), cancellationToken);
+
+                    return new CallToolResult
+                    {
+                        Content = [new TextContentBlock { Text = agentResult?.ToString() ?? string.Empty }],
+                    };
                 }
 
                 throw new McpException($"Tool '{request.Params.Name}' not found.");
@@ -203,6 +278,54 @@ public static class McpServerBuilderExtensions
 
                 return await resourceService.ReadAsync(request, cancellationToken);
             });
+    }
+
+    /// <summary>
+    /// Gets the agent profiles this server is configured to expose, in a stable order.
+    /// </summary>
+    /// <remarks>
+    /// An agent needs a name and a description to be exposed at all: the description is the only signal an
+    /// MCP client has for what the agent is for, and an agent nobody can tell apart is worse than an absent
+    /// one. Availability (<c>AlwaysAvailable</c> versus <c>OnDemand</c>) is deliberately ignored — that
+    /// governs a completion's token budget, not who may reach the agent from outside.
+    /// </remarks>
+    /// <param name="services">The request services.</param>
+    /// <param name="serverOptions">The server exposure settings.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The exposable agent profiles.</returns>
+    private static async Task<IReadOnlyList<AIProfile>> GetAllowedAgentsAsync(
+        IServiceProvider services,
+        McpServerOptions serverOptions,
+        CancellationToken cancellationToken)
+    {
+        var exposeAllAgents = serverOptions.ExposeAllAgents;
+
+        if (!exposeAllAgents && serverOptions.Agents is not { Count: > 0 })
+        {
+            return [];
+        }
+
+        var profileManager = services.GetService<IAIProfileManager>();
+
+        if (profileManager is null)
+        {
+            return [];
+        }
+
+        var agents = await profileManager.GetAsync(AIProfileType.Agent, cancellationToken);
+
+        if (agents is null)
+        {
+            return [];
+        }
+
+        var allowList = exposeAllAgents ? null : BuildAllowList(serverOptions.Agents);
+
+        return agents
+            .Where(agent => !string.IsNullOrEmpty(agent.Name) &&
+                !string.IsNullOrEmpty(agent.Description) &&
+                IsAllowed(exposeAllAgents, allowList, agent.Name))
+            .ToList();
     }
 
     private static HashSet<string> BuildAllowList(IEnumerable<string> names)

--- a/src/Primitives/CrestApps.Core.AI.Mcp/Models/McpServerOptions.cs
+++ b/src/Primitives/CrestApps.Core.AI.Mcp/Models/McpServerOptions.cs
@@ -43,4 +43,29 @@ public sealed class McpServerOptions
     /// only listed and callable when it appears here.
     /// </summary>
     public IList<string> Tools { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether every agent profile is exposed to MCP clients as a callable
+    /// tool. When <c>false</c> (the default), no agent is exposed unless it is named in <see cref="Agents"/>.
+    /// </summary>
+    /// <remarks>
+    /// Agents are gated separately from <see cref="ExposeAllTools"/> on purpose. An agent runs a whole AI
+    /// profile — its system message, its tools, its data sources, and the credentials behind them — so
+    /// letting the tool switch turn agents on would silently widen an existing deployment's surface the
+    /// moment it upgraded.
+    /// </remarks>
+    public bool ExposeAllAgents { get; set; }
+
+    /// <summary>
+    /// Gets or sets the allow-list of agent profile names exposed to MCP clients when
+    /// <see cref="ExposeAllAgents"/> is <c>false</c>. Each entry matches the <c>Name</c> of an AI profile of
+    /// type agent.
+    /// </summary>
+    /// <remarks>
+    /// This list is a security boundary: an allow-listed agent is runnable by any client that clears the
+    /// server's authentication. It governs only what a client may <em>invoke</em> — the tools an agent uses
+    /// internally to do its job are its own configuration and are never filtered by
+    /// <see cref="Tools"/>, nor made directly callable by being listed here.
+    /// </remarks>
+    public IList<string> Agents { get; set; } = [];
 }

--- a/src/Primitives/CrestApps.Core.AI/Properties/AssemblyInfo.cs
+++ b/src/Primitives/CrestApps.Core.AI/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("CrestApps.Core.AI.Chat")]
+[assembly: InternalsVisibleTo("CrestApps.Core.AI.Mcp")]
 [assembly: InternalsVisibleTo("CrestApps.OrchardCore.AI")]
 [assembly: InternalsVisibleTo("CrestApps.OrchardCore.AI.Chat")]
 [assembly: InternalsVisibleTo("CrestApps.OrchardCore.AI.Chat.Core")]

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Admin/Settings/Index.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Admin/Settings/Index.razor
@@ -823,6 +823,48 @@ else
                                 }
                             </div>
                         }
+
+                        <hr />
+                        <p class="text-muted mb-2">
+                            Choose which AI agents are exposed to MCP clients as callable tools. Invoking an agent runs
+                            its whole profile, so it uses the tools, data sources, and connections that profile
+                            configures — none of which this list grants or restricts, and none of which become
+                            directly callable by being used.
+                        </p>
+                        <div class="alert alert-warning py-2">
+                            <i class="fa-solid fa-triangle-exclamation"></i>
+                            An exposed agent can be run by any client that passes this server's authentication. Add
+                            agents that hold privileged tools or credentials deliberately.
+                        </div>
+                        <div class="form-check form-switch mb-3">
+                            <InputCheckbox id="mcpExposeAllAgents" @bind-Value="_model.McpServerExposeAllAgents" class="form-check-input" />
+                            <label for="mcpExposeAllAgents" class="form-check-label">Expose all agents</label>
+                        </div>
+                        @if (!_model.McpServerExposeAllAgents)
+                        {
+                            <div class="mb-3">
+                                <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-user-astronaut"></i> Exposed agents</h6>
+                                @if (_model.McpServerAvailableAgents.Count == 0)
+                                {
+                                    <div class="alert alert-info mb-0">
+                                        <i class="fa-solid fa-circle-info"></i> No AI agents with a description are available. An agent needs a description before it can be exposed, because that is all an MCP client has to go on.
+                                    </div>
+                                }
+                                else
+                                {
+                                    @foreach (var agent in _model.McpServerAvailableAgents)
+                                    {
+                                        <div class="form-check mb-2">
+                                            <input class="form-check-input" type="checkbox" checked="@agent.IsSelected" @onchange="e => ToggleMcpServerAgent(agent.Name, (bool)e.Value)" id="mcp_agent_@agent.Name" />
+                                            <label class="form-check-label" for="mcp_agent_@agent.Name">
+                                                <strong>@agent.Name</strong>
+                                                <br /><small class="text-muted">@agent.Description</small>
+                                            </label>
+                                        </div>
+                                    }
+                                }
+                            </div>
+                        }
                     </div>
                 </div>
 
@@ -971,6 +1013,8 @@ else
             McpServerRequireAccessPermission = mcpServerSettings.RequireAccessPermission,
             McpServerExposeAllTools = mcpServerSettings.ExposeAllTools,
             McpServerSelectedToolNames = mcpServerSettings.Tools?.ToArray() ?? [],
+            McpServerExposeAllAgents = mcpServerSettings.ExposeAllAgents,
+            McpServerSelectedAgentNames = mcpServerSettings.Agents?.ToArray() ?? [],
 
             CopilotAuthenticationType = copilotSettings.AuthenticationType,
             CopilotClientId = copilotSettings.ClientId,
@@ -1066,6 +1110,19 @@ else
             .ThenBy(tool => tool.Title, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
+        var selectedAgentNames = new HashSet<string>(_model.McpServerSelectedAgentNames ?? [], StringComparer.OrdinalIgnoreCase);
+
+        _model.McpServerAvailableAgents = (await ProfileManager.GetAsync(AIProfileType.Agent))
+            .Where(agent => !string.IsNullOrWhiteSpace(agent.Name) && !string.IsNullOrWhiteSpace(agent.Description))
+            .OrderBy(agent => agent.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(agent => new McpServerAgentSelectionItem
+            {
+                Name = agent.Name,
+                Description = agent.Description,
+                IsSelected = selectedAgentNames.Contains(agent.Name),
+            })
+            .ToList();
+
         _model.McpServerAvailableToolInstances = (await ToolInstanceCatalog.GetAllAsync())
             .Where(instance => !string.IsNullOrWhiteSpace(instance.Name))
             .OrderBy(instance => instance.Name, StringComparer.OrdinalIgnoreCase)
@@ -1119,6 +1176,26 @@ else
         {
             instance.IsSelected = value;
         }
+    }
+
+    private void ToggleMcpServerAgent(string name, bool value)
+    {
+        var agent = _model.McpServerAvailableAgents.FirstOrDefault(item => item.Name == name);
+
+        if (agent is not null)
+        {
+            agent.IsSelected = value;
+        }
+    }
+
+    private string[] GetSelectedMcpServerAgentNames()
+    {
+        return _model.McpServerAvailableAgents
+            .Where(agent => agent.IsSelected)
+            .Select(agent => agent.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private void SelectAllMcpServerTools()
@@ -1207,6 +1284,7 @@ else
     {
         _errors.Clear();
         _model.McpServerSelectedToolNames = GetSelectedMcpServerToolNames();
+        _model.McpServerSelectedAgentNames = GetSelectedMcpServerAgentNames();
 
         if (_model.MaximumIterationsPerRequest < 1)
         {
@@ -1392,6 +1470,10 @@ else
             Tools = _model.McpServerExposeAllTools
                 ? []
                 : _model.McpServerSelectedToolNames.ToList(),
+            ExposeAllAgents = _model.McpServerExposeAllAgents,
+            Agents = _model.McpServerExposeAllAgents
+                ? []
+                : _model.McpServerSelectedAgentNames.ToList(),
         });
 
         SiteSettings.Set(new MemoryMetadata

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/SettingsViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/SettingsViewModel.cs
@@ -59,6 +59,12 @@ public sealed class SettingsViewModel
 
     public List<McpServerToolInstanceSelectionItem> McpServerAvailableToolInstances { get; set; } = [];
 
+    public bool McpServerExposeAllAgents { get; set; }
+
+    public string[] McpServerSelectedAgentNames { get; set; } = [];
+
+    public List<McpServerAgentSelectionItem> McpServerAvailableAgents { get; set; } = [];
+
     // Default deployment settings.
     public string DefaultChatDeploymentName { get; set; }
 
@@ -183,6 +189,15 @@ public sealed class McpServerToolSelectionItem
     public string Description { get; set; }
 
     public string Category { get; set; }
+
+    public bool IsSelected { get; set; }
+}
+
+public sealed class McpServerAgentSelectionItem
+{
+    public string Name { get; set; }
+
+    public string Description { get; set; }
 
     public bool IsSelected { get; set; }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Controllers/SettingsController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Controllers/SettingsController.cs
@@ -131,6 +131,8 @@ public sealed class SettingsController : Controller
             McpServerRequireAccessPermission = mcpServerSettings.RequireAccessPermission,
             McpServerExposeAllTools = mcpServerSettings.ExposeAllTools,
             McpServerSelectedToolNames = mcpServerSettings.Tools?.ToArray() ?? [],
+            McpServerExposeAllAgents = mcpServerSettings.ExposeAllAgents,
+            McpServerSelectedAgentNames = mcpServerSettings.Agents?.ToArray() ?? [],
             CopilotAuthenticationType = copilotSettings.AuthenticationType,
             CopilotClientId = copilotSettings.ClientId,
             CopilotHasSecret = !string.IsNullOrWhiteSpace(copilotSettings.ProtectedClientSecret),
@@ -382,6 +384,14 @@ public sealed class SettingsController : Controller
                     .Select(name => name.Trim())
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList(),
+            ExposeAllAgents = model.McpServerExposeAllAgents,
+            Agents = model.McpServerExposeAllAgents
+                ? []
+                : (model.McpServerSelectedAgentNames ?? [])
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+                    .Select(name => name.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
         });
 
         _siteSettings.Set(new MemoryMetadata
@@ -558,6 +568,21 @@ public sealed class SettingsController : Controller
                 Description = instance.Description,
                 Source = instance.Source,
                 IsSelected = selectedNames.Contains(instance.Name),
+            })
+            .ToList();
+
+        var selectedAgentNames = new HashSet<string>(model.McpServerSelectedAgentNames ?? [], StringComparer.OrdinalIgnoreCase);
+
+        // An agent without a description is skipped: the description is all an MCP client has to tell one
+        // agent from another, so exposing an undescribed one only adds noise.
+        model.McpServerAvailableAgents = (await _profileManager.GetAsync(AIProfileType.Agent))
+            .Where(agent => !string.IsNullOrWhiteSpace(agent.Name) && !string.IsNullOrWhiteSpace(agent.Description))
+            .OrderBy(agent => agent.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(agent => new McpServerAgentSelectionItem
+            {
+                Name = agent.Name,
+                Description = agent.Description,
+                IsSelected = selectedAgentNames.Contains(agent.Name),
             })
             .ToList();
     }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/ViewModels/SettingsViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/ViewModels/SettingsViewModel.cs
@@ -66,6 +66,21 @@ public sealed class SettingsViewModel
     [BindNever]
     public List<McpServerToolInstanceSelectionItem> McpServerAvailableToolInstances { get; set; } = [];
 
+    /// <summary>
+    /// Gets or sets a value indicating whether every agent is exposed to MCP clients.
+    /// </summary>
+    public bool McpServerExposeAllAgents { get; set; }
+
+    /// <summary>
+    /// Gets or sets the names of the agents exposed to MCP clients.
+    /// </summary>
+    public string[] McpServerSelectedAgentNames { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the agents available to expose to MCP clients.
+    /// </summary>
+    public List<McpServerAgentSelectionItem> McpServerAvailableAgents { get; set; } = [];
+
     // Default deployment settings.
     public string DefaultChatDeploymentName { get; set; }
 
@@ -216,6 +231,27 @@ public sealed class McpServerToolSelectionItem
 
     public string Category { get; set; }
 
+    public bool IsSelected { get; set; }
+}
+
+/// <summary>
+/// An AI agent that may be exposed to MCP clients as a callable tool.
+/// </summary>
+public sealed class McpServerAgentSelectionItem
+{
+    /// <summary>
+    /// Gets or sets the agent name, which is also the tool name MCP clients see.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the agent description shown to MCP clients.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this agent is exposed.
+    /// </summary>
     public bool IsSelected { get; set; }
 }
 

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Views/Settings/Index.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Admin/Views/Settings/Index.cshtml
@@ -726,6 +726,46 @@
                             }
                         }
                     </div>
+                    <hr />
+                    <p class="text-muted mb-2">
+                        Choose which AI agents are exposed to MCP clients as callable tools. Invoking an agent runs
+                        its whole profile, so it uses the tools, data sources, and connections that profile
+                        configures &mdash; none of which this list grants or restricts, and none of which become
+                        directly callable by being used.
+                    </p>
+                    <div class="alert alert-warning py-2">
+                        <i class="fa-solid fa-triangle-exclamation"></i>
+                        An exposed agent can be run by any client that passes this server's authentication. Add
+                        agents that hold privileged tools or credentials deliberately.
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                        <input asp-for="McpServerExposeAllAgents" class="form-check-input" type="checkbox" />
+                        <label asp-for="McpServerExposeAllAgents" class="form-check-label">Expose all agents</label>
+                    </div>
+                    <div class="mb-3 @(Model.McpServerExposeAllAgents ? "d-none" : null)" data-mcp-exposed-agents-picker="true">
+                        <h6 class="mb-2 border-bottom pb-2"><i class="fa-solid fa-user-astronaut"></i> Exposed agents</h6>
+                        @if (Model.McpServerAvailableAgents.Count == 0)
+                        {
+                            <div class="alert alert-info mb-0">
+                                <i class="fa-solid fa-circle-info"></i> No AI agents with a description are available. An agent needs a description before it can be exposed, because that is all an MCP client has to go on.
+                            </div>
+                        }
+                        else
+                        {
+                            @foreach (var agent in Model.McpServerAvailableAgents)
+                            {
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" name="McpServerSelectedAgentNames" value="@agent.Name" id="mcp_agent_@agent.Name" @(agent.IsSelected ? "checked" : null) />
+                                    <label class="form-check-label" for="mcp_agent_@agent.Name">
+                                        <strong>@agent.Name</strong>
+                                        <br />
+
+                                        <small class="text-muted">@agent.Description</small>
+                                    </label>
+                                </div>
+                            }
+                        }
+                    </div>
                 </div>
             </div>
 
@@ -1044,6 +1084,18 @@
 
         exposeAllTools.addEventListener('change', updateExposedToolsVisibility);
         updateExposedToolsVisibility();
+
+        const exposeAllAgents = document.getElementById('@Html.IdFor(m => m.McpServerExposeAllAgents)');
+        const exposedAgentsPicker = document.querySelector('[data-mcp-exposed-agents-picker="true"]');
+
+        if (exposeAllAgents && exposedAgentsPicker) {
+            const updateExposedAgentsVisibility = function () {
+                exposedAgentsPicker.classList.toggle('d-none', exposeAllAgents.checked);
+            };
+
+            exposeAllAgents.addEventListener('change', updateExposedAgentsVisibility);
+            updateExposedAgentsVisibility();
+        }
 
         if (selectAllTools) {
             selectAllTools.addEventListener('click', function () {

--- a/tests/CrestApps.Core.Tests/Core/Mcp/McpServerBuilderExtensionsTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Mcp/McpServerBuilderExtensionsTests.cs
@@ -1,5 +1,11 @@
 using System.Text.Json;
+using CrestApps.Core.AI.Clients;
+using CrestApps.Core.AI.Completions;
+using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Mcp;
+using CrestApps.Core.AI.Models;
+using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.AI.Profiles;
 using CrestApps.Core.AI.Mcp.Services;
 using CrestApps.Core.AI.Tooling;
 using CrestApps.Core.Services;
@@ -234,7 +240,7 @@ public sealed class McpServerBuilderExtensionsTests
             await InvokeCallToolHandlerAsync(
                 serviceProvider,
                 "search",
-                TestContext.Current.CancellationToken));
+                cancellationToken: TestContext.Current.CancellationToken));
     }
 
     /// <summary>
@@ -252,7 +258,7 @@ public sealed class McpServerBuilderExtensionsTests
         var result = await InvokeCallToolHandlerAsync(
             serviceProvider,
             "search",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }
@@ -274,7 +280,7 @@ public sealed class McpServerBuilderExtensionsTests
         var result = await InvokeCallToolHandlerAsync(
             serviceProvider,
             "search",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }
@@ -290,7 +296,7 @@ public sealed class McpServerBuilderExtensionsTests
         var result = await InvokeCallToolHandlerAsync(
             serviceProvider,
             "search",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }
@@ -318,7 +324,7 @@ public sealed class McpServerBuilderExtensionsTests
         var result = await InvokeCallToolHandlerAsync(
             serviceProvider,
             "crestapps-docs",
-            TestContext.Current.CancellationToken);
+            cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }
@@ -347,7 +353,7 @@ public sealed class McpServerBuilderExtensionsTests
             await InvokeCallToolHandlerAsync(
                 serviceProvider,
                 "crestapps-docs",
-                TestContext.Current.CancellationToken));
+                cancellationToken: TestContext.Current.CancellationToken));
     }
 
     /// <summary>
@@ -367,7 +373,398 @@ public sealed class McpServerBuilderExtensionsTests
             await InvokeCallToolHandlerAsync(
                 serviceProvider,
                 "system",
-                TestContext.Current.CancellationToken));
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Verifies that agents stay hidden until explicitly allowed, so adding the feature never widens an
+    /// existing server's surface on upgrade.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_DefaultDeny_DoesNotExposeAgents()
+    {
+        var services = CreateServices();
+
+        AddAgents(services, CreateAgent("researcher"), CreateAgent("summarizer"));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.Tools);
+    }
+
+    /// <summary>
+    /// Verifies that turning on every tool does NOT turn on every agent. An agent runs a whole profile with
+    /// its own tools and credentials, so a server that had opted into exposing tools must not start exposing
+    /// agents the moment this feature ships.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_ExposeAllTools_DoesNotExposeAgents()
+    {
+        var services = CreateServices(configureOptions: options => options.ExposeAllTools = true);
+
+        AddLocalTool(services, "search-key", new TestAIFunction("search"));
+        AddAgents(services, CreateAgent("researcher"));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["search"], result.Tools.Select(tool => tool.Name));
+    }
+
+    /// <summary>
+    /// Verifies that an allow-listed agent is exposed as a tool carrying the agent's own description and the
+    /// prompt schema, so a client calls it the way the orchestrator does.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_AgentAllowList_ExposesOnlyNamedAgents()
+    {
+        var services = CreateServices(configureOptions: options => options.Agents = ["researcher"]);
+
+        AddAgents(services, CreateAgent("researcher"), CreateAgent("summarizer"));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var tool = Assert.Single(result.Tools);
+
+        Assert.Equal("researcher", tool.Name);
+        Assert.Equal("The researcher agent.", tool.Description);
+        Assert.True(tool.InputSchema.TryGetProperty("properties", out var properties));
+        Assert.True(properties.TryGetProperty("prompt", out _));
+    }
+
+    /// <summary>
+    /// Verifies that <c>ExposeAllAgents</c> lists every agent, and that an agent missing a description is
+    /// skipped because a client would have no way to tell what it is for.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_ExposeAllAgents_ListsEveryDescribedAgent()
+    {
+        var services = CreateServices(configureOptions: options => options.ExposeAllAgents = true);
+
+        AddAgents(
+            services,
+            CreateAgent("researcher"),
+            CreateAgent("summarizer"),
+            new AIProfile { ItemId = "3", Name = "undescribed", Type = AIProfileType.Agent });
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["researcher", "summarizer"], result.Tools.Select(tool => tool.Name));
+    }
+
+    /// <summary>
+    /// Verifies that an agent sharing a name with an exposed tool is dropped from the listing, so the listed
+    /// name matches what the call handler — which resolves tools first — will actually invoke.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_AgentNameCollidingWithTool_KeepsTheTool()
+    {
+        var services = CreateServices(configureOptions: options =>
+        {
+            options.ExposeAllTools = true;
+            options.ExposeAllAgents = true;
+        });
+
+        AddLocalTool(services, "researcher-key", new TestAIFunction("researcher", "The registered tool."));
+        AddAgents(services, CreateAgent("researcher"));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var tool = Assert.Single(result.Tools);
+
+        Assert.Equal("researcher", tool.Name);
+        Assert.Equal("The registered tool.", tool.Description);
+    }
+
+    /// <summary>
+    /// Verifies that availability is irrelevant to MCP exposure. <c>AlwaysAvailable</c> versus
+    /// <c>OnDemand</c> governs a completion's token budget, not who may reach an agent from outside, so the
+    /// allow-list stays the only gate.
+    /// </summary>
+    [Fact]
+    public async Task ListToolsHandler_AgentAvailability_DoesNotAffectExposure()
+    {
+        var onDemand = CreateAgent("on-demand");
+        var alwaysAvailable = CreateAgent("always-available");
+        alwaysAvailable.Put(new AgentMetadata { Availability = AgentAvailability.AlwaysAvailable });
+
+        var services = CreateServices(configureOptions: options => options.Agents = ["on-demand"]);
+
+        AddAgents(services, onDemand, alwaysAvailable);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["on-demand"], result.Tools.Select(tool => tool.Name));
+    }
+
+    /// <summary>
+    /// Verifies that an agent that was never allow-listed cannot be invoked by name, so the listing is the
+    /// real boundary rather than merely a discovery hint.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_UnlistedAgent_Throws()
+    {
+        var services = CreateServices();
+
+        AddAgents(services, CreateAgent("researcher"));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await InvokeCallToolHandlerAsync(
+                serviceProvider,
+                "researcher",
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Verifies that the call handler establishes an AI invocation scope. Without one, an agent reached over
+    /// MCP silently runs with its tools disabled, because the proxy treats an untrackable recursion depth as
+    /// unsafe — a wrong answer rather than an error.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_EstablishesAnInvocationScope()
+    {
+        var services = CreateServices(configureOptions: options => options.ExposeAllTools = true);
+        var probe = new ScopeProbeFunction("probe");
+
+        AddLocalTool(services, "probe-key", probe);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.Null(AIInvocationScope.Current);
+
+        await InvokeCallToolHandlerAsync(
+            serviceProvider,
+            "probe",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(probe.SawScope);
+
+        // The scope is the call's own; it must not leak into whatever runs next on this flow.
+        Assert.Null(AIInvocationScope.Current);
+    }
+
+    /// <summary>
+    /// Verifies that the scope an MCP call establishes starts at depth zero, which is what lets an agent run
+    /// its own configured tools rather than falling back to the tool-less path.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_InvocationScopeStartsAtTopLevelDepth()
+    {
+        var services = CreateServices(configureOptions: options => options.ExposeAllTools = true);
+        var probe = new ScopeProbeFunction("probe");
+
+        AddLocalTool(services, "probe-key", probe);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        await InvokeCallToolHandlerAsync(
+            serviceProvider,
+            "probe",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, probe.ObservedAgentDepth);
+    }
+
+    /// <summary>
+    /// Verifies the central contract of exposing an agent: the allow-list decides what a client may INVOKE,
+    /// never what an agent uses internally. An allow-listed agent runs through the orchestrator with its own
+    /// configured tools even though none of those tools is exposed over MCP — and those tools stay
+    /// unreachable by name, so exposing the agent never exposes its internals.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_AllowedAgent_RunsItsOwnToolsWithoutExposingThem()
+    {
+        var agent = CreateAgent("researcher");
+        agent.Put(new AgentMetadata { AllowToolInvocation = true });
+
+        // Only the agent is allow-listed. The tool below stands in for one the agent uses internally.
+        var services = CreateServices(configureOptions: options => options.Agents = ["researcher"]);
+        var orchestrator = new RecordingOrchestrator("The agent used its own tools.");
+
+        AddLocalTool(services, "internal-key", new TestAIFunction("internal-tool"));
+        AddAgents(services, agent);
+        AddOrchestration(services, orchestrator);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        // The agent is listed; the tool it uses internally is not.
+        var listed = await InvokeListToolsHandlerAsync(
+            serviceProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(["researcher"], listed.Tools.Select(tool => tool.Name));
+
+        var result = await InvokeCallToolHandlerAsync(
+            serviceProvider,
+            "researcher",
+            AgentPrompt("Find the latest figures."),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Reaching the orchestrator at all is the proof: the tool-less path never builds an orchestration
+        // context, so the agent ran with its profile's tools enabled.
+        Assert.True(orchestrator.WasExecuted);
+        Assert.Contains("The agent used its own tools.", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+
+        // The internal tool remains unreachable by name, which is the whole point of exposing the agent
+        // instead of the tools it happens to use.
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await InvokeCallToolHandlerAsync(
+                serviceProvider,
+                "internal-tool",
+                cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Verifies that an agent which has not opted into tool invocation still runs, taking the tool-less path
+    /// rather than the orchestrator. Exposure over MCP does not silently grant an agent more than its own
+    /// profile allows.
+    /// </summary>
+    [Fact]
+    public async Task CallToolHandler_AgentWithoutToolInvocation_DoesNotRunTheOrchestrator()
+    {
+        var services = CreateServices(configureOptions: options => options.Agents = ["researcher"]);
+        var orchestrator = new RecordingOrchestrator("Should not run.");
+
+        // No AgentMetadata at all, so AllowToolInvocation is false.
+        AddAgents(services, CreateAgent("researcher"));
+        AddOrchestration(services, orchestrator);
+        var completionService = AddToollessCompletion(services, "The agent answered without tools.");
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var result = await InvokeCallToolHandlerAsync(
+            serviceProvider,
+            "researcher",
+            AgentPrompt("Find the latest figures."),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(orchestrator.WasExecuted);
+        Assert.Contains("The agent answered without tools.", Assert.IsType<TextContentBlock>(Assert.Single(result.Content)).Text);
+
+        // The tool-less path disables tools on the agent's own context, which is what "did not opt in" means.
+        Assert.True(completionService.LastContext?.DisableTools);
+    }
+
+    /// <summary>
+    /// Registers the services the tool-less agent path needs, and returns the recording completion service.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="response">The assistant text the completion returns.</param>
+    /// <returns>The recording completion service.</returns>
+    private static RecordingCompletionService AddToollessCompletion(IServiceCollection services, string response)
+    {
+        var completionService = new RecordingCompletionService(response);
+
+        var contextBuilder = new Mock<IAICompletionContextBuilder>();
+        contextBuilder
+            .Setup(value => value.BuildAsync(It.IsAny<object>(), It.IsAny<Action<AICompletionContext>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AICompletionContext());
+
+        var deploymentManager = new Mock<IAIDeploymentManager>();
+        deploymentManager
+            .Setup(value => value.ResolveSlotAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AIDeployment { ItemId = "deployment", Name = "chat" });
+
+        services.AddSingleton<IAICompletionService>(completionService);
+        services.AddSingleton(contextBuilder.Object);
+        services.AddSingleton(deploymentManager.Object);
+
+        return completionService;
+    }
+
+    /// <summary>
+    /// Registers the orchestration services an agent needs to run with its own tools.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="orchestrator">The orchestrator to resolve.</param>
+    private static void AddOrchestration(IServiceCollection services, RecordingOrchestrator orchestrator)
+    {
+        var contextBuilder = new Mock<IOrchestrationContextBuilder>();
+        contextBuilder
+            .Setup(value => value.BuildAsync(It.IsAny<object>(), It.IsAny<Action<OrchestrationContext>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OrchestrationContext());
+
+        var resolver = new Mock<IOrchestratorResolver>();
+        resolver
+            .Setup(value => value.Resolve(It.IsAny<string>()))
+            .Returns(orchestrator);
+
+        services.AddSingleton(contextBuilder.Object);
+        services.AddSingleton(resolver.Object);
+    }
+
+    /// <summary>
+    /// Builds the argument dictionary an agent expects.
+    /// </summary>
+    /// <param name="prompt">The prompt to send to the agent.</param>
+    /// <returns>The call arguments.</returns>
+    private static Dictionary<string, JsonElement> AgentPrompt(string prompt)
+    {
+        return new Dictionary<string, JsonElement>
+        {
+            ["prompt"] = JsonSerializer.SerializeToElement(prompt),
+        };
+    }
+
+    /// <summary>
+    /// Creates an agent profile with a description, which exposure requires.
+    /// </summary>
+    /// <param name="name">The agent name.</param>
+    /// <returns>The agent profile.</returns>
+    private static AIProfile CreateAgent(string name)
+    {
+        return new AIProfile
+        {
+            ItemId = name,
+            Name = name,
+            Description = $"The {name} agent.",
+            Type = AIProfileType.Agent,
+        };
+    }
+
+    /// <summary>
+    /// Registers a fake profile manager returning the supplied agents.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="agents">The agent profiles to return.</param>
+    private static void AddAgents(IServiceCollection services, params AIProfile[] agents)
+    {
+        var manager = new Mock<IAIProfileManager>();
+        manager
+            .Setup(value => value.GetAsync(AIProfileType.Agent, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agents);
+
+        services.AddSingleton(manager.Object);
     }
 
     /// <summary>
@@ -381,6 +778,7 @@ public sealed class McpServerBuilderExtensionsTests
         var services = new ServiceCollection();
         var builder = services.AddMcpServer();
 
+        services.AddLogging();
         services.AddOptions<AIToolDefinitionOptions>();
         services.AddOptions<ServerToolOptions>();
 
@@ -504,11 +902,13 @@ public sealed class McpServerBuilderExtensionsTests
     /// </summary>
     /// <param name="serviceProvider">The provider containing the registered handler.</param>
     /// <param name="toolName">The name of the tool to invoke.</param>
+    /// <param name="arguments">The arguments supplied with the call.</param>
     /// <param name="cancellationToken">The cancellation token passed to the handler.</param>
     /// <returns>The call-tool result.</returns>
     private static async ValueTask<CallToolResult> InvokeCallToolHandlerAsync(
         IServiceProvider serviceProvider,
         string toolName,
+        IDictionary<string, JsonElement> arguments = null,
         CancellationToken cancellationToken = default)
     {
         var options = serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value;
@@ -528,12 +928,118 @@ public sealed class McpServerBuilderExtensionsTests
             new CallToolRequestParams
             {
                 Name = toolName,
+                Arguments = arguments,
             })
         {
             Services = serviceProvider,
         };
 
         return await handler(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// A completion service that records the context it was given and returns a fixed assistant reply.
+    /// </summary>
+    private sealed class RecordingCompletionService : IAICompletionService
+    {
+        private readonly string _response;
+
+        public RecordingCompletionService(string response)
+        {
+            _response = response;
+        }
+
+        public AICompletionContext LastContext { get; private set; }
+
+        public Task<ChatResponse> CompleteAsync(
+            AIDeployment deployment,
+            IEnumerable<ChatMessage> messages,
+            AICompletionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            LastContext = context;
+
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, _response)));
+        }
+
+        public IAsyncEnumerable<ChatResponseUpdate> CompleteStreamingAsync(
+            AIDeployment deployment,
+            IEnumerable<ChatMessage> messages,
+            AICompletionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    /// <summary>
+    /// An orchestrator that records whether it ran and streams a fixed response.
+    /// </summary>
+    private sealed class RecordingOrchestrator : IOrchestrator
+    {
+        private readonly string _response;
+
+        public RecordingOrchestrator(string response)
+        {
+            _response = response;
+        }
+
+        public bool WasExecuted { get; private set; }
+
+        public string Name => "recording";
+
+        public async IAsyncEnumerable<ChatResponseUpdate> ExecuteStreamingAsync(
+            OrchestrationContext context,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+
+            WasExecuted = true;
+
+            yield return new ChatResponseUpdate(ChatRole.Assistant, _response);
+        }
+    }
+
+    /// <summary>
+    /// A tool that records the ambient invocation scope it observed while running.
+    /// </summary>
+    private sealed class ScopeProbeFunction : AIFunction
+    {
+        private static readonly JsonElement _schema = JsonSerializer.Deserialize<JsonElement>(
+        """
+        {
+          "type": "object"
+        }
+        """);
+
+        private readonly string _name;
+
+        public ScopeProbeFunction(string name)
+        {
+            _name = name;
+        }
+
+        public bool SawScope { get; private set; }
+
+        public int? ObservedAgentDepth { get; private set; }
+
+        public override string Name => _name;
+
+        public override string Description => "Records the ambient invocation scope.";
+
+        public override JsonElement JsonSchema => _schema;
+
+        protected override ValueTask<object> InvokeCoreAsync(
+            AIFunctionArguments arguments,
+            CancellationToken cancellationToken)
+        {
+            var context = AIInvocationScope.Current;
+
+            SawScope = context is not null;
+            ObservedAgentDepth = context?.AgentInvocationDepth;
+
+            return ValueTask.FromResult<object>(string.Empty);
+        }
     }
 
     private sealed class TestToolInstanceSource : IAIToolInstanceSource


### PR DESCRIPTION
## What

An **AI agent can now be exposed to MCP clients as a callable tool**, alongside plain tools and tool instances. The client sees one tool per allow-listed agent — named after the agent, described by its description, taking the single `prompt` argument `AgentProxyTool` already presents to the model. Invoking it runs that agent.

Agents previously reached the model only through `AgentToolRegistryProvider`, which is completion-scoped: it takes an `AICompletionContext` and reads `AgentNames` and the recursion depth off it. The MCP server enumerates code tools and tool instances directly and never consults `IToolRegistryProvider`, so agents were structurally invisible to it — a site could publish its tools but not the curated agents built on them.

```csharp
services.Configure<McpServerOptions>(options =>
{
    options.Agents = ["researcher", "report-writer"];
    // or: options.ExposeAllAgents = true;
});
```

Both settings are editable from **Settings → MCP server** in each host.

## Two decisions worth reviewing

**1. Agents get their own switch, not `ExposeAllTools`.** An agent runs a whole profile — system message, tools, data sources, and the credentials behind them. Folding agents into the existing switch would mean any server already running with `ExposeAllTools = true` silently began exposing every agent the moment it upgraded. Separate namespaces matter too: one shared list would let an agent be exposed because a tool happened to share its name. There's a test pinning that `ExposeAllTools` alone exposes no agents.

**2. An agent's own tools are NOT filtered by the tool allow-list.** The two lists answer different questions:

| | Question it answers |
|---|---|
| `Tools` / `ExposeAllTools` | What may a client **directly name and invoke**? |
| The agent's own profile | What does the agent use **internally**? |

Intersecting them would be backwards: an operator wanting a working agent would have to allow-list every tool it uses internally, and each of those would then become directly callable — forcing *more* exposure, and defeating the point of publishing a curated agent instead of raw tools. Encapsulation: exposing an agent exposes a function signature, not its implementation.

`CallToolHandler_AllowedAgent_RunsItsOwnToolsWithoutExposingThem` pins both halves — the agent runs through the orchestrator with its own tools, and the tool it uses internally stays unreachable by name.

## Bug fixed along the way

**The call handler ran tools with no AI invocation scope.** `AgentProxyTool.ShouldRunWithTools` treats an untrackable recursion depth as unsafe:

```csharp
var depth = AIInvocationScope.Current?.AgentInvocationDepth;
return depth is >= 0 and < MaxAgentToolInvocationDepth;
```

`AIInvocationScope.Current` is null outside a completion, so an agent invoked over MCP would have silently run with `DisableTools = true` — a plausible-looking wrong answer, not an error. It also affected the data source search tool merged in #177, whose citation collector reads the same scope and was falling back to local reference numbering instead of registering `ToolReferences`.

Beginning a scope in the call handler places an agent at top-level depth, where its own tools run if its profile sets `AllowToolInvocation` — exactly as when the model invokes it as a tool in a chat completion. **I verified this is really pinned**: removing the scope again fails three of the new tests, including the encapsulation one.

## Smaller behaviors, all tested

- Agents are enumerated **last**, and one whose name is already exposed is skipped with a warning — so the listed name always matches what a call will reach (the call handler resolves code tools first).
- An agent needs a **description** to be exposed; it's all a client has to tell agents apart.
- **`AgentAvailability` is ignored.** `AlwaysAvailable` vs `OnDemand` governs a completion's token budget, not who may reach an agent from outside. The allow-list is the only gate.
- An agent that hasn't set `AllowToolInvocation` still runs, via the tool-less path — exposure never grants an agent more than its own profile allows.

## Note on scope

`AgentProxyTool` is `internal`, so `CrestApps.Core.AI.Mcp` was added to `InternalsVisibleTo` — consistent with the existing entries (`CrestApps.Core.AI.Chat`, `CrestApps.Core.Mvc.Web`, …). Say the word if you'd rather have a public factory instead.

## Testing

- **11 new tests** covering default-deny, `ExposeAllTools` not leaking agents, the allow-list, `ExposeAllAgents`, name collisions, availability being ignored, unlisted agents being uncallable, scope establishment and depth, and both halves of the encapsulation contract.
- Full suite on current main: **3233 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
