### PR TITLE
Stop a failed title generation from ending a realtime session

### DIFF
--- a/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
+++ b/src/Primitives/CrestApps.Core.AI.Chat/Hubs/AIChatHubCore.cs
@@ -422,7 +422,8 @@ public class AIChatHubCore<TClient> : Hub<TClient>
     /// <summary>
     /// Generates a title for a new session. The default implementation uses AI
     /// title generation when configured on the profile, falling back to a
-    /// truncated user prompt.
+    /// truncated user prompt. A failing title generation call degrades to that
+    /// fallback rather than propagating, because the callers create the session.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <param name="profile">The profile.</param>
@@ -432,7 +433,23 @@ public class AIChatHubCore<TClient> : Hub<TClient>
         var titleUserPrompt = BuildTitleUserPrompt(profile, userPrompt);
         if (profile.TitleType == AISessionTitleType.Generated)
         {
-            var generated = await GetAIGeneratedTitleAsync(services, profile, titleUserPrompt);
+            string generated = null;
+
+            try
+            {
+                generated = await GetAIGeneratedTitleAsync(services, profile, titleUserPrompt);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A title is cosmetic, but this runs inside GetOrCreateSessionAsync, so letting a
+                // utility-deployment failure escape aborts whatever asked for the session. On the
+                // realtime path that is the entire voice conversation: StartRealtimeWebRtc receives an
+                // empty session id on the first turn, so a misconfigured utility deployment ended the
+                // session before any audio flowed, while later turns - which already carry a session id
+                // and generate their title through GenerateRealtimeSessionTitleAsync - were unaffected.
+                Logger.LogWarning(ex, "Failed to generate a session title for profile {ProfileId}. Falling back to the user prompt.", profile.ItemId);
+            }
+
             if (!string.IsNullOrEmpty(generated))
             {
                 return generated;


### PR DESCRIPTION
## Problem

Starting a voice conversation from the external chat widget failed immediately with a SignalR error — `An error occurred during the conversation. Please try again.` — while realtime worked normally from Chat Interactions and the AI session UI.

The realtime plumbing was never at fault. Server logs showed the utility deployment returning `HTTP 400 (invalid_request_error: unsupported_parameter) — 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`, thrown from title generation:

```
StartRealtimeWebRtc → GetOrCreateSessionAsync → GenerateSessionTitleAsync
  → GetAIGeneratedTitleAsync → AzureOpenAICompletionClient.CompleteAsync → 400
  → InvalidOperationException escapes the hub method → client shows the error
```

`GenerateSessionTitleAsync` is called from inside `GetOrCreateSessionAsync`, so an exception from the utility deployment aborted whatever asked for the session. On the realtime path that is the entire voice conversation.

## Why it looked like a widget-only bug

`GetOrCreateSessionAsync` only generates a title when it has to *create* a session. The external widget starts voice with an empty session id, so it always takes the create branch. Chat Interactions and the AI session UI already carry a session id, take the find-existing branch, and never generate a title there.

Later turns in the same conversation were also unaffected, because they route their title through `GenerateRealtimeSessionTitleAsync`, which already catches and logs the identical failure — with the comment *"an ungenerated title must never end a voice conversation."* That principle simply was not honored on the start path.

## Change

`GenerateSessionTitleAsync` now degrades to the truncated user prompt when AI title generation throws, and logs a warning. Applied at this altitude so every caller benefits — session creation, the text chat path, and realtime — rather than patching the realtime call site alone.

- `OperationCanceledException` still propagates, so cancellation is not swallowed.
- `ChatSessionStartRateLimitedException` is unaffected — the rate limit is evaluated before title generation in `GetOrCreateSessionAsync`.

## Note on the underlying 400

This change makes a failing utility deployment non-fatal; it does not fix the misrouted request itself. That is a deployment-configuration matter on the affected tenant: with no explicit utility deployment and no site default, the Utility slot falls through its chain to "first text-capable deployment", which can land on a reasoning-family model that rejects `max_tokens`. Setting an explicit utility deployment resolves it.

Worth noting the asymmetry that made this hard to spot: `CapabilityEnforcingChatClient` strips unsupported options on the `IChatClient` path, but `AzureOpenAICompletionClient` — which title generation uses — has no equivalent guard.

## Testing

`CrestApps.Core.AI.Chat` builds clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
