### PR TITLE
Drop the in-scope setting from the data source tool instance

### DIFF
--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -624,8 +624,8 @@ microphone, desk speakers):
   own function name and description, and the model picks.
   - Each instance carries its own retrieval parameters rather than reading them off the resource:
     **data source**, **retrieval model** (`Chunk` by default, or `Hierarchical`), **retrieved documents**
-    (top N), **strictness**, **filter**, and whether answers are limited to the retrieved content. These
-    are the same parameters a chat interaction configures, applied the same way.
+    (top N), **strictness**, and **filter**. The query-time parameters are applied exactly the way a chat
+    interaction's are.
   - The model's search phrases are embedded with the **same embedding deployment the knowledge base index
     was indexed with** — `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by
     `DataSourceIndexProfileMetadata` — so the queries and the stored chunks are compared in the same vector
@@ -643,13 +643,6 @@ microphone, desk speakers):
   - `Hierarchical` retrieval collapses the matching chunks onto their source documents and returns each
     document's complete text under one citation, read back through the data source's own source handler.
     When those documents cannot be read, the search degrades to the matching chunks rather than failing.
-  - **Removed the instance's in-scope setting.** It only reworded the message a fruitless search returned,
-    which is not a policy a single tool can hold the model to — an answering constraint binds only when it
-    reaches the system prompt, which is what `AIDataSourceRagMetadata.IsInScope` does on a profile or chat
-    interaction through the orchestration handlers. A tool instance now reports the plain fact ("No relevant
-    content was found in the data source for this query.") and leaves the policy to whatever owns the turn.
-    The profile-bound `DataSourceSearchTool` is unchanged and still states its profile's policy, because
-    there the same policy is already in the system prompt for the whole turn.
   - Both editors (MVC and Blazor) gained the matching form section, and `DataSourceRetrievalMode` was
     added alongside the existing `DocumentRetrievalMode`. The two are separate because
     `DocumentRetrievalMode` lives in `CrestApps.Core.AI.Documents`, which depends on

--- a/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
+++ b/src/CrestApps.Core.Docs/docs/changelog/2.0.0.md
@@ -643,6 +643,13 @@ microphone, desk speakers):
   - `Hierarchical` retrieval collapses the matching chunks onto their source documents and returns each
     document's complete text under one citation, read back through the data source's own source handler.
     When those documents cannot be read, the search degrades to the matching chunks rather than failing.
+  - **Removed the instance's in-scope setting.** It only reworded the message a fruitless search returned,
+    which is not a policy a single tool can hold the model to — an answering constraint binds only when it
+    reaches the system prompt, which is what `AIDataSourceRagMetadata.IsInScope` does on a profile or chat
+    interaction through the orchestration handlers. A tool instance now reports the plain fact ("No relevant
+    content was found in the data source for this query.") and leaves the policy to whatever owns the turn.
+    The profile-bound `DataSourceSearchTool` is unchanged and still states its profile's policy, because
+    there the same policy is already in the system prompt for the whole turn.
   - Both editors (MVC and Blazor) gained the matching form section, and `DataSourceRetrievalMode` was
     added alongside the existing `DocumentRetrievalMode`. The two are separate because
     `DocumentRetrievalMode` lives in `CrestApps.Core.AI.Documents`, which depends on

--- a/src/CrestApps.Core.Docs/docs/core/tool-instances.md
+++ b/src/CrestApps.Core.Docs/docs/core/tool-instances.md
@@ -518,11 +518,12 @@ Each instance binds **one** data source plus the retrieval parameters applied to
 | `TopNDocuments` | site default | The number of top-scoring results to return, between `AIDataSourceOptions.MinTopNDocuments` and `MaxTopNDocuments`. |
 | `Strictness` | site default | How relevant a result must be to survive, between `AIDataSourceOptions.MinStrictness` and `MaxStrictness`. Higher values keep only closer matches. |
 | `Filter` | *(none)* | An OData filter expression translated to the index provider's own filter syntax before the search runs. |
-| `IsInScope` | `false` | When set, a search that finds nothing tells the model the answer is unavailable rather than inviting it to fall back to general knowledge. |
 
 The model's phrases are embedded with the **same embedding deployment the knowledge base index was indexed with** — resolved from `SearchIndexProfile.EmbeddingDeploymentName`, optionally overridden by `DataSourceIndexProfileMetadata` on that profile — so the queries and the stored chunks live in the same vector space. This is the identical resolution the indexing service performs, which is what keeps a profile indexed under the top-level embedding deployment queryable.
 
 Results are returned with `[doc:N]` citations, one index per source document, and each citation is registered on the active invocation context so a host can render it as a link.
+
+A search that finds nothing reports exactly that — *"No relevant content was found in the data source for this query."* — and stops there. It does not tell the model whether it may answer from general knowledge, because a single tool has no way to hold it to that: an answering policy only binds when it reaches the system prompt, which is why `AIDataSourceRagMetadata.IsInScope` lives on the profile or chat interaction and is applied by the orchestration handlers across the whole turn. A tool instance states the fact and leaves the policy to whatever owns the turn.
 
 ### Searching several phrases at once
 

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrieval.cs
@@ -157,9 +157,9 @@ internal static class DataSourceRetrieval
 
         if (resultSets.All(resultSet => resultSet == null || !resultSet.Any()))
         {
-            return request.IsInScope
-                ? "No relevant content was found in the data source for this query. The answer is not available in the configured data source."
-                : "No relevant content was found in the data source for this query. Answer using your general knowledge instead.";
+            return BuildEmptyResultMessage(
+                "No relevant content was found in the data source for this query.",
+                request.IsInScope);
         }
 
         var minimumScore = siteSettings.GetMinimumScore(request.Strictness);
@@ -167,9 +167,9 @@ internal static class DataSourceRetrieval
 
         if (selected.Count == 0)
         {
-            return request.IsInScope
-                ? "No results met the strictness and quality thresholds. The answer is not available in the configured data source."
-                : "No results met the strictness and quality thresholds. Answer using your general knowledge instead.";
+            return BuildEmptyResultMessage(
+                "No results met the strictness and quality thresholds.",
+                request.IsInScope);
         }
 
         var textNormalizer = services.GetRequiredService<IAITextNormalizer>();
@@ -198,6 +198,22 @@ internal static class DataSourceRetrieval
         builder.Append(references.Render());
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// Builds the message returned when a search finds nothing worth returning.
+    /// </summary>
+    /// <param name="reason">The plain statement of what happened.</param>
+    /// <param name="isInScope">The caller's answering policy, when it has one.</param>
+    /// <returns>The message to hand back to the AI model.</returns>
+    private static string BuildEmptyResultMessage(string reason, bool? isInScope)
+    {
+        return isInScope switch
+        {
+            true => $"{reason} The answer is not available in the configured data source.",
+            false => $"{reason} Answer using your general knowledge instead.",
+            _ => reason,
+        };
     }
 
     /// <summary>

--- a/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
+++ b/src/Primitives/CrestApps.Core.AI/Services/DataSourceRetrievalRequest.cs
@@ -39,8 +39,17 @@ internal sealed class DataSourceRetrievalRequest
     public DataSourceRetrievalMode RetrievalMode { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether the model must answer only from the retrieved content. This only
-    /// changes the guidance returned when nothing relevant is found.
+    /// Gets how an empty result should be reported to the model, when the caller is in a position to say.
+    /// <see langword="true"/> states that the answer is not available; <see langword="false"/> invites a
+    /// fall back to general knowledge; <see langword="null"/> — the default — reports only that nothing was
+    /// found.
     /// </summary>
-    public bool IsInScope { get; init; }
+    /// <remarks>
+    /// Only a caller that owns the model's whole turn can hold the model to an answering policy, because the
+    /// policy has to reach the system prompt. A single tool cannot: the model is free to ignore a sentence in
+    /// one tool result. So a caller configured per profile or interaction passes its setting through, while a
+    /// standalone tool leaves this unset and states the plain fact instead of implying a constraint it has no
+    /// way to enforce.
+    /// </remarks>
+    public bool? IsInScope { get; init; }
 }

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolFunction.cs
@@ -131,7 +131,6 @@ public sealed class DataSourceSearchToolFunction : AIFunction
                     Strictness = _settings.Strictness,
                     Filter = _settings.Filter,
                     RetrievalMode = _settings.RetrievalMode,
-                    IsInScope = _settings.IsInScope,
                 },
                 _name,
                 logger,

--- a/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolSettings.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tooling/Instances/DataSources/DataSourceSearchToolSettings.cs
@@ -38,10 +38,4 @@ public sealed class DataSourceSearchToolSettings
     /// It is translated to the index provider's own filter syntax before the search runs.
     /// </summary>
     public string Filter { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the model must answer only from the retrieved content.
-    /// When <see langword="false"/> (the default), the model may fall back to its general knowledge.
-    /// </summary>
-    public bool IsInScope { get; set; }
 }

--- a/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
+++ b/src/Primitives/CrestApps.Core.AI/Tools/DataSourceSearchTool.cs
@@ -104,6 +104,9 @@ public sealed class DataSourceSearchTool : AIFunction
                     TopNDocuments = ragMetadata?.TopNDocuments,
                     Strictness = ragMetadata?.Strictness,
                     Filter = ragMetadata?.Filter,
+
+                    // A profile always states a policy, even when it has no RAG metadata, because the
+                    // orchestration handlers put that same policy in the system prompt for the whole turn.
                     IsInScope = ragMetadata?.IsInScope == true,
                 },
                 Name,

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Create.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Create.razor
@@ -405,12 +405,6 @@
                 <InputText @bind-Value="_model.DataSourceFilter" class="form-control font-monospace" placeholder="filters/status eq 'published'" />
                 <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
             </div>
-
-            <div class="form-check mb-3">
-                <InputCheckbox @bind-Value="_model.DataSourceIsInScope" class="form-check-input" />
-                <label class="form-check-label">Limit answers to the retrieved content</label>
-                <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
-            </div>
         }
 
         <ToolInstanceParameterEditor Source="@_model.Source"
@@ -820,7 +814,6 @@
                 TopNDocuments = model.DataSourceTopNDocuments,
                 Strictness = model.DataSourceStrictness,
                 Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
-                IsInScope = model.DataSourceIsInScope,
             });
 
             return;

--- a/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Edit.razor
+++ b/src/Startup/CrestApps.Core.Blazor.Web/Components/Pages/Tooling/ToolInstances/Edit.razor
@@ -427,12 +427,6 @@ else
                     <InputText @bind-Value="_model.DataSourceFilter" class="form-control font-monospace" placeholder="filters/status eq 'published'" />
                     <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
                 </div>
-
-                <div class="form-check mb-3">
-                    <InputCheckbox @bind-Value="_model.DataSourceIsInScope" class="form-check-input" />
-                    <label class="form-check-label">Limit answers to the retrieved content</label>
-                    <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
-                </div>
             }
 
             <ToolInstanceParameterEditor Source="@_model.Source"
@@ -820,7 +814,6 @@ else
                 TopNDocuments = model.DataSourceTopNDocuments,
                 Strictness = model.DataSourceStrictness,
                 Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
-                IsInScope = model.DataSourceIsInScope,
             });
 
             return;
@@ -955,7 +948,6 @@ else
             model.DataSourceTopNDocuments = dataSourceSettings.TopNDocuments;
             model.DataSourceStrictness = dataSourceSettings.Strictness;
             model.DataSourceFilter = dataSourceSettings.Filter;
-            model.DataSourceIsInScope = dataSourceSettings.IsInScope;
         }
 
         return model;

--- a/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIToolInstanceViewModel.cs
+++ b/src/Startup/CrestApps.Core.Blazor.Web/ViewModels/AIToolInstanceViewModel.cs
@@ -283,9 +283,4 @@ public sealed class AIToolInstanceViewModel
     /// </summary>
     public string DataSourceFilter { get; set; }
 
-    /// <summary>
-    /// Gets or sets a value indicating whether the data source search source instructs the model to answer
-    /// only from the retrieved content.
-    /// </summary>
-    public bool DataSourceIsInScope { get; set; }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Controllers/AIToolInstanceController.cs
@@ -636,7 +636,6 @@ public sealed class AIToolInstanceController : Controller
                 TopNDocuments = model.DataSourceTopNDocuments,
                 Strictness = model.DataSourceStrictness,
                 Filter = string.IsNullOrWhiteSpace(model.DataSourceFilter) ? null : model.DataSourceFilter.Trim(),
-                IsInScope = model.DataSourceIsInScope,
             });
 
             return;
@@ -809,7 +808,6 @@ public sealed class AIToolInstanceController : Controller
             model.DataSourceTopNDocuments = dataSourceSettings.TopNDocuments;
             model.DataSourceStrictness = dataSourceSettings.Strictness;
             model.DataSourceFilter = dataSourceSettings.Filter;
-            model.DataSourceIsInScope = dataSourceSettings.IsInScope;
         }
 
         return model;

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/ViewModels/AIToolInstanceViewModel.cs
@@ -313,10 +313,4 @@ public sealed class AIToolInstanceViewModel
     /// Gets or sets the OData filter expression applied by the data source search source.
     /// </summary>
     public string DataSourceFilter { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the data source search source instructs the model to answer
-    /// only from the retrieved content.
-    /// </summary>
-    public bool DataSourceIsInScope { get; set; }
 }

--- a/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
+++ b/src/Startup/CrestApps.Core.Mvc.Web/Areas/Tooling/Views/AIToolInstance/_Form.cshtml
@@ -375,11 +375,6 @@
                     <span asp-validation-for="DataSourceFilter" class="text-danger"></span>
                     <div class="form-text">Optional OData filter expression translated to the index provider's own syntax before the search runs.</div>
                 </div>
-                <div class="form-check mb-3">
-                    <input asp-for="DataSourceIsInScope" class="form-check-input" type="checkbox" />
-                    <label asp-for="DataSourceIsInScope" class="form-check-label">Limit answers to the retrieved content</label>
-                    <div class="form-text">When checked, the tool tells the model the answer is unavailable rather than letting it fall back to general knowledge.</div>
-                </div>
             </div>
 
             <partial name="_Parameters" model="Model" />

--- a/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
+++ b/tests/CrestApps.Core.Tests/Core/Tools/DataSourceSearchToolInstanceTests.cs
@@ -4,7 +4,10 @@ using CrestApps.Core.AI.Deployments;
 using CrestApps.Core.AI.Models;
 using CrestApps.Core.AI.Services;
 using CrestApps.Core.AI.Tooling;
+using CrestApps.Core.AI.Orchestration;
+using CrestApps.Core.AI.Profiles;
 using CrestApps.Core.AI.Tooling.Instances.DataSources;
+using CrestApps.Core.AI.Tools;
 using CrestApps.Core.Infrastructure.Indexing;
 using CrestApps.Core.Infrastructure.Indexing.DataSources;
 using CrestApps.Core.Infrastructure.Indexing.Models;
@@ -277,8 +280,8 @@ public sealed class DataSourceSearchToolInstanceTests
     }
 
     /// <summary>
-    /// Verifies that a strictness high enough to reject every match tells the model the knowledge base has
-    /// no answer instead of returning an empty block of context.
+    /// Verifies that a strictness high enough to reject every match says so, instead of returning an empty
+    /// block of context.
     /// </summary>
     [Fact]
     public async Task InvokeAsync_ReportsNoMatches_WhenStrictnessRejectsEveryResult()
@@ -299,13 +302,83 @@ public sealed class DataSourceSearchToolInstanceTests
         {
             DataSourceId = DataSourceId,
             Strictness = AIDataSourceOptions.MaxStrictness,
-            IsInScope = true,
         });
 
         var result = await InvokeAsync(function, services, "vacation policy");
 
         Assert.Contains("strictness", result, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("not available", result, StringComparison.OrdinalIgnoreCase);
+        AssertStatesTheFactWithoutDirectingTheModel(result);
+    }
+
+    /// <summary>
+    /// Verifies that a search finding nothing reports exactly that, without telling the model whether it may
+    /// answer from general knowledge. A standalone tool cannot hold the model to an answering policy — that
+    /// has to reach the system prompt — so it states the fact and leaves the decision where it belongs.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_ReportsNoResults_WithoutDirectingHowToAnswer()
+    {
+        var contentManager = new RecordingContentManager([]);
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+
+        var function = CreateFunction(new DataSourceSearchToolSettings { DataSourceId = DataSourceId });
+
+        var result = await InvokeAsync(function, services, "vacation policy");
+
+        Assert.Contains("No relevant content was found in the data source", result, StringComparison.OrdinalIgnoreCase);
+        AssertStatesTheFactWithoutDirectingTheModel(result);
+    }
+
+    /// <summary>
+    /// Verifies that the profile-bound tool still states the profile's answering policy on an empty result.
+    /// Only that tool can: the same policy reaches the system prompt through the orchestration handlers, so
+    /// repeating it in the tool result reinforces something the model is already bound by. A tool instance,
+    /// which has no such backing, would only be asserting a constraint it cannot enforce.
+    /// </summary>
+    /// <param name="isInScope">The profile's in-scope setting.</param>
+    /// <param name="expected">The guidance the empty result must carry.</param>
+    [Theory]
+    [InlineData(true, "not available in the configured data source")]
+    [InlineData(false, "Answer using your general knowledge instead")]
+    public async Task ProfileBoundTool_StillStatesTheProfilePolicy_OnEmptyResults(bool isInScope, string expected)
+    {
+        var contentManager = new RecordingContentManager([]);
+        var services = BuildServices(contentManager, new RecordingEmbeddingGenerator());
+
+        var profile = new AIProfile
+        {
+            ItemId = "profile-1",
+            Name = "grounded",
+            Type = AIProfileType.Chat,
+        };
+
+        profile.Put(new AIDataSourceRagMetadata { IsInScope = isInScope });
+
+        using var scope = AIInvocationScope.Begin();
+
+        AIInvocationScope.Current.DataSourceId = DataSourceId;
+        AIInvocationScope.Current.ToolExecutionContext = new AIToolExecutionContext(profile);
+
+        var result = await new DataSourceSearchTool().InvokeAsync(new AIFunctionArguments(new Dictionary<string, object>
+        {
+            ["query"] = "vacation policy",
+        })
+        {
+            Services = services,
+        },
+        cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Contains(expected, result?.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Asserts an empty-result message reports what happened without prescribing how the model should answer.
+    /// </summary>
+    /// <param name="result">The tool result.</param>
+    private static void AssertStatesTheFactWithoutDirectingTheModel(string result)
+    {
+        Assert.DoesNotContain("general knowledge", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("not available in the configured data source", result, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Removes `IsInScope` from `DataSourceSearchToolSettings` and both editors.

The setting only reworded the message a fruitless search returned — either *"the answer is not available in the configured data source"* or *"answer using your general knowledge instead."* Neither is something a tool can hold the model to. An answering policy binds only when it reaches the **system prompt**, which is exactly what `AIDataSourceRagMetadata.IsInScope` does on a profile or chat interaction, applied across the whole turn by `PreemptiveRagOrchestrationHandler` and `RealtimeRagGuidanceHandler`. A sentence in one tool result is a suggestion the model is free to ignore — so the instance was asserting a constraint it had no way to enforce.

A tool instance now reports the plain fact and stops:

> No relevant content was found in the data source for this query.

## The profile-bound tool is deliberately unchanged

`DataSourceSearchTool` still states its profile's policy, because there the same policy is *already* in the system prompt — the tool result reinforces something the model is genuinely bound by, rather than inventing a rule.

To carry both behaviors through the shared retrieval path, `DataSourceRetrievalRequest.IsInScope` becomes `bool?`:

| Value | Empty-result message | Passed by |
|---|---|---|
| `true` | `… The answer is not available in the configured data source.` | profile with in-scope on |
| `false` | `… Answer using your general knowledge instead.` | profile with in-scope off |
| `null` | just the fact | tool instances |

The profile tool passes a non-null value **even when a profile has no RAG metadata** (`ragMetadata?.IsInScope == true` yields `false`, not null), so its wording is unchanged in every case, including that one.

## Tests

That asymmetry is the kind of thing a later cleanup would flatten back to a plain `bool`, so both sides are pinned:

- A `[Theory]` over the profile-bound tool asserting both directive messages still appear.
- `InvokeAsync_ReportsNoResults_WithoutDirectingHowToAnswer` asserting the instance's empty result mentions **neither** "general knowledge" **nor** "not available in the configured data source".

Full suite: **3225 passed, 0 failed**. Docs and changelog updated; docs site builds clean.

## Note

Separate from [#178](https://github.com/CrestApps/CrestApps.Core/pull/178) (MCP agent exposure) — this branches off main, which already has the data source tool from #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
