### PR TITLE
Bump svgo to 3.3.5 in the docs site to fix GHSA-w27v-7q3p-w38r

### DIFF
--- a/src/CrestApps.Core.Docs/package-lock.json
+++ b/src/CrestApps.Core.Docs/package-lock.json
@@ -18533,9 +18533,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/svgo/-/svgo-3.3.4.tgz",
-      "integrity": "sha1-/SqhD/WFs70rg842AvVYK8Bxi7U=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.5.tgz",
+      "integrity": "sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/src/CrestApps.Core.Docs/package.json
+++ b/src/CrestApps.Core.Docs/package.json
@@ -46,6 +46,7 @@
   "overrides": {
     "minimatch": "^10.0.1",
     "serialize-javascript": "^7.0.3",
+    "svgo": "^3.3.5",
     "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Fixes [GHSA-w27v-7q3p-w38r](https://github.com/advisories/GHSA-w27v-7q3p-w38r) (CVE-2026-84370, High, CVSS 8.2).

## The problem

`src/CrestApps.Core.Docs` resolved **svgo 3.3.4** transitively, through two paths:

- `@docusaurus/preset-classic` → `@svgr/webpack` → `@svgr/plugin-svgo` (`svgo: ^3.0.2`)
- `@docusaurus/core` → `cssnano-preset-advanced` → `postcss-svgo` (`svgo: ^3.2.0`)

In that version the `removeScripts` plugin failed to strip executable links two ways:

1. **Namespace bypass** — it only matched unprefixed `<a>` elements, so a namespace-prefixed `<svg:a href="javascript:...">` kept its `href`.
2. **Control-character bypass** — scheme validation didn't normalize embedded tabs, line feeds, or carriage returns, so `java&#9;script:` slipped past the `javascript:` check while browsers still parsed it as a script URL.

An app that optimizes attacker-supplied SVGs with that plugin and then serves them in a browser context could execute script in the SVG's origin.

## The fix

- Added `"svgo": "^3.3.5"` to the existing `overrides` block in `src/CrestApps.Core.Docs/package.json`, alongside the `minimatch`, `serialize-javascript`, and `uuid` pins already there. Both transitive ranges (`^3.0.2` and `^3.2.0`) accept 3.3.5, so the override keeps the patched version in place rather than fighting the resolver.
- Updated `src/CrestApps.Core.Docs/package-lock.json` to svgo 3.3.5. The dependency set is unchanged between 3.3.4 and 3.3.5, so this is a three-line change to `version`/`resolved`/`integrity` with no downstream churn.

The root `package-lock.json` does not contain svgo, so no change was needed there.

## Verification

- `npm ci --dry-run` in `src/CrestApps.Core.Docs` succeeds and resolves `svgo 3.3.5`, confirming `package.json` and the lockfile are in sync.
- Downloaded the 3.3.5 tarball and confirmed the integrity hash matches the lockfile entry, and that `plugins/removeScriptElement.js` now carries the namespace-aware element matching (`isNamespaceAwareElem`, `ANCHOR_NAMESPACES`) and the shared `isExecutableUrl` scheme check that close both bypasses.

One note on the lockfile: the existing docs lockfile resolves packages through the `ms-feed-*.pkgs.visualstudio.com` 1ES mirror, but that host is not reachable from this environment, so the new entry points at `registry.npmjs.org` with the official sha512 integrity. npm handles the mixed hosts fine, but if you would rather keep the file uniform, regenerating the entry from the mirror will swap it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELjK1ZcXrvTuv59mkf4d9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELjK1ZcXrvTuv59mkf4d9S)_