### PR TITLE
Stop user memory reads from throwing when there is no current user

### DIFF
--- a/src/Abstractions/CrestApps.Core.AI.Abstractions/Memory/IAIMemoryStore.cs
+++ b/src/Abstractions/CrestApps.Core.AI.Abstractions/Memory/IAIMemoryStore.cs
@@ -14,7 +14,7 @@ public interface IAIMemoryStore : ICatalog<AIMemoryEntry>
     /// Asynchronously counts the number of memory entries owned by the specified user.
     /// </summary>
     /// <param name="userId">The unique identifier of the user.</param>
-    /// <returns>The total number of memory entries for the user.</returns>
+    /// <returns>The total number of memory entries for the user, or <c>0</c> when <paramref name="userId"/> is <see langword="null"/> or empty.</returns>
     Task<int> CountByUserAsync(string userId);
 
     /// <summary>
@@ -22,7 +22,7 @@ public interface IAIMemoryStore : ICatalog<AIMemoryEntry>
     /// </summary>
     /// <param name="userId">The unique identifier of the user.</param>
     /// <param name="name">The unique name of the memory entry within the user scope.</param>
-    /// <returns>The matching entry, or <see langword="null"/> if not found.</returns>
+    /// <returns>The matching entry, or <see langword="null"/> if not found or when <paramref name="userId"/> is <see langword="null"/> or empty.</returns>
     Task<AIMemoryEntry> FindByUserAndNameAsync(string userId, string name);
 
     /// <summary>
@@ -30,6 +30,6 @@ public interface IAIMemoryStore : ICatalog<AIMemoryEntry>
     /// </summary>
     /// <param name="userId">The unique identifier of the user.</param>
     /// <param name="limit">The maximum number of entries to return. Defaults to 100.</param>
-    /// <returns>A read-only collection of the user's memory entries.</returns>
+    /// <returns>A read-only collection of the user's memory entries, empty when <paramref name="userId"/> is <see langword="null"/> or empty.</returns>
     Task<IReadOnlyCollection<AIMemoryEntry>> GetByUserAsync(string userId, int limit = 100);
 }

--- a/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreAIMemoryStore.cs
+++ b/src/Stores/CrestApps.Core.Data.EntityCore/Services/EntityCoreAIMemoryStore.cs
@@ -25,7 +25,10 @@ public sealed class EntityCoreAIMemoryStore : DocumentCatalog<AIMemoryEntry>, IA
     /// <param name="userId">The user id.</param>
     public Task<int> CountByUserAsync(string userId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Task.FromResult(0);
+        }
 
         return GetReadQuery()
                     .Where(x => x.UserId == userId)
@@ -39,7 +42,11 @@ public sealed class EntityCoreAIMemoryStore : DocumentCatalog<AIMemoryEntry>, IA
     /// <param name="name">The name.</param>
     public async Task<AIMemoryEntry> FindByUserAndNameAsync(string userId, string name)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return null;
+        }
+
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         var record = await GetReadQuery()
@@ -55,7 +62,10 @@ public sealed class EntityCoreAIMemoryStore : DocumentCatalog<AIMemoryEntry>, IA
     /// <param name="limit">The limit.</param>
     public async Task<IReadOnlyCollection<AIMemoryEntry>> GetByUserAsync(string userId, int limit = 100)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return [];
+        }
 
         var records = await GetReadQuery()
             .Where(x => x.UserId == userId)

--- a/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlAIMemoryStore.cs
+++ b/src/Stores/CrestApps.Core.Data.YesSql/Services/YesSqlAIMemoryStore.cs
@@ -26,7 +26,10 @@ public sealed class YesSqlAIMemoryStore : DocumentCatalog<AIMemoryEntry, AIMemor
     /// <param name="userId">The user id.</param>
     public async Task<int> CountByUserAsync(string userId)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return 0;
+        }
 
         return await Session.Query<AIMemoryEntry, AIMemoryEntryIndex>(x => x.UserId == userId, collection: CollectionName)
                     .CountAsync();
@@ -39,7 +42,11 @@ public sealed class YesSqlAIMemoryStore : DocumentCatalog<AIMemoryEntry, AIMemor
     /// <param name="name">The name.</param>
     public async Task<AIMemoryEntry> FindByUserAndNameAsync(string userId, string name)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return null;
+        }
+
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         return await Session.Query<AIMemoryEntry, AIMemoryEntryIndex>(x =>
@@ -53,7 +60,10 @@ public sealed class YesSqlAIMemoryStore : DocumentCatalog<AIMemoryEntry, AIMemor
     /// <param name="limit">The limit.</param>
     public async Task<IReadOnlyCollection<AIMemoryEntry>> GetByUserAsync(string userId, int limit = 100)
     {
-        ArgumentException.ThrowIfNullOrEmpty(userId);
+        if (string.IsNullOrEmpty(userId))
+        {
+            return [];
+        }
 
         var items = await Session.Query<AIMemoryEntry, AIMemoryEntryIndex>(x => x.UserId == userId, collection: CollectionName)
             .Take(limit)

--- a/tests/CrestApps.Core.Tests/EntityCoreStoreTests.cs
+++ b/tests/CrestApps.Core.Tests/EntityCoreStoreTests.cs
@@ -67,6 +67,24 @@ public sealed class EntityCoreStoreTests
             .SingleAsync(cancellationToken));
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Memory_store_user_scoped_reads_return_empty_for_missing_user(string userId)
+    {
+        // The memory display driver renders the current user's memory count while building the editor,
+        // and does so even when there is no authenticated user. A null/empty user simply owns no
+        // memories, so the user-scoped reads must return empty results instead of throwing and taking
+        // down the whole editor render.
+        await using var harness = await EntityCoreTestHarness.CreateAsync();
+        using var scope = harness.Services.CreateScope();
+        var memoryStore = scope.ServiceProvider.GetRequiredService<IAIMemoryStore>();
+
+        Assert.Equal(0, await memoryStore.CountByUserAsync(userId));
+        Assert.Null(await memoryStore.FindByUserAndNameAsync(userId, "favorite-language"));
+        Assert.Empty(await memoryStore.GetByUserAsync(userId));
+    }
+
     [Fact]
     public async Task Document_catalog_create_then_update_in_same_uncommitted_scope_does_not_duplicate()
     {


### PR DESCRIPTION
## Problem

Production logs (`stateoffloridadcf` tenant) were filling with `ArgumentNullException` while rendering the memory editor:

```
ArgumentNullException thrown from IDisplayDriver`1 by CrestApps.OrchardCore.AI.Memory.Drivers.UserMemoryDisplayDriver
System.ArgumentNullException: Value cannot be null. (Parameter 'userId')
   at CrestApps.Core.Data.YesSql.Services.YesSqlAIMemoryStore.CountByUserAsync(String userId)
   at CrestApps.OrchardCore.AI.Memory.Drivers.UserMemoryDisplayDriver...
```

`UserMemoryDisplayDriver` queries the memory store while building the editor, and does so even when there is no authenticated user. That reached `CountByUserAsync` with a `null` `userId`, whose `ArgumentException.ThrowIfNullOrEmpty` guard threw and failed the whole editor render (both `Edit` and `UpdateEditor`).

## Fix

A null or empty user simply owns no memories, so the user-scoped **read** methods now short-circuit to an empty result instead of throwing:

- `CountByUserAsync` → `0`
- `FindByUserAndNameAsync` → `null`
- `GetByUserAsync` → empty collection

Applied consistently to both the YesSql and EntityCore stores, with the `IAIMemoryStore` contract updated to document the behavior.

The write paths (`SaveUserMemoryTool`, `RemoveUserMemoryTool`) already reject an empty `userId` up front with "User memory is only available for authenticated users", so this change only affects reads and does not mask a real write-time bug.

## Tests

Added `Memory_store_user_scoped_reads_return_empty_for_missing_user` (theory: `null` and `""`) asserting all three reads return empty. Passing, alongside the existing `Entity_core_stores_support_specialized_queries` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)